### PR TITLE
ADL terminology generator

### DIFF
--- a/adlchecker/build.gradle
+++ b/adlchecker/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 }
 
 run {
-    args = ['archetypes']//, '--outputFlat']
+    args = ['archetypes', '--lint']//, '--outputFlat']
 }
 
 mainClassName='com.nedap.archie.adlchecker.AdlChecker'

--- a/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
+++ b/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
@@ -123,23 +123,23 @@ public class AdlChecker {
     }
 
     private static void printValidationResult(ValidationResult result) {
-        System.out.println();
-        System.out.print("============= ");
-        System.out.print(result.getArchetypeId());
-        System.out.print("      ");
-        if(result.passes()) {
-            System.out.print("PASSED");
-        } else {
-            System.out.print("FAILED");
-        }
-        System.out.print(" =============");
-        System.out.println();
+        printHeader(result.getArchetypeId(), result.passes() ? "PASSED" : "FAILED");
         for(ValidationMessage error:result.getErrors()) {
             System.out.println(error.toString());
         }
         for(ValidationResult overlayResult:result.getOverlayValidations()) {
             printValidationResult(overlayResult);
         }
+    }
+
+    private static void printHeader(String archetypeId, String status) {
+        System.out.println();
+        System.out.print("============= ");
+        System.out.print(archetypeId);
+        System.out.print("      ");
+        System.out.print(status);
+        System.out.print(" =============");
+        System.out.println();
     }
 
     private static void parseArchetype(Path path, InMemoryFullArchetypeRepository repository) {
@@ -154,9 +154,8 @@ public class AdlChecker {
                 if(adlParser.getErrors().hasNoErrors()) {
                     repository.addArchetype(parsed);
                 }
-                if(adlParser.getErrors().hasNoMessages()){
-                    System.out.println(path.getFileName() + " has no messages, ok!");
-                } else {
+                if(!adlParser.getErrors().hasNoMessages()){
+                    printHeader(path.getFileName().toString(), "PARSING FAILED");
                     System.out.println("errors found for " + path.getFileName());
 
                     for(ANTLRParserMessage message:adlParser.getErrors().getWarnings()) {

--- a/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
+++ b/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
@@ -140,6 +140,7 @@ public class AdlChecker {
         System.out.print(status);
         System.out.print(" =============");
         System.out.println();
+        System.out.println();
     }
 
     private static void parseArchetype(Path path, InMemoryFullArchetypeRepository repository) {
@@ -155,22 +156,38 @@ public class AdlChecker {
                     repository.addArchetype(parsed);
                 }
                 if(!adlParser.getErrors().hasNoMessages()){
-                    printHeader(path.getFileName().toString(), "PARSING FAILED");
-                    System.out.println("errors found for " + path.getFileName());
-
-                    for(ANTLRParserMessage message:adlParser.getErrors().getWarnings()) {
-                        System.err.println("warning: " + message.getMessage());
-                    }
-                    for(ANTLRParserMessage message:adlParser.getErrors().getErrors()) {
-                        System.err.println("error: " + message.getMessage());
-                    }
+                    printParseErrors(path, adlParser);
                 }
             } catch (Exception e) {
+                printParseErrors(path, adlParser);
                 e.printStackTrace();
             }
         } catch (IOException e) {
             System.err.println("error opening file");
             e.printStackTrace();
+        }
+    }
+
+    private static void printParseErrors(Path path, ADLParser adlParser) {
+        if(adlParser.getErrors() == null) {
+            printHeader(path.getFileName().toString(), "PARSING FAILED");
+            return;
+        }
+        else if(adlParser.getErrors().hasNoErrors()) {
+            printHeader(path.getFileName().toString(), "PARSING GENERATED WARNINGS");
+        } else {
+            printHeader(path.getFileName().toString(), "PARSING FAILED");
+        }
+        System.out.println("errors found for " + path.getFileName());
+
+        if(adlParser.getErrors() != null) {
+            for (ANTLRParserMessage message : adlParser.getErrors().getWarnings()) {
+                System.err.println("warning: " + message.getMessage());
+            }
+            for (ANTLRParserMessage message : adlParser.getErrors().getErrors()) {
+                System.err.println("error: " + message.getMessage());
+            }
+
         }
     }
 

--- a/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
+++ b/adlchecker/src/main/java/com/nedap/archie/adlchecker/AdlChecker.java
@@ -149,6 +149,7 @@ public class AdlChecker {
             return;
         }
         ADLParser adlParser = new ADLParser();
+        adlParser.setLogEnabled(false);
         try (FileInputStream stream = new FileInputStream(file)) {
             try {
                 Archetype parsed = adlParser.parse(stream);

--- a/adlchecker/src/main/java/com/nedap/archie/adlchecker/TerminologyContentGenerator.java
+++ b/adlchecker/src/main/java/com/nedap/archie/adlchecker/TerminologyContentGenerator.java
@@ -115,7 +115,6 @@ public class TerminologyContentGenerator {
         for(String line:lines) {
             Matcher matcher = commentPattern.matcher(line);
             if(matcher.matches()) {
-                System.out.println("we have a match!");
                 String idcode = matcher.group("idcode");
                 String comment = matcher.group("comment");
                 if(idcode.equalsIgnoreCase(nodeId)) {

--- a/adlchecker/src/main/java/com/nedap/archie/adlchecker/TerminologyContentGenerator.java
+++ b/adlchecker/src/main/java/com/nedap/archie/adlchecker/TerminologyContentGenerator.java
@@ -1,0 +1,167 @@
+package com.nedap.archie.adlchecker;
+
+import com.nedap.archie.adlparser.ADLParser;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CAttribute;
+import com.nedap.archie.aom.CObject;
+import com.nedap.archie.aom.terminology.ArchetypeTerm;
+import com.nedap.archie.aom.utils.AOMUtils;
+import com.nedap.archie.rminfo.MetaModels;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * If you create an archetype, generates a line of empty terminology for every missing term in every language.
+ * Adds the comments as default text
+ */
+public class TerminologyContentGenerator {
+
+    private MetaModels models;
+    Pattern commentPattern = Pattern.compile(".*\\[(?<idcode>id[0-9]+)(,|\\]).*--(?<comment>.*)");
+
+    public TerminologyContentGenerator(MetaModels models) {
+        this.models = models;
+    }
+
+    public Archetype addTerms(String adlContent) {
+        ADLParser parser = new ADLParser();
+        try {
+            Archetype archetype = parser.parse(adlContent);
+            models.selectModel(archetype);
+
+            //TODO: just run the CodeValidation in the context of an archetype repository, and process the error messages?
+            if(parser.getErrors().hasErrors()) {
+                throw new RuntimeException("parse errors!" + parser.getErrors().toString());
+            }
+            Archetype resultingArchetype = parser.parse(adlContent); //instantiate twice
+            walkArchetype(adlContent, archetype, resultingArchetype);
+            sortTerminology(resultingArchetype);
+            return resultingArchetype;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void sortTerminology(Archetype resultingArchetype) {
+        Map<String, Map<String, ArchetypeTerm>> termDefinitions = resultingArchetype.getTerminology().getTermDefinitions();
+        for(String language: termDefinitions.keySet()) {
+            Map<String, ArchetypeTerm> stringArchetypeTermMap = termDefinitions.get(language);
+            Map<String, ArchetypeTerm> sortedArchetypeTermMap = new TreeMap<>(new Comparator<String>() {
+                @Override
+                public int compare(String o1, String o2) {
+                    String code1 = o1.substring(0, 2);
+                    String code2 = o2.substring(0, 2);
+                    if(code1.equalsIgnoreCase(code2)) {
+                        int number1 = Integer.parseInt(o1.substring(2));
+                        int number2 = Integer.parseInt(o2.substring(2));
+                        return number1 - number2;
+                    } else {
+                        return code2.compareTo(code1);
+                    }
+                }
+            });//TODO: comparator!
+            sortedArchetypeTermMap.putAll(stringArchetypeTermMap);
+            termDefinitions.put(language, sortedArchetypeTermMap);
+
+        }
+    }
+
+    private void walkArchetype(String sourceFile, Archetype archetype, Archetype resultingArchetype) {
+        Stack<CObject> workList = new Stack<>();
+        workList.push(archetype.getDefinition());
+        List<CObject> cObjects = new ArrayList<>();
+        while(!workList.empty()) {
+            CObject next = workList.pop();
+            if(!terminologyHasCode(archetype, next)) {
+                cObjects.add(next);
+                addCodeToTerminology(sourceFile, resultingArchetype, next);
+            }
+            for(CAttribute attribute:next.getAttributes()) {
+                for(CObject child:attribute.getChildren()) {
+                    workList.push(child);
+                }
+            }
+        }
+    }
+
+    private void addCodeToTerminology(String sourceFile, Archetype resultingArchetype, CObject next) {
+        String text = getCommentName(sourceFile, next.getNodeId());
+        if(text == null) {
+            text = "X";
+        }
+        String description = text; //TODO: grep comment from sourcefile!
+        Map<String, Map<String, ArchetypeTerm>> termDefinitions = resultingArchetype.getTerminology().getTermDefinitions();
+        for(String language: termDefinitions.keySet()) {
+            if(termDefinitions.get(language).get(next.getNodeId()) == null) {
+                ArchetypeTerm newCode = new ArchetypeTerm();
+                newCode.setCode(next.getNodeId());
+                newCode.setText(text);
+                newCode.setDescription(description);
+                termDefinitions.get(language).put(next.getNodeId(), newCode);
+            }
+        }
+    }
+
+    private String getCommentName(String sourceFile, String nodeId) {
+        String[] lines = sourceFile.split("\n");
+        for(String line:lines) {
+            Matcher matcher = commentPattern.matcher(line);
+            if(matcher.matches()) {
+                System.out.println("we have a match!");
+                String idcode = matcher.group("idcode");
+                String comment = matcher.group("comment");
+                if(idcode.equalsIgnoreCase(nodeId)) {
+                    return comment.trim();
+                }
+            }
+
+        }
+        return null;
+    }
+
+    public boolean terminologyHasCode(Archetype archetype, CObject cObject) {
+        String nodeId = cObject.getNodeId();
+        int codeSpecializationDepth = AOMUtils.getSpecializationDepthFromCode(nodeId);
+        int archetypeSpecializationDepth = archetype.specializationDepth();
+        if(codeSpecializationDepth > archetypeSpecializationDepth) {
+            return true;//not exactly, this is a validation failure that needs to be fixed. log?
+        } else if (cObject.isRoot() || parentIsMultiple(cObject)) {
+            if( codeSpecializationDepth == archetypeSpecializationDepth &&  !archetype.getTerminology().hasIdCodeInAllLanguages(nodeId)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean parentIsMultiple(CObject cObject) {
+        if(cObject.getParent() != null) {
+
+            CAttribute parent = cObject.getParent();
+            CObject owningObject = parent.getParent();
+            if (parent.getDifferentialPath() != null) {
+                //not supported yet here.
+                return false;
+                /*&&
+            } flatParent != null) {
+                CAttribute attributeFromParent = (CAttribute) AOMUtils.getDifferentialPathFromParent(flatParent, parent);
+                if(attributeFromParent != null) {
+                    owningObject = attributeFromParent.getParent();
+                }*/
+
+            }
+            if(owningObject != null) {
+                return models.isMultiple(owningObject.getRmTypeName(), parent.getRmAttributeName());
+            }
+        }
+        return false;
+    }
+
+}

--- a/aom/src/main/java/com/nedap/archie/aom/terminology/ArchetypeTerminology.java
+++ b/aom/src/main/java/com/nedap/archie/aom/terminology/ArchetypeTerminology.java
@@ -196,6 +196,22 @@ public class ArchetypeTerminology extends ArchetypeModelObject {
         return AOMUtils.isIdCode(code) && hasCode(code);
     }
 
+    public boolean hasCodeInAllLanguages(String code) {
+        if(termDefinitions == null) {
+            return false;
+        }
+        for(String language:getTermDefinitions().keySet()) {
+            if(!getTermDefinitions().get(language).containsKey(code)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean hasIdCodeInAllLanguages(String code) {
+        return AOMUtils.isIdCode(code) && hasCodeInAllLanguages(code);
+    }
+
     public boolean hasValueSetCode(String code) {
         return AOMUtils.isValueSetCode(code) && hasCode(code);
     }

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java
@@ -78,7 +78,7 @@ public enum ErrorType {
     VDSEV("archetype slot 'exclude' constraint validity. The 'exclude' constraint in an archetype slot must conform to the slot constraint validity rules."),
     VACSO("single-valued attribute child object occurrences validity: the occurrences of a child object of a single-valued attribute cannot have an upper limit greater than 1."),
     VACMCU(" cardinality/occurrences upper bound validity: where a cardinality with a finite upper bound is stated on an attribute, for all immediate child objects for which an occurrences constraint is stated, the occurrences must either have an open upper bound (i.e. n..*) which is interpreted as the maximum value allowed within the cardinality, or else a finite upper bound which is ⇐ the cardinality upper bound."),
-    WOUC("codein terminology not used in archetype definition");
+    WOUC("code in terminology not used in archetype definition");
 
 
 


### PR DESCRIPTION
A tool to make ADL editing by hand easier:

Simply write your ADL, including comments after the node ids with the text. Add the languages you want to the terminology, with no or just a few entries per language. Then run it through the adlchecker with the '--lint' option.

Now you'll receive a correctly indented version, with all missing terms in the terminology added automatically.

at- and ac-codes get added with a text marking they should be translated. id codes with a comment on the same line where it is used in the definition get that comment added to both its text and definition, so you can easily complete the terminology. If no comment has been provided it gets added with a 'translate me' text+description. If the id code translation is not mandatory in the terminology (DV_* in ELEMENT.value, for example), it does not get added at all.

Saves a lot of time if you don't have a functional ADL 2 compatible archetype editor...
