### PR TITLE
Fix BMM tests to use BMM metamodels only, plus some fixes

### DIFF
--- a/adlchecker/build.gradle
+++ b/adlchecker/build.gradle
@@ -7,14 +7,14 @@ repositories {
 }
 
 dependencies {
-    compile 'com.nedap.healthcare.archie:tools:0.4.0-SNAPSHOT'
-    compile 'com.nedap.healthcare.archie:openehr-rm:0.4.0-SNAPSHOT'
-    compile 'com.nedap.healthcare.archie:test-rm:0.4.0-SNAPSHOT'
+    compile 'com.nedap.healthcare.archie:tools:0.4.1'
+    compile 'com.nedap.healthcare.archie:openehr-rm:0.4.1'
+    compile 'com.nedap.healthcare.archie:test-rm:0.4.1'
     compile 'net.sourceforge.argparse4j:argparse4j:0.7.0'
 }
 
 run {
-    args = ['archetypes', '--outputFlat']
+    args = ['archetypes']//, '--outputFlat']
 }
 
 mainClassName='com.nedap.archie.adlchecker.AdlChecker'

--- a/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
+++ b/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
@@ -1,7 +1,7 @@
 package com.nedap.archie.adlchecker;
 
 import com.nedap.archie.adlparser.ADLParser;
-import com.nedap.archie.adlparser.ADLParserMessage;
+import com.nedap.archie.antlr.errors.ANTLRParserMessage;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.archetypevalidator.ArchetypeValidator;
 import com.nedap.archie.archetypevalidator.ValidationMessage;
@@ -74,25 +74,31 @@ public class AdlChecker {
         System.out.println("step 2: validations");
 
         for(ValidationResult result:repository.getAllValidationResults()) {
-            System.out.println();
-            System.out.print("============= ");
-            System.out.print(result.getArchetypeId());
-            System.out.print("      ");
-            if(result.passes()) {
-                System.out.print("PASSED");
-            } else {
-                System.out.print("FAILED");
-            }
-            System.out.print(" =============");
-            System.out.println();
-            for(ValidationMessage error:result.getErrors()) {
-                System.out.println(error.toString());
-            }
-
+            printValidationResult(result);
             if(printFlatAdl && result.passes()) {
                 System.out.println(ADLArchetypeSerializer.serialize(result.getFlattened()));
             }
 
+        }
+    }
+
+    private static void printValidationResult(ValidationResult result) {
+        System.out.println();
+        System.out.print("============= ");
+        System.out.print(result.getArchetypeId());
+        System.out.print("      ");
+        if(result.passes()) {
+            System.out.print("PASSED");
+        } else {
+            System.out.print("FAILED");
+        }
+        System.out.print(" =============");
+        System.out.println();
+        for(ValidationMessage error:result.getErrors()) {
+            System.out.println(error.toString());
+        }
+        for(ValidationResult overlayResult:result.getOverlayValidations()) {
+            printValidationResult(overlayResult);
         }
     }
 
@@ -113,10 +119,10 @@ public class AdlChecker {
                 } else {
                     System.out.println("errors found for " + path.getFileName());
 
-                    for(ADLParserMessage message:adlParser.getErrors().getWarnings()) {
+                    for(ANTLRParserMessage message:adlParser.getErrors().getWarnings()) {
                         System.err.println("warning: " + message.getMessage());
                     }
-                    for(ADLParserMessage message:adlParser.getErrors().getErrors()) {
+                    for(ANTLRParserMessage message:adlParser.getErrors().getErrors()) {
                         System.err.println("error: " + message.getMessage());
                     }
                 }

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -67,7 +67,9 @@ public class ADLListener extends AdlBaseListener {
         overlay.setDifferential(true);
         if(rootArchetype != null) {
             if(rootArchetype instanceof Template) {
-                ((Template) rootArchetype).addTemplateOverlay(overlay);
+                Template owningTemplate = (Template) rootArchetype;
+                owningTemplate.addTemplateOverlay(overlay);
+                overlay.setOwningTemplate(owningTemplate);
             } else {
                 throw new IllegalArgumentException("Template overlay in a non-template archetype is not allowed. This sounds like a grammar problem.");
             }

--- a/aom/src/main/java/com/nedap/archie/aom/TemplateOverlay.java
+++ b/aom/src/main/java/com/nedap/archie/aom/TemplateOverlay.java
@@ -1,10 +1,45 @@
 package com.nedap.archie.aom;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 /**
+ * Template overlay class, for the template overlays used in a template. Has one implementation specific addition to the normal archetype: methods to obtain the owning archetype
+ * plus methods to get the adl version and rm release of the owning archetype
+ * This makes for less instanceof calls in obtaining the BMM model of the overlay
+ *
  * Created by pieter.bos on 15/10/15.
  */
 @XmlType(name="TEMPLATE_OVERLAY")
 public class TemplateOverlay extends Archetype {
+
+    @JsonIgnore
+    private transient Template owningTemplate;
+
+    @JsonIgnore
+    @XmlTransient
+    @Override
+    public String getRmRelease() {
+        return owningTemplate == null ? null : owningTemplate.getRmRelease();
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    @Override
+    public String getAdlVersion() {
+        return owningTemplate == null ? null : owningTemplate.getAdlVersion();
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public Template getOwningTemplate() {
+        return owningTemplate;
+    }
+
+
+    public void setOwningTemplate(Template owningTemplate) {
+        this.owningTemplate = owningTemplate;
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModel.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModel.java
@@ -223,7 +223,9 @@ public class MetaModel implements MetaModelInterface {
 
     @Override
     public boolean validatePrimitiveType(String rmTypeName, String rmAttributeName, CPrimitiveObject cObject) {
-        if(selectedAomProfile == null) {
+        if(selectedAomProfile == null && selectedModel == null) {
+            throw new IllegalStateException("no AOM profile and no selected ModelInfoLookup, cannot validate primitive type");
+        } else if (selectedAomProfile == null) {
             return selectedModel.validatePrimitiveType(rmTypeName, rmAttributeName, cObject);
         } else {
             String cRmTypeName = cObject.getRmTypeName();

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
@@ -40,6 +40,12 @@ public class MetaModels implements MetaModelInterface {
     private AomProfile selectedAomProfile;
 
 
+    public MetaModels(ReferenceModels models, ReferenceModelAccess bmmModels, AomProfiles profiles) {
+        this.models = models;
+        this.bmmModels = bmmModels;
+        this.aomProfiles = profiles;
+    }
+
     public MetaModels(ReferenceModels models, ReferenceModelAccess bmmModels) {
         this.models = models;
         this.bmmModels = bmmModels;

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CArchetypeRootSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CArchetypeRootSerializer.java
@@ -38,10 +38,17 @@ public class CArchetypeRootSerializer extends CComplexObjectSerializer<CArchetyp
         builder.append("use_archetype");
         builder.append(" ").append(cobj.getRmTypeName());
         builder.append("[");
+        boolean nodeIdAppended = false;
         if (cobj.getNodeId() != null) {
-            builder.append(cobj.getNodeId()).append(", ");
+            nodeIdAppended = true;
+            builder.append(cobj.getNodeId());
         }
-        builder.append(cobj.getArchetypeRef());
+        if(cobj.getArchetypeRef() != null) {
+            if(nodeIdAppended) {
+                builder.append(", ");
+            }
+            builder.append(cobj.getArchetypeRef());
+        }
         builder.append("]");
 
         appendOccurrences(cobj);

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
@@ -166,7 +166,7 @@ public class ArchetypeValidator {
         result.setErrors(messages);
         if(messages.isEmpty()) {
             try {
-                Archetype flattened = new Flattener(repository, combinedModels.getReferenceModels()).flatten(archetype);
+                Archetype flattened = new Flattener(repository, combinedModels).flatten(archetype);
                 result.setFlattened(flattened);
                 messages.addAll(runValidations(flattened, repository, flatParent, validationsPhase3));
             } catch (Exception e) {

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/ValidationResult.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/ValidationResult.java
@@ -26,6 +26,7 @@ public class ValidationResult {
     public ValidationResult(Archetype archetype) {
         this.sourceArchetype = archetype;
         this.archetypeId = archetype.getArchetypeId().toString();
+        this.overlayValidations = new ArrayList<>();
     }
 
     /**

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/SpecializedDefinitionValidation.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/SpecializedDefinitionValidation.java
@@ -135,17 +135,21 @@ public class SpecializedDefinitionValidation extends ValidatingVisitor {
     }
 
     private boolean validateRootSpecializedWithRoot(CArchetypeRoot parentCObject, CArchetypeRoot cObject) {
-        Archetype usedArchetype = repository.getArchetype(cObject.getArchetypeRef());
-        if(usedArchetype != null) {
-            if(!repository.isChildOf(repository.getArchetype(parentCObject.getArchetypeRef()), usedArchetype)) {
-                addMessage(ErrorType.VARXAV, cObject.path());
+        if(cObject.getArchetypeRef() == null && cObject.getOccurrences() != null && cObject.getOccurrences().isProhibited()) {
+            return true;//prohibiting archetype roots with another archetype root does not require the archetype ref
+        } else {
+            Archetype usedArchetype = repository.getArchetype(cObject.getArchetypeRef());
+            if (usedArchetype != null) {
+                if (!repository.isChildOf(repository.getArchetype(parentCObject.getArchetypeRef()), usedArchetype)) {
+                    addMessage(ErrorType.VARXAV, cObject.path());
+                    return false;
+                }
+            } else {
+                addMessageWithPath(ErrorType.VARXRA, cObject.path());
                 return false;
             }
-        } else {
-            addMessageWithPath(ErrorType.VARXRA, cObject.path());
-            return false;
+            return true;
         }
-        return true;
     }
 
     private boolean validateSlotSpecializedWithSlot(ArchetypeSlot parentCObject, ArchetypeSlot cObject) {

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/VariousStructureValidation.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/VariousStructureValidation.java
@@ -46,20 +46,26 @@ public class VariousStructureValidation extends ValidatingVisitor {
     protected void validate(CComplexObject cComplexObject) {
         if(cComplexObject instanceof CArchetypeRoot) {
             CArchetypeRoot archetypeRoot = (CArchetypeRoot) cComplexObject;
-            if(repository.getArchetype(archetypeRoot.getArchetypeRef()) == null) {
-                addMessageWithPath(ErrorType.VARXRA, cComplexObject.path(), String.format("archetype with id %s not found", archetypeRoot.getArchetypeRef()));
-            }
+            if(archetypeRoot.getArchetypeRef() != null) {
+                if (repository.getArchetype(archetypeRoot.getArchetypeRef()) == null) {
+                    addMessageWithPath(ErrorType.VARXRA, cComplexObject.path(), String.format("archetype with id %s not found", archetypeRoot.getArchetypeRef()));
+                }
 
-            ArchetypeHRID hrId = new ArchetypeHRID(archetypeRoot.getArchetypeRef());
-            String archetypeRootTypeName = cComplexObject.getRmTypeName();
-            String archetypeReferenceTypeName = hrId.getRmClass();
+                ArchetypeHRID hrId = new ArchetypeHRID(archetypeRoot.getArchetypeRef());
+                String archetypeRootTypeName = cComplexObject.getRmTypeName();
+                String archetypeReferenceTypeName = hrId.getRmClass();
 
-            if(combinedModels.typeNameExists(archetypeRootTypeName)) {
-                //if parent type info not found will be checked later in phase 2
-                if(!combinedModels.typeNameExists(archetypeReferenceTypeName)) {
-                    addMessageWithPath(ErrorType.VCORM, cComplexObject.getPath(), cComplexObject.getRmTypeName());
-                } else if(!combinedModels.rmTypesConformant(archetypeReferenceTypeName, archetypeRootTypeName)) {
-                    addMessageWithPath(ErrorType.VARXTV, cComplexObject.getPath(), cComplexObject.getRmTypeName());
+                if (combinedModels.typeNameExists(archetypeRootTypeName)) {
+                    //if parent type info not found will be checked later in phase 2
+                    if (!combinedModels.typeNameExists(archetypeReferenceTypeName)) {
+                        addMessageWithPath(ErrorType.VCORM, cComplexObject.getPath(), cComplexObject.getRmTypeName());
+                    } else if (!combinedModels.rmTypesConformant(archetypeReferenceTypeName, archetypeRootTypeName)) {
+                        addMessageWithPath(ErrorType.VARXTV, cComplexObject.getPath(), cComplexObject.getRmTypeName());
+                    }
+                }
+            } else {
+                if(!(archetypeRoot.getOccurrences() != null && archetypeRoot.getOccurrences().isProhibited())) {
+                    addMessageWithPath(ErrorType.VARXR, archetypeRoot.getPath(), "archetype root must have an archetype reference or be prohibited (occurrences matches {0})");
                 }
             }
         }

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/BigArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/BigArchetypeValidatorTest.java
@@ -125,7 +125,7 @@ public class BigArchetypeValidatorTest {
 
     @Test
     public void testFullValidityPackageBmm() {
-        testInner(BuiltinReferenceModels.getMetaModels());
+        testInner(new MetaModels(null, BuiltinReferenceModels.getBMMReferenceModels(), BuiltinReferenceModels.getAomProfiles()));
 
     }
 

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/CKMArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/CKMArchetypeValidatorTest.java
@@ -61,7 +61,7 @@ public class CKMArchetypeValidatorTest {
 
     @Test
     public void fullCKMTestBmm() {
-        MetaModels bmmReferenceModels = BuiltinReferenceModels.getMetaModels();
+        MetaModels bmmReferenceModels = new MetaModels(null, BuiltinReferenceModels.getBMMReferenceModels(), BuiltinReferenceModels.getAomProfiles());
 
         FullArchetypeRepository repository = parseCKM();
         repository.compile(bmmReferenceModels);

--- a/tools/src/test/java/com/nedap/archie/flattener/specexamples/FlattenerExamplesFromSpecBMMTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/specexamples/FlattenerExamplesFromSpecBMMTest.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.flattener.specexamples;
 
 import com.nedap.archie.flattener.SimpleArchetypeRepository;
+import com.nedap.archie.rminfo.MetaModels;
 import org.junit.Before;
 import org.openehr.referencemodels.BuiltinReferenceModels;
 
@@ -9,6 +10,6 @@ public class FlattenerExamplesFromSpecBMMTest extends FlattenerExamplesFromSpecT
     @Before
     public void setup() throws Exception {
         repository = new SimpleArchetypeRepository();
-        models = BuiltinReferenceModels.getMetaModels();
+        models = new MetaModels(null, BuiltinReferenceModels.getBMMReferenceModels(), BuiltinReferenceModels.getAomProfiles());
     }
 }


### PR DESCRIPTION
The archetype validator passed the ModelInfoLookup to the flattener, instead of the combined MetaModels. This gave NullPointerExceptions.

This wasn't detected by tests because both the BMM and ModelInfoLookup models were passed to the tests.

The TemplateOverlay did not have a way to obtain the metadata from the Template, so the correct BMM model could not be selected.

The ADLChecker no longer worked because it does not get compiled with the standard build.

prohibiting a use_archetype with only the node id (no archetype reference) gave a NullPointerException when validation - it does validate in the ADL workbench although the spec says the archetype_ref field is required.

serializing a use_archetype with only the node id output the text [id10, null] instead of [id10]

These issues have been fixed.