### PR TITLE
Fix operational template parsing 2

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -173,15 +173,23 @@ public class ADLListener extends AdlBaseListener {
     }
 
     public void enterComponent_terminologies_section(AdlParser.Component_terminologies_sectionContext ctx) {
-        if(archetype instanceof OperationalTemplate) {
+        if (!(archetype instanceof OperationalTemplate)) {
+            throw new IllegalArgumentException("cannot add component terminologies to anything but an operational template");
+        }
+        if(ctx.odin_text().attr_vals() != null) {
+            //this is 'component_terminologies = <...>'
+            OperationalTemplate template = (OperationalTemplate) archetype;
+
+            ComponentTerminologiesHelper helper = OdinObjectParser.convert(ctx.odin_text(), ComponentTerminologiesHelper.class);
+            template.setComponentTerminologies(helper.getComponentTerminologies());
+        } else {
+            //this is a direct <["archetype_id"] = ...> syntax
             OperationalTemplate template = (OperationalTemplate) archetype;
 
             TypeFactory typeFactory = OdinToJsonConverter.getObjectMapper().getTypeFactory();
             MapType mapType = typeFactory.constructMapType(ConcurrentHashMap.class, String.class, ArchetypeTerminology.class);
 
             template.setComponentTerminologies(OdinObjectParser.convert(ctx.odin_text(), mapType));
-        } else {
-            throw new IllegalArgumentException("cannot add component terminologies to anything but an operational template");
         }
     }
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ComponentTerminologiesHelper.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ComponentTerminologiesHelper.java
@@ -1,0 +1,22 @@
+package com.nedap.archie.adlparser.treewalkers;
+
+import com.nedap.archie.aom.terminology.ArchetypeTerminology;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A helper class for parsing component terminologies. Not to be used outside of the parser
+ */
+public class ComponentTerminologiesHelper {
+
+    private Map<String, ArchetypeTerminology> componentTerminologies = new ConcurrentHashMap<>();
+
+    public Map<String, ArchetypeTerminology> getComponentTerminologies() {
+        return componentTerminologies;
+    }
+
+    public void setComponentTerminologies(Map<String, ArchetypeTerminology> componentTerminologies) {
+        this.componentTerminologies = componentTerminologies;
+    }
+}

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ComponentTerminologiesHelper.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ComponentTerminologiesHelper.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * A helper class for parsing component terminologies. Not to be used outside of the parser
  */
-public class ComponentTerminologiesHelper {
+class ComponentTerminologiesHelper {
 
     private Map<String, ArchetypeTerminology> componentTerminologies = new ConcurrentHashMap<>();
 

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/ADLOperationalTemplateSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/ADLOperationalTemplateSerializer.java
@@ -18,7 +18,7 @@ class ADLOperationalTemplateSerializer extends ADLAuthoredArchetypeSerializer<Op
     protected String serialize() {
         super.serialize();
         builder.newline().append("component_terminologies").newIndentedLine()
-                .append("< ") //todo: this should perhaps be in the ODIN serializer?
+                .append("component_terminologies = < ") //todo: this should perhaps be in the ODIN serializer?
                 .indent()
                 .odin(archetype.getComponentTerminologies())
                 .unindent()

--- a/grammars/src/main/antlr/odin.g4
+++ b/grammars/src/main/antlr/odin.g4
@@ -16,6 +16,7 @@ import odin_values;
 odin_text :
       attr_vals
     | object_value_block
+    | keyed_object+
 	;
 
 attr_vals : ( attr_val ';'? )+ ;

--- a/odin/src/main/java/com/nedap/archie/serializer/odin/OdinToJsonConverter.java
+++ b/odin/src/main/java/com/nedap/archie/serializer/odin/OdinToJsonConverter.java
@@ -42,11 +42,11 @@ public class OdinToJsonConverter {
             return "{}";
         }
         if (context.attr_vals() != null) {
-            output(context.attr_vals().attr_val());
+            output(context.attr_vals().attr_val(), null /* no type id here */);
         } else if(context.object_value_block() != null){
             output(context.object_value_block());
         } else if (context.keyed_object() != null && context.keyed_object().size() > 0) {
-            outputKeyedObjects(context.keyed_object());
+            outputKeyedObjects(context.keyed_object(), null /* no type id here */);
         } else {
             //empty
             return "{}";
@@ -55,9 +55,13 @@ public class OdinToJsonConverter {
 
     }
 
-    private void output(List<Attr_valContext> context) {
+    private void output(List<Attr_valContext> context, Type_idContext type_idContext) {
         output.append("{");
         boolean first = true;
+        if(type_idContext != null) {
+            first = false;
+            outputTypeId(type_idContext);
+        }
         for (Attr_valContext attrValContext : context) {
             if(!first) {
                 output.append(',');
@@ -70,6 +74,12 @@ public class OdinToJsonConverter {
             output(attrValContext.object_block());
         }
         output.append("}");
+    }
+
+    private void outputTypeId(Type_idContext type_idContext) {
+        outputEscaped("@type");
+        output.append(":");
+        outputEscaped(type_idContext.getText());//we might need to remove the generics from the type id if present
     }
 
     private void output(Object_blockContext context) {
@@ -87,9 +97,9 @@ public class OdinToJsonConverter {
         List<Keyed_objectContext> keyedObjectContexts = valueBlockContext.keyed_object();
         Primitive_objectContext primitiveObjectContext = valueBlockContext.primitive_object();
         if (valueBlockContext.attr_vals() != null) {
-            output(valueBlockContext.attr_vals().attr_val());
+            output(valueBlockContext.attr_vals().attr_val(), valueBlockContext.type_id());
         } else if (keyedObjectContexts != null && !keyedObjectContexts.isEmpty()) {
-            outputKeyedObjects(keyedObjectContexts);
+            outputKeyedObjects(keyedObjectContexts, valueBlockContext.type_id());
         } else if (primitiveObjectContext != null) {
             if(primitiveObjectContext.primitive_value() != null) {
                 output(primitiveObjectContext.primitive_value());
@@ -106,9 +116,13 @@ public class OdinToJsonConverter {
         }
     }
 
-    private void outputKeyedObjects(List<Keyed_objectContext> keyedObjectContexts) {
+    private void outputKeyedObjects(List<Keyed_objectContext> keyedObjectContexts, Type_idContext type_idContext) {
         output.append("{");
         boolean first = true;
+        if(type_idContext != null) {
+            first = false;
+            outputTypeId(type_idContext);
+        }
         for (Keyed_objectContext keyedObjectContext : keyedObjectContexts) {
             if(!first) {
                 output.append(',');

--- a/odin/src/main/java/com/nedap/archie/serializer/odin/OdinToJsonConverter.java
+++ b/odin/src/main/java/com/nedap/archie/serializer/odin/OdinToJsonConverter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.nedap.archie.adlparser.antlr.AdlParser;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
 
 import java.util.List;
@@ -44,6 +45,8 @@ public class OdinToJsonConverter {
             output(context.attr_vals().attr_val());
         } else if(context.object_value_block() != null){
             output(context.object_value_block());
+        } else if (context.keyed_object() != null && context.keyed_object().size() > 0) {
+            outputKeyedObjects(context.keyed_object());
         } else {
             //empty
             return "{}";
@@ -86,21 +89,7 @@ public class OdinToJsonConverter {
         if (valueBlockContext.attr_vals() != null) {
             output(valueBlockContext.attr_vals().attr_val());
         } else if (keyedObjectContexts != null && !keyedObjectContexts.isEmpty()) {
-            output.append("{");
-            boolean first = true;
-            for (Keyed_objectContext keyedObjectContext : keyedObjectContexts) {
-                if(!first) {
-                    output.append(',');
-                }
-                first = false;
-                //output.append('"');
-                output(keyedObjectContext.primitive_value());
-                //output.append('"');
-                output.append(':');
-                output(keyedObjectContext.object_block());
-
-            }
-            output.append("}");
+            outputKeyedObjects(keyedObjectContexts);
         } else if (primitiveObjectContext != null) {
             if(primitiveObjectContext.primitive_value() != null) {
                 output(primitiveObjectContext.primitive_value());
@@ -115,6 +104,24 @@ public class OdinToJsonConverter {
         } else {
             output.append("{}");
         }
+    }
+
+    private void outputKeyedObjects(List<Keyed_objectContext> keyedObjectContexts) {
+        output.append("{");
+        boolean first = true;
+        for (Keyed_objectContext keyedObjectContext : keyedObjectContexts) {
+            if(!first) {
+                output.append(',');
+            }
+            first = false;
+            //output.append('"');
+            output(keyedObjectContext.primitive_value());
+            //output.append('"');
+            output.append(':');
+            output(keyedObjectContext.object_block());
+
+        }
+        output.append("}");
     }
 
     private void output(Primitive_list_valueContext listContext) {

--- a/tools/src/test/java/com/nedap/archie/adlparser/ComponentTerminologiesParseTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/ComponentTerminologiesParseTest.java
@@ -6,17 +6,39 @@ import static org.junit.Assert.assertTrue;
 
 public class ComponentTerminologiesParseTest {
 
+    /**
+     * Archie used to serialize a non-standard form. Kept here for backwards compatibility. It is deprecated and no longer
+     * generated
+     * @throws Exception
+     */
     @Test
-    public void shortForm() throws Exception {
+    public void nonStandardFirstForm() throws Exception {
         ADLParser parser = new ADLParser();
         parser.parse(getClass().getResourceAsStream("openEHR-EHR-ELEMENT.component_terminologies_1.v1.0.0.adls"));
         assertTrue(parser.getErrors().hasNoErrors());
     }
 
+    /**
+     * component_terminologies
+     *    component_terminologies = < [jfdlf] = ... >
+     *
+     * @throws Exception
+     */
     @Test
     public void extendedForm() throws Exception {
         ADLParser parser = new ADLParser();
         parser.parse(getClass().getResourceAsStream("openEHR-EHR-ELEMENT.component_terminologies_2.v1.0.0.adls"));
+        assertTrue(parser.getErrors().hasNoErrors());
+    }
+
+    /**
+     * component_terminologies
+        [jfdlf] = <...>
+     */
+    @Test
+    public void shortForm() throws Exception {
+        ADLParser parser = new ADLParser();
+        parser.parse(getClass().getResourceAsStream("openEHR-EHR-ELEMENT.component_terminologies_3.v1.0.0.adls"));
         assertTrue(parser.getErrors().hasNoErrors());
     }
 }

--- a/tools/src/test/java/com/nedap/archie/adlparser/ComponentTerminologiesParseTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/ComponentTerminologiesParseTest.java
@@ -1,0 +1,22 @@
+package com.nedap.archie.adlparser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ComponentTerminologiesParseTest {
+
+    @Test
+    public void shortForm() throws Exception {
+        ADLParser parser = new ADLParser();
+        parser.parse(getClass().getResourceAsStream("openEHR-EHR-ELEMENT.component_terminologies_1.v1.0.0.adls"));
+        assertTrue(parser.getErrors().hasNoErrors());
+    }
+
+    @Test
+    public void extendedForm() throws Exception {
+        ADLParser parser = new ADLParser();
+        parser.parse(getClass().getResourceAsStream("openEHR-EHR-ELEMENT.component_terminologies_2.v1.0.0.adls"));
+        assertTrue(parser.getErrors().hasNoErrors());
+    }
+}

--- a/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-ELEMENT.component_terminologies_1.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-ELEMENT.component_terminologies_1.v1.0.0.adls
@@ -1,0 +1,224 @@
+operational_template (adl_version=2.0.5; rm_release=1.0.2)
+	openEHR-EHR-COMPOSITION.annotations_rm_path.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Thomas Beale">
+		["organisation"] = <"openEHR Foundation <http://www.openEHR.org>">
+		["email"] = <"thomas.beale@openEHR.org">
+		["date"] = <"2010-11-09">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Demonstrate annotations on pure Reference Model paths, i.e. paths that must be valid, but have not been archetyped. They are thus still valid for annotations.">
+			use = <"The typical use is to add design notes about RM data items that are not archetyped (i.e. don't specifically need to be constrained) but whose meaning is specific to the archetype.">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"Copyright © 2010 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	COMPOSITION[id1] matches {	-- Prescription
+		category matches {
+			DV_CODED_TEXT[id10] matches {
+				defining_code matches {[at1]}
+			}
+		}
+		context matches {
+			EVENT_CONTEXT[id11] matches {
+				other_context matches {
+					ITEM_TREE[id2] matches {
+						items matches {
+							CLUSTER[id3] occurrences matches {0..*} matches {	-- Qualification
+								items matches {
+									ELEMENT[id4] occurrences matches {0..1} matches {	-- OrderID
+										value matches {
+											DV_EHR_URI[id12]
+											DV_IDENTIFIER[id13]
+										}
+									}
+									ELEMENT[id5] occurrences matches {0..*} matches {	-- Endorsement
+										value matches {
+											DV_TEXT[id14] matches {
+												value matches {"Robert", "Rick", "Clara"}
+											}
+										}
+									}
+									ELEMENT[id6] occurrences matches {0..*} matches {	-- AuthorisationID
+										value matches {
+											DV_IDENTIFIER[id15]
+										}
+									}
+									ELEMENT[id7] occurrences matches {0..*} matches {	-- Comment
+										value matches {
+											DV_QUANTITY[id16] matches {
+													[units, magnitude] matches {
+															[{"kg"}, {|5.0..300.0|}],
+															[{"lb"}, {|10.0..600.0|}]
+															}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		content cardinality matches {1..*; unordered} matches {
+			allow_archetype INSTRUCTION[id8] occurrences matches {1..*} matches {	-- Medication instruction
+				include
+					archetype_id/value matches {/openEHR-EHR-INSTRUCTION\.medication\.v1/}
+			}
+			allow_archetype ENTRY[id9] occurrences matches {0..*} matches {	-- Other data
+				include
+					archetype_id/value matches {/.*/}
+			}
+		}
+	}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Prescription">
+				description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
+			>
+			["id3"] = <
+				text = <"Qualification">
+				description = <"Qualifications on any medication order included in the prescription.">
+			>
+			["id4"] = <
+				text = <"OrderID">
+				description = <"The path or ID of the order referenced. If there is no OrderID then the endorsement relates to the entire prescription.">
+			>
+			["id5"] = <
+				text = <"Endorsement">
+				description = <"Asserting that a special condition applies such as approval for  enhanced subsidy or concurrent supply. Australian examples include Regulation 24 (PBS), Hardship Conditions (RPBS) or CTG for 'close the gap'.">
+			>
+			["id6"] = <
+				text = <"AuthorisationID">
+				description = <"An identifier authorising prescription, dispensing or reimbursement for this medication order.">
+			>
+			["id7"] = <
+				text = <"Comment">
+				description = <"Comment on any qualification.">
+				extra = <"Extra value">
+			>
+			["id8"] = <
+				text = <"Medication instruction">
+				description = <"Contains one or more medication instructions to be supplied.">
+			>
+			["id9"] = <
+				text = <"Other data">
+				description = <"Other observational or relevant data.">
+			>
+			["at1"] = <
+				text = <"event">
+				description = <"event">
+			>
+		>
+		["nl"] = <
+			["id1"] = <
+				text = <"Recept">
+				description = <"Een document waarmee uitgifte van een of meerdere medicijnen of hulpmiddel wordt geautoriseerd.">
+			>
+			["id3"] = <
+				text = <"Kwalificatie">
+				description = <"Qualifications on any medication order included in the prescription.">
+			>
+			["id4"] = <
+				text = <"OrderID">
+				description = <"The path or ID of the order referenced. If there is no OrderID then the endorsement relates to the entire prescription.">
+			>
+			["id5"] = <
+				text = <"Endorsement">
+				description = <"Asserting that a special condition applies such as approval for  enhanced subsidy or concurrent supply. Australian examples include Regulation 24 (PBS), Hardship Conditions (RPBS) or CTG for 'close the gap'.">
+			>
+			["id6"] = <
+				text = <"AuthorisationID">
+				description = <"An identifier authorising prescription, dispensing or reimbursement for this medication order.">
+			>
+			["id7"] = <
+				text = <"Comment">
+				description = <"Comment on any qualification.">
+				extra = <"Extra value">
+			>
+			["id8"] = <
+				text = <"Medication instruction">
+				description = <"Contains one or more medication instructions to be supplied.">
+			>
+			["id9"] = <
+				text = <"Other data">
+				description = <"Other observational or relevant data.">
+			>
+			["at1"] = <
+				text = <"event">
+				description = <"event">
+			>
+		>
+	>
+	term_bindings = <
+		["openehr"] = <
+			["at1"] = <http://openehr.org/id/433>
+		>
+	>
+
+component_terminologies
+<
+    ["openehr-ehr-WORK_PLAN.breast_cancer_treatment.v0.0.1"] = <
+         term_definitions = <
+             ["en"] = <
+                 ["id1"] = <
+                     text = <"Breast cancer treatment plan">
+                     description = <"-">
+                 >
+                 ["id2"] = <
+                     text = <"Decision pathway">
+                     description = <"-">
+                 >
+                 ["id4"] = <
+                     text = <"Has menopause">
+                     description = <"-">
+                 >
+                 ["id8"] = <
+                     text = <"TNM - tumour (T)">
+                     description = <"-">
+                 >
+                 ["id14"] = <
+                     text = <"TNM - node (N)">
+                     description = <"-">
+                 >
+                 ["id15"] = <
+                     text = <"TNM - metastasis (M)">
+                     description = <"-">
+                 >
+                 ["id20"] = <
+                     text = <"Molecular subtype">
+                     description = <"-">
+                 >
+                 ["id22"] = <
+                     text = <"Metastasis">
+                     description = <"-">
+                 >
+                 ["id34"] = <
+                     text = <"Query id parameter def">
+                     description = <"-">
+                 >
+                 ["id35"] = <
+                     text = <"Has BRCA1 mutation">
+                     description = <"-">
+                 >
+             >
+         >
+     >
+ >

--- a/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-ELEMENT.component_terminologies_2.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-ELEMENT.component_terminologies_2.v1.0.0.adls
@@ -1,0 +1,224 @@
+operational_template (adl_version=2.0.5; rm_release=1.0.2)
+	openEHR-EHR-COMPOSITION.annotations_rm_path.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Thomas Beale">
+		["organisation"] = <"openEHR Foundation <http://www.openEHR.org>">
+		["email"] = <"thomas.beale@openEHR.org">
+		["date"] = <"2010-11-09">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Demonstrate annotations on pure Reference Model paths, i.e. paths that must be valid, but have not been archetyped. They are thus still valid for annotations.">
+			use = <"The typical use is to add design notes about RM data items that are not archetyped (i.e. don't specifically need to be constrained) but whose meaning is specific to the archetype.">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"Copyright © 2010 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	COMPOSITION[id1] matches {	-- Prescription
+		category matches {
+			DV_CODED_TEXT[id10] matches {
+				defining_code matches {[at1]}
+			}
+		}
+		context matches {
+			EVENT_CONTEXT[id11] matches {
+				other_context matches {
+					ITEM_TREE[id2] matches {
+						items matches {
+							CLUSTER[id3] occurrences matches {0..*} matches {	-- Qualification
+								items matches {
+									ELEMENT[id4] occurrences matches {0..1} matches {	-- OrderID
+										value matches {
+											DV_EHR_URI[id12]
+											DV_IDENTIFIER[id13]
+										}
+									}
+									ELEMENT[id5] occurrences matches {0..*} matches {	-- Endorsement
+										value matches {
+											DV_TEXT[id14] matches {
+												value matches {"Robert", "Rick", "Clara"}
+											}
+										}
+									}
+									ELEMENT[id6] occurrences matches {0..*} matches {	-- AuthorisationID
+										value matches {
+											DV_IDENTIFIER[id15]
+										}
+									}
+									ELEMENT[id7] occurrences matches {0..*} matches {	-- Comment
+										value matches {
+											DV_QUANTITY[id16] matches {
+													[units, magnitude] matches {
+															[{"kg"}, {|5.0..300.0|}],
+															[{"lb"}, {|10.0..600.0|}]
+															}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		content cardinality matches {1..*; unordered} matches {
+			allow_archetype INSTRUCTION[id8] occurrences matches {1..*} matches {	-- Medication instruction
+				include
+					archetype_id/value matches {/openEHR-EHR-INSTRUCTION\.medication\.v1/}
+			}
+			allow_archetype ENTRY[id9] occurrences matches {0..*} matches {	-- Other data
+				include
+					archetype_id/value matches {/.*/}
+			}
+		}
+	}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Prescription">
+				description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
+			>
+			["id3"] = <
+				text = <"Qualification">
+				description = <"Qualifications on any medication order included in the prescription.">
+			>
+			["id4"] = <
+				text = <"OrderID">
+				description = <"The path or ID of the order referenced. If there is no OrderID then the endorsement relates to the entire prescription.">
+			>
+			["id5"] = <
+				text = <"Endorsement">
+				description = <"Asserting that a special condition applies such as approval for  enhanced subsidy or concurrent supply. Australian examples include Regulation 24 (PBS), Hardship Conditions (RPBS) or CTG for 'close the gap'.">
+			>
+			["id6"] = <
+				text = <"AuthorisationID">
+				description = <"An identifier authorising prescription, dispensing or reimbursement for this medication order.">
+			>
+			["id7"] = <
+				text = <"Comment">
+				description = <"Comment on any qualification.">
+				extra = <"Extra value">
+			>
+			["id8"] = <
+				text = <"Medication instruction">
+				description = <"Contains one or more medication instructions to be supplied.">
+			>
+			["id9"] = <
+				text = <"Other data">
+				description = <"Other observational or relevant data.">
+			>
+			["at1"] = <
+				text = <"event">
+				description = <"event">
+			>
+		>
+		["nl"] = <
+			["id1"] = <
+				text = <"Recept">
+				description = <"Een document waarmee uitgifte van een of meerdere medicijnen of hulpmiddel wordt geautoriseerd.">
+			>
+			["id3"] = <
+				text = <"Kwalificatie">
+				description = <"Qualifications on any medication order included in the prescription.">
+			>
+			["id4"] = <
+				text = <"OrderID">
+				description = <"The path or ID of the order referenced. If there is no OrderID then the endorsement relates to the entire prescription.">
+			>
+			["id5"] = <
+				text = <"Endorsement">
+				description = <"Asserting that a special condition applies such as approval for  enhanced subsidy or concurrent supply. Australian examples include Regulation 24 (PBS), Hardship Conditions (RPBS) or CTG for 'close the gap'.">
+			>
+			["id6"] = <
+				text = <"AuthorisationID">
+				description = <"An identifier authorising prescription, dispensing or reimbursement for this medication order.">
+			>
+			["id7"] = <
+				text = <"Comment">
+				description = <"Comment on any qualification.">
+				extra = <"Extra value">
+			>
+			["id8"] = <
+				text = <"Medication instruction">
+				description = <"Contains one or more medication instructions to be supplied.">
+			>
+			["id9"] = <
+				text = <"Other data">
+				description = <"Other observational or relevant data.">
+			>
+			["at1"] = <
+				text = <"event">
+				description = <"event">
+			>
+		>
+	>
+	term_bindings = <
+		["openehr"] = <
+			["at1"] = <http://openehr.org/id/433>
+		>
+	>
+
+component_terminologies
+    component_terminologies = <
+        ["openehr-ehr-WORK_PLAN.breast_cancer_treatment.v0.0.1"] = <
+             term_definitions = <
+                 ["en"] = <
+                     ["id1"] = <
+                         text = <"Breast cancer treatment plan">
+                         description = <"-">
+                     >
+                     ["id2"] = <
+                         text = <"Decision pathway">
+                         description = <"-">
+                     >
+                     ["id4"] = <
+                         text = <"Has menopause">
+                         description = <"-">
+                     >
+                     ["id8"] = <
+                         text = <"TNM - tumour (T)">
+                         description = <"-">
+                     >
+                     ["id14"] = <
+                         text = <"TNM - node (N)">
+                         description = <"-">
+                     >
+                     ["id15"] = <
+                         text = <"TNM - metastasis (M)">
+                         description = <"-">
+                     >
+                     ["id20"] = <
+                         text = <"Molecular subtype">
+                         description = <"-">
+                     >
+                     ["id22"] = <
+                         text = <"Metastasis">
+                         description = <"-">
+                     >
+                     ["id34"] = <
+                         text = <"Query id parameter def">
+                         description = <"-">
+                     >
+                     ["id35"] = <
+                         text = <"Has BRCA1 mutation">
+                         description = <"-">
+                     >
+                 >
+             >
+         >
+     >

--- a/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-ELEMENT.component_terminologies_3.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-ELEMENT.component_terminologies_3.v1.0.0.adls
@@ -1,0 +1,223 @@
+operational_template (adl_version=2.0.5; rm_release=1.0.2)
+	openEHR-EHR-COMPOSITION.annotations_rm_path.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Thomas Beale">
+		["organisation"] = <"openEHR Foundation <http://www.openEHR.org>">
+		["email"] = <"thomas.beale@openEHR.org">
+		["date"] = <"2010-11-09">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Demonstrate annotations on pure Reference Model paths, i.e. paths that must be valid, but have not been archetyped. They are thus still valid for annotations.">
+			use = <"The typical use is to add design notes about RM data items that are not archetyped (i.e. don't specifically need to be constrained) but whose meaning is specific to the archetype.">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"Copyright © 2010 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	COMPOSITION[id1] matches {	-- Prescription
+		category matches {
+			DV_CODED_TEXT[id10] matches {
+				defining_code matches {[at1]}
+			}
+		}
+		context matches {
+			EVENT_CONTEXT[id11] matches {
+				other_context matches {
+					ITEM_TREE[id2] matches {
+						items matches {
+							CLUSTER[id3] occurrences matches {0..*} matches {	-- Qualification
+								items matches {
+									ELEMENT[id4] occurrences matches {0..1} matches {	-- OrderID
+										value matches {
+											DV_EHR_URI[id12]
+											DV_IDENTIFIER[id13]
+										}
+									}
+									ELEMENT[id5] occurrences matches {0..*} matches {	-- Endorsement
+										value matches {
+											DV_TEXT[id14] matches {
+												value matches {"Robert", "Rick", "Clara"}
+											}
+										}
+									}
+									ELEMENT[id6] occurrences matches {0..*} matches {	-- AuthorisationID
+										value matches {
+											DV_IDENTIFIER[id15]
+										}
+									}
+									ELEMENT[id7] occurrences matches {0..*} matches {	-- Comment
+										value matches {
+											DV_QUANTITY[id16] matches {
+													[units, magnitude] matches {
+															[{"kg"}, {|5.0..300.0|}],
+															[{"lb"}, {|10.0..600.0|}]
+															}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		content cardinality matches {1..*; unordered} matches {
+			allow_archetype INSTRUCTION[id8] occurrences matches {1..*} matches {	-- Medication instruction
+				include
+					archetype_id/value matches {/openEHR-EHR-INSTRUCTION\.medication\.v1/}
+			}
+			allow_archetype ENTRY[id9] occurrences matches {0..*} matches {	-- Other data
+				include
+					archetype_id/value matches {/.*/}
+			}
+		}
+	}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Prescription">
+				description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
+			>
+			["id3"] = <
+				text = <"Qualification">
+				description = <"Qualifications on any medication order included in the prescription.">
+			>
+			["id4"] = <
+				text = <"OrderID">
+				description = <"The path or ID of the order referenced. If there is no OrderID then the endorsement relates to the entire prescription.">
+			>
+			["id5"] = <
+				text = <"Endorsement">
+				description = <"Asserting that a special condition applies such as approval for  enhanced subsidy or concurrent supply. Australian examples include Regulation 24 (PBS), Hardship Conditions (RPBS) or CTG for 'close the gap'.">
+			>
+			["id6"] = <
+				text = <"AuthorisationID">
+				description = <"An identifier authorising prescription, dispensing or reimbursement for this medication order.">
+			>
+			["id7"] = <
+				text = <"Comment">
+				description = <"Comment on any qualification.">
+				extra = <"Extra value">
+			>
+			["id8"] = <
+				text = <"Medication instruction">
+				description = <"Contains one or more medication instructions to be supplied.">
+			>
+			["id9"] = <
+				text = <"Other data">
+				description = <"Other observational or relevant data.">
+			>
+			["at1"] = <
+				text = <"event">
+				description = <"event">
+			>
+		>
+		["nl"] = <
+			["id1"] = <
+				text = <"Recept">
+				description = <"Een document waarmee uitgifte van een of meerdere medicijnen of hulpmiddel wordt geautoriseerd.">
+			>
+			["id3"] = <
+				text = <"Kwalificatie">
+				description = <"Qualifications on any medication order included in the prescription.">
+			>
+			["id4"] = <
+				text = <"OrderID">
+				description = <"The path or ID of the order referenced. If there is no OrderID then the endorsement relates to the entire prescription.">
+			>
+			["id5"] = <
+				text = <"Endorsement">
+				description = <"Asserting that a special condition applies such as approval for  enhanced subsidy or concurrent supply. Australian examples include Regulation 24 (PBS), Hardship Conditions (RPBS) or CTG for 'close the gap'.">
+			>
+			["id6"] = <
+				text = <"AuthorisationID">
+				description = <"An identifier authorising prescription, dispensing or reimbursement for this medication order.">
+			>
+			["id7"] = <
+				text = <"Comment">
+				description = <"Comment on any qualification.">
+				extra = <"Extra value">
+			>
+			["id8"] = <
+				text = <"Medication instruction">
+				description = <"Contains one or more medication instructions to be supplied.">
+			>
+			["id9"] = <
+				text = <"Other data">
+				description = <"Other observational or relevant data.">
+			>
+			["at1"] = <
+				text = <"event">
+				description = <"event">
+			>
+		>
+	>
+	term_bindings = <
+		["openehr"] = <
+			["at1"] = <http://openehr.org/id/433>
+		>
+	>
+
+component_terminologies
+    ["openehr-ehr-WORK_PLAN.breast_cancer_treatment.v0.0.1"] = <
+         term_definitions = <
+             ["en"] = <
+                 ["id1"] = <
+                     text = <"Breast cancer treatment plan">
+                     description = <"-">
+                 >
+                 ["id2"] = <
+                     text = <"Decision pathway">
+                     description = <"-">
+                 >
+                 ["id4"] = <
+                     text = <"Has menopause">
+                     description = <"-">
+                 >
+                 ["id8"] = <
+                     text = <"TNM - tumour (T)">
+                     description = <"-">
+                 >
+                 ["id14"] = <
+                     text = <"TNM - node (N)">
+                     description = <"-">
+                 >
+                 ["id15"] = <
+                     text = <"TNM - metastasis (M)">
+                     description = <"-">
+                 >
+                 ["id20"] = <
+                     text = <"Molecular subtype">
+                     description = <"-">
+                 >
+                 ["id22"] = <
+                     text = <"Metastasis">
+                     description = <"-">
+                 >
+                 ["id34"] = <
+                     text = <"Query id parameter def">
+                     description = <"-">
+                 >
+                 ["id35"] = <
+                     text = <"Has BRCA1 mutation">
+                     description = <"-">
+                 >
+             >
+         >
+     >
+


### PR DESCRIPTION
Fix operational template parsing, by allowing both ```component_terminologies <...>``` and ```component_terminologies component_terminologies = <...>``` syntax