### PR TITLE
Modified ArchetypeValidator to bypass flattening in case of warnings.

### DIFF
--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
@@ -164,7 +164,7 @@ public class ArchetypeValidator {
 
         ValidationResult result = new ValidationResult(archetype);
         result.setErrors(messages);
-        if(messages.isEmpty()) {
+        if(result.passes()) {
             try {
                 Archetype flattened = new Flattener(repository, combinedModels).flatten(archetype);
                 result.setFlattened(flattened);


### PR DESCRIPTION
On line 167 of ArchetypeValidator, the setting of flattened archetypes in the result is skipped if either errors or warnings are present. yet, the correct behavior should probably be to only skip in case of errors and not in the case of warnings. Hence, modified if statement to check for the case of errors explicitly by changing the condition from messages.isEmpty() to result.passes().