### PR TITLE
Add updated value to assertion result, along with symbol

### DIFF
--- a/aom/src/main/java/com/nedap/archie/rminfo/ArchieAOMInfoLookup.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/ArchieAOMInfoLookup.java
@@ -72,7 +72,7 @@ public class ArchieAOMInfoLookup extends ReflectionModelInfoLookup {
     }
 
     @Override
-    public Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
+    public Map<String, Object> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
         throw new UnsupportedOperationException("not supported");//TODO: split this to different classes
     }
 

--- a/aom/src/main/java/com/nedap/archie/rminfo/ArchieAOMInfoLookup.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/ArchieAOMInfoLookup.java
@@ -8,9 +8,10 @@ import com.nedap.archie.base.Cardinality;
 import com.nedap.archie.base.Interval;
 import com.nedap.archie.base.terminology.TerminologyCode;
 
-import java.util.List;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by pieter.bos on 06/07/16.
@@ -71,7 +72,7 @@ public class ArchieAOMInfoLookup extends ReflectionModelInfoLookup {
     }
 
     @Override
-    public void pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
+    public Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
         throw new UnsupportedOperationException("not supported");//TODO: split this to different classes
     }
 

--- a/aom/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
@@ -158,7 +158,7 @@ public interface ModelInfoLookup {
      * @return Each key is a path that was updated as a result of the previously updated path and each corresponding
      * value is this path's updated value
      */
-    Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent);
+    Map<String, Object> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent);
 
     /**
      * True if the given attribute at given type is ok for given CPrimitiveObject, false otherwise

--- a/aom/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/ModelInfoLookup.java
@@ -141,6 +141,11 @@ public interface ModelInfoLookup {
      * Perform any actions necessary if the value at the given path has just been updated
      * For example, if an ordinal value has been set, this method should also set the symbol.
      *
+     * In addition to changing the actual values, it returns which additional paths have been updated as well.
+     * For example, if an ordinal's symbol was updated, it will update both the value and the symbol of that ordinal
+     * and return the value's path and updated value. This is done to obtain a full set of instructions of what must be
+     * changed due to the rule evaluation.
+     *
      * This can be the most complex operation of this entire class to implement. If you just throw an exception instead of implementing it
      * everything will work fine except for the rule evaluation.
      *
@@ -150,8 +155,10 @@ public interface ModelInfoLookup {
      * @param archetype
      * @param pathOfParent
      * @param parent
+     * @return Each key is a path that was updated as a result of the previously updated path and each corresponding
+     * value is this path's updated value
      */
-    void pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent);
+    Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent);
 
     /**
      * True if the given attribute at given type is ok for given CPrimitiveObject, false otherwise

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -141,7 +141,7 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
      * @param parent
      */
     @Override
-    public Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
+    public Map<String, Object> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
         return UpdatedValueHandler.pathHasBeenUpdated(rmObject, archetype, pathOfParent, parent);
     }
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -3,24 +3,15 @@ package com.nedap.archie.rminfo;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.aom.CPrimitiveObject;
-import com.nedap.archie.aom.primitives.CBoolean;
-import com.nedap.archie.aom.primitives.CDate;
-import com.nedap.archie.aom.primitives.CDateTime;
-import com.nedap.archie.aom.primitives.CDuration;
-import com.nedap.archie.aom.primitives.CInteger;
-import com.nedap.archie.aom.primitives.CReal;
-import com.nedap.archie.aom.primitives.CString;
-import com.nedap.archie.aom.primitives.CTerminologyCode;
-import com.nedap.archie.aom.primitives.CTime;
+import com.nedap.archie.aom.primitives.*;
 import com.nedap.archie.base.Interval;
 import com.nedap.archie.base.terminology.TerminologyCode;
-import com.nedap.archie.rm.archetyped.Locatable;
-import com.nedap.archie.rm.datavalues.DvBoolean;
-import com.nedap.archie.rm.support.identification.TerminologyId;
 import com.nedap.archie.rm.RMObject;
+import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rm.datastructures.PointEvent;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DvCodedText;
+import com.nedap.archie.rm.support.identification.TerminologyId;
 
 import java.lang.reflect.Method;
 import java.time.temporal.Temporal;
@@ -29,6 +20,7 @@ import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by pieter.bos on 02/02/16.
@@ -149,8 +141,8 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
      * @param parent
      */
     @Override
-    public void pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
-        UpdatedValueHandler.pathHasBeenUpdated(rmObject, archetype, pathOfParent, parent);
+    public Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
+        return UpdatedValueHandler.pathHasBeenUpdated(rmObject, archetype, pathOfParent, parent);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
@@ -54,6 +54,8 @@ public class UpdatedValueHandler {
     }
 
     private static Map<String, Long> fixDvOrdinal(Object rmObject, Archetype archetype, String pathOfParent) throws XPathExpressionException {
+        Map<String, Long> result = new HashMap<>();
+
         RMPathQuery rmPathQuery = new RMPathQuery(pathOfParent.replace("/symbol/defining_code", ""));
         DvOrdinal ordinal = rmPathQuery.find(ArchieRMInfoLookup.getInstance(), rmObject);
         Long value = null;
@@ -72,6 +74,8 @@ public class UpdatedValueHandler {
                                 if(interval.getLower().equals(interval.getUpper()) && !interval.isLowerUnbounded() && !interval.isUpperUnbounded()) {
                                     value = interval.getLower();
                                     ordinal.setValue(value);
+                                    String pathToValue = pathOfParent.replace("/symbol/defining_code", "/value");
+                                    result.put(pathToValue, value);
                                 }
 
                             }
@@ -81,10 +85,6 @@ public class UpdatedValueHandler {
                 }
             }
         }
-
-        Map<String, Long> result = new HashMap<>();
-        String pathToValue = pathOfParent.replace("/symbol/defining_code", "/value");
-        result.put(pathToValue, value);
 
         return result;
     }

--- a/test-rm/src/main/java/com/nedap/archie/openehrtestrm/TestRMInfoLookup.java
+++ b/test-rm/src/main/java/com/nedap/archie/openehrtestrm/TestRMInfoLookup.java
@@ -3,15 +3,7 @@ package com.nedap.archie.openehrtestrm;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.aom.CPrimitiveObject;
-import com.nedap.archie.aom.primitives.CBoolean;
-import com.nedap.archie.aom.primitives.CDate;
-import com.nedap.archie.aom.primitives.CDateTime;
-import com.nedap.archie.aom.primitives.CDuration;
-import com.nedap.archie.aom.primitives.CInteger;
-import com.nedap.archie.aom.primitives.CReal;
-import com.nedap.archie.aom.primitives.CString;
-import com.nedap.archie.aom.primitives.CTerminologyCode;
-import com.nedap.archie.aom.primitives.CTime;
+import com.nedap.archie.aom.primitives.*;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DataValue;
 import com.nedap.archie.rm.datavalues.DvCodedText;
@@ -22,9 +14,7 @@ import com.nedap.archie.rminfo.ReflectionModelInfoLookup;
 
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 /**
  * Created by pieter.bos on 02/02/16.
@@ -98,8 +88,8 @@ public class TestRMInfoLookup extends ReflectionModelInfoLookup {
      * @param parent
      */
     @Override
-    public void pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
-
+    public Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
+        return new HashMap<>();
     }
 
     @Override

--- a/test-rm/src/main/java/com/nedap/archie/openehrtestrm/TestRMInfoLookup.java
+++ b/test-rm/src/main/java/com/nedap/archie/openehrtestrm/TestRMInfoLookup.java
@@ -88,7 +88,7 @@ public class TestRMInfoLookup extends ReflectionModelInfoLookup {
      * @param parent
      */
     @Override
-    public Map<String, Long> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
+    public Map<String, Object> pathHasBeenUpdated(Object rmObject, Archetype archetype, String pathOfParent, Object parent) {
         return new HashMap<>();
     }
 

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
@@ -1,11 +1,7 @@
 package com.nedap.archie.rules.evaluation;
 
 import com.google.common.collect.Lists;
-import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.ArchetypeModelObject;
-import com.nedap.archie.aom.CAttribute;
-import com.nedap.archie.aom.CComplexObject;
-import com.nedap.archie.aom.CObject;
+import com.nedap.archie.aom.*;
 import com.nedap.archie.creation.RMObjectCreator;
 import com.nedap.archie.rminfo.ModelInfoLookup;
 import com.nedap.archie.rminfo.RMAttributeInfo;
@@ -13,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.xml.xpath.XPathExpressionException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,8 +32,10 @@ public class AssertionsFixer {
         this.modelInfoLookup = ruleEvaluation.getModelInfoLookup();
         emptyRMObjectConstructor = new EmptyRMObjectConstructor(evaluation.getModelInfoLookup());
     }
-    
-    public void fixAssertions(Archetype archetype, AssertionResult assertionResult) {
+
+    public Map<String, Long> fixAssertions(Archetype archetype, AssertionResult assertionResult) {
+        Map<String, Long> result = new HashMap<>();
+
         try {
             Map<String, Value> setPathValues = assertionResult.getSetPathValues();
             for(String path:setPathValues.keySet()) {
@@ -71,13 +70,16 @@ public class AssertionsFixer {
                     } else {
                         creator.set(parent, lastPathSegment, Lists.newArrayList(value.getValue()));
                     }
-                    modelInfoLookup.pathHasBeenUpdated(ruleEvaluation.getRMRoot(), archetype, pathOfParent, parent);
+
+                    result = modelInfoLookup.pathHasBeenUpdated(ruleEvaluation.getRMRoot(), archetype, pathOfParent, parent);
                     ruleEvaluation.refreshQueryContext();
                 }
             }
         } catch (XPathExpressionException e) {
             logger.error("error fixing assertionResult {}", assertionResult, e);
         }
+
+        return result;
     }
 
 

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
@@ -33,8 +33,8 @@ public class AssertionsFixer {
         emptyRMObjectConstructor = new EmptyRMObjectConstructor(evaluation.getModelInfoLookup());
     }
 
-    public Map<String, Long> fixAssertions(Archetype archetype, AssertionResult assertionResult) {
-        Map<String, Long> result = new HashMap<>();
+    public Map<String, Object> fixAssertions(Archetype archetype, AssertionResult assertionResult) {
+        Map<String, Object> result = new HashMap<>();
 
         try {
             Map<String, Value> setPathValues = assertionResult.getSetPathValues();

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -150,7 +150,7 @@ public class RuleEvaluation<T> {
         Map<String, Long> valuesToUpdate = assertionsFixer.fixAssertions(archetype, assertionResult);
         for (String path : valuesToUpdate.keySet()) {
             Long value = valuesToUpdate.get(path);
-            assertionResult.setSetPathValue(path, new ValueList(new Value(value)));
+            assertionResult.setSetPathValue(path, new ValueList(value));
         }
 
         //before re-evaluation, reset any overridden existence from evaluation?

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -8,15 +8,7 @@ import com.nedap.archie.rminfo.ModelInfoLookup;
 import com.nedap.archie.rules.Expression;
 import com.nedap.archie.rules.RuleElement;
 import com.nedap.archie.rules.RuleStatement;
-import com.nedap.archie.rules.evaluation.evaluators.AssertionEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.BinaryOperatorEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.ConstantEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.ForAllEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.FunctionEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.ModelReferenceEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.UnaryOperatorEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.VariableDeclarationEvaluator;
-import com.nedap.archie.rules.evaluation.evaluators.VariableReferenceEvaluator;
+import com.nedap.archie.rules.evaluation.evaluators.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +16,7 @@ import javax.xml.bind.JAXBContext;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by pieter.bos on 31/03/16.
@@ -154,8 +147,11 @@ public class RuleEvaluation<T> {
         //Fix any assertions that should be fixed before processing the next rule
         //this means we can calculate a score, then use that score in the next rule
         //otherwise this would mean several passes through the evaluator
-        assertionsFixer.fixAssertions(archetype, assertionResult);
-
+        Map<String, Long> valuesToUpdate = assertionsFixer.fixAssertions(archetype, assertionResult);
+        for (String path : valuesToUpdate.keySet()) {
+            Long value = valuesToUpdate.get(path);
+            assertionResult.setSetPathValue(path, new ValueList(new Value(value)));
+        }
 
         //before re-evaluation, reset any overridden existence from evaluation?
     }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -147,9 +147,9 @@ public class RuleEvaluation<T> {
         //Fix any assertions that should be fixed before processing the next rule
         //this means we can calculate a score, then use that score in the next rule
         //otherwise this would mean several passes through the evaluator
-        Map<String, Long> valuesToUpdate = assertionsFixer.fixAssertions(archetype, assertionResult);
+        Map<String, Object> valuesToUpdate = assertionsFixer.fixAssertions(archetype, assertionResult);
         for (String path : valuesToUpdate.keySet()) {
-            Long value = valuesToUpdate.get(path);
+            Object value = valuesToUpdate.get(path);
             assertionResult.setSetPathValue(path, new ValueList(value));
         }
 

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -49,17 +49,19 @@ public class FixableAssertionsCheckerTest {
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("There are four values that must be set", 4, evaluate.getSetPathValues().size());
+        assertEquals("There are four values that must be set", 5, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
         assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string").getValue());
+        assertEquals("Option 1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/value").getValue());
         assertEquals("at6", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string").getValue());
         assertEquals(0l, evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/value").getValue());
 
         //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
         assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
         assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string"));
+        assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/value"));
         assertEquals("at6", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string"));
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
 

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -49,17 +49,19 @@ public class FixableAssertionsCheckerTest {
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("there must be three values that must be set", 3, evaluate.getSetPathValues().size());
+        assertEquals("There are four values that must be set", 4, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
         assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string").getValue());
         assertEquals("at6", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string").getValue());
+        assertEquals(0l, evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/value").getValue());
 
         //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
         assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
         assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string"));
         assertEquals("at6", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string"));
+        assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
 
         //and of course the DV_ORDINAL and DV_CODED_TEXT should be constructed correctly, with the correct numeric respectively a textual value
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
@@ -80,17 +82,21 @@ public class FixableAssertionsCheckerTest {
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("there must be three values that must be set", 3, evaluate.getSetPathValues().size());
+        assertEquals("There are four values that must be set", 4, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
         assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string").getValue());
         assertEquals("at6", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string").getValue());
+        assertEquals(0l, evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/value").getValue());
+
 
         //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
         assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
         assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string"));
         assertEquals("at6", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string"));
+        assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
+
 
         //and of course the DV_ORDINAL and DV_CODED_TEXT should be constructed correctly, with the correct numeric respectively a textual value
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));


### PR DESCRIPTION
After updating the RMObject based on the assertion result, the assertion result itself will be updated with a DVOrdinal's value, if only the symbol was set.