### PR TITLE
Fix effective occurrences with a differential path instead of RM Attr…

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/CObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CObject.java
@@ -260,7 +260,7 @@ public abstract class CObject extends ArchetypeConstraint {
     /**
      * True if constraints represented by this node, ignoring any sub-parts, are narrower or the same as other. Typically used during validation of special-ised archetype nodes.
      * @param other
-     * @param lookup
+     * @param rmTypesConformant
      * @return
      */
     public boolean cConformsTo(CObject other, BiFunction<String, String, Boolean> rmTypesConformant) {
@@ -322,7 +322,6 @@ public abstract class CObject extends ArchetypeConstraint {
                     return MultiplicityInterval.createBounded(occurrencesLower, parent.getCardinality().getInterval().getUpper());
                 }
             } else if(parent.getParent() != null) {
-                //TODO: this can be a (differential) path, but we don't support that yet.
                 return referenceModelPropMultiplicity.apply(parent.getParent().getRmTypeName(), parent.getDifferentialPath() == null ? parent.getRmAttributeName() : parent.getDifferentialPath());
             } else {
                 return MultiplicityInterval.createUpperUnbounded(occurrencesLower);

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
@@ -58,7 +58,7 @@ public class MetaModels implements MetaModelInterface {
              selectedModel = models.getModel(archetype);
         }
         if(bmmModels != null) {
-             selectedBmmModel = bmmModels.getReferenceModelForClosure(BmmDefinitions.publisherQualifiedRmClosureName(archetype.getArchetypeId().getRmPublisher(), archetype.getArchetypeId().getRmPackage()));
+             selectedBmmModel = bmmModels.getReferenceModelForClosure(BmmDefinitions.publisherQualifiedRmClosureName(archetype.getArchetypeId().getRmPublisher(), archetype.getArchetypeId().getRmPackage()), archetype.getRmRelease());
         }
 
         for(AomProfile profile:aomProfiles.getProfiles()) {

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
@@ -52,13 +52,25 @@ public class MetaModels implements MetaModelInterface {
      * @throws ModelNotFoundException when no BMM and no ModelInfoLookup model has been found matching the archetype
      */
     public void selectModel(Archetype archetype) throws ModelNotFoundException {
+        selectModel(archetype, null);
+    }
+
+
+    /**
+     * Select a model based on an archetype, but override the RM Release with the given rm release version
+     * @param archetype the archetype to find the model for
+     * @param overridenRmRelease the version of the reference model you want to check with.
+     * @throws ModelNotFoundException
+     */
+    public void selectModel(Archetype archetype, String overridenRmRelease) throws ModelNotFoundException {
         ModelInfoLookup selectedModel = null;
         BmmModel selectedBmmModel = null;
         if(models != null) {
              selectedModel = models.getModel(archetype);
         }
         if(bmmModels != null) {
-             selectedBmmModel = bmmModels.getReferenceModelForClosure(BmmDefinitions.publisherQualifiedRmClosureName(archetype.getArchetypeId().getRmPublisher(), archetype.getArchetypeId().getRmPackage()), archetype.getRmRelease());
+            String rmRelease = overridenRmRelease == null ? archetype.getRmRelease() : overridenRmRelease;
+             selectedBmmModel = bmmModels.getReferenceModelForClosure(BmmDefinitions.publisherQualifiedRmClosureName(archetype.getArchetypeId().getRmPublisher(), archetype.getArchetypeId().getRmPackage()), rmRelease);
         }
 
         for(AomProfile profile:aomProfiles.getProfiles()) {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ task wrapper(type: Wrapper) {
 }
 
 allprojects {
-  version = '0.4.0'
+  version = '0.5.0-SNAPSHOT'
   group = 'com.nedap.healthcare.archie'
   ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
   //archivesBaseName = 'archie'


### PR DESCRIPTION
…ibute

And immediately we need a version 0.4.1  :)
Two fixes:

- it fixes the problem that the Flattener throws a NullPointerException on some nodes with differential path, even tough the validator said it was correct.

- Before you could just add three openEHR RM versions without any warnings and it would pick a random one to check. Now it picks the correct one based on rmRelease in an archetype. MetaModels.selectModel() has an overloaded model where you can override the RM Release version, in case you want to check against a different version than what is given in the Archetype. Note that the validator and flattener don't support this custom version yet - this will be a separate feature.

