### PR TITLE
Fix URL parsing in ODIN grammar to work with URls with no path or '/'…

### DIFF
--- a/base/src/main/java/com/nedap/archie/antlr/errors/ArchieErrorListener.java
+++ b/base/src/main/java/com/nedap/archie/antlr/errors/ArchieErrorListener.java
@@ -23,6 +23,10 @@ public class ArchieErrorListener implements ANTLRErrorListener {
     private static final Logger logger = LoggerFactory.getLogger(ArchieErrorListener.class);
     private final ANTLRParserErrors errors;
 
+    public ArchieErrorListener() {
+        errors = new ANTLRParserErrors();
+    }
+
     public ArchieErrorListener(ANTLRParserErrors errors) {
         this.errors = errors;
     }

--- a/grammars/src/main/antlr/base_patterns.g4
+++ b/grammars/src/main/antlr/base_patterns.g4
@@ -95,12 +95,12 @@ TERM_CODE_REF : '[' NAME_CHAR+ ( '(' NAME_CHAR+ ')' )? '::' NAME_CHAR+ ']' ;  //
 // URIs - simple recogniser based on https://tools.ietf.org/html/rfc3986 and
 // http://www.w3.org/Addressing/URL/5_URI_BNF.html
 URI : URI_SCHEME SYM_COLON URI_HIER_PART ( '?' URI_QUERY )? ;
-fragment URI_HIER_PART : ( '//' URI_AUTHORITY )? URI_PATH ;
+fragment URI_HIER_PART : ( '//' URI_AUTHORITY ) URI_PATH? ;
 fragment URI_AUTHORITY : ( URI_USER '@' )? URI_HOST ( SYM_COLON NATURAL )? ;
 fragment URI_HOST : IP_LITERAL | NAMESPACE ;
 fragment URI_USER : URI_RESERVED+ ;
 fragment URI_SCHEME : ALPHANUM_CHAR URI_XALPHA* ;
-fragment URI_PATH   : ( '/' URI_XPALPHA+ )+ ;
+fragment URI_PATH   : '/' | ( '/' URI_XPALPHA+ )+ ('/')?;
 fragment URI_QUERY  : URI_XALPHA+ ( '+' URI_XALPHA+ )* ;
 
 fragment IP_LITERAL   : IPV4_LITERAL | IPV6_LITERAL ;

--- a/odin/src/test/java/com/nedap/archie/serializer/odin/OdinToJsonConverterTest.java
+++ b/odin/src/test/java/com/nedap/archie/serializer/odin/OdinToJsonConverterTest.java
@@ -1,0 +1,43 @@
+package com.nedap.archie.serializer.odin;
+
+
+import com.nedap.archie.adlparser.antlr.AdlLexer;
+import com.nedap.archie.adlparser.antlr.AdlParser;
+import com.nedap.archie.antlr.errors.ArchieErrorListener;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.junit.Test;
+import org.antlr.v4.runtime.CharStreams;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class OdinToJsonConverterTest {
+
+    @Test
+    public void convertURI() throws Exception {
+        assertConvertedEqual("original_resource_uri = < [\"resource A\"] = <http://test.example.com> >",
+                "{\"original_resource_uri\":{\"resource A\":\"http://test.example.com\"}}");
+        assertConvertedEqual("original_resource_uri = < [\"resource A\"] = <http://test.example.com/> >",
+                "{\"original_resource_uri\":{\"resource A\":\"http://test.example.com/\"}}");
+
+        assertConvertedEqual("original_resource_uri = < [\"resource A\"] = <http://test.example.com/aa/bb> >",
+                "{\"original_resource_uri\":{\"resource A\":\"http://test.example.com/aa/bb\"}}");
+
+        assertConvertedEqual("original_resource_uri = < [\"resource A\"] = <http://test.example.com/aa/bb/> >",
+                "{\"original_resource_uri\":{\"resource A\":\"http://test.example.com/aa/bb/\"}}");
+    }
+
+    private void assertConvertedEqual(String odin, String json) {
+        String input = odin;
+        AdlLexer adlLexer = new AdlLexer(CharStreams.fromString(input));
+        AdlParser parser = new AdlParser(new CommonTokenStream(adlLexer));
+        ArchieErrorListener errorListener = new ArchieErrorListener();
+        parser.addErrorListener(errorListener);
+        OdinToJsonConverter converter = new OdinToJsonConverter();
+        String result = converter.convert(parser.odin_text());
+        assertTrue(errorListener.getErrors().toString(), errorListener.getErrors().hasNoErrors());
+
+        assertEquals("the converted json should be equal to the expected", json, result);
+    }
+}

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/AuthoredArchetypeMetadataChecks.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/AuthoredArchetypeMetadataChecks.java
@@ -32,8 +32,8 @@ public class AuthoredArchetypeMetadataChecks extends ArchetypeValidationBase {
         if(archetype.getDescription().getDetails() != null) {
             for(String language:archetype.getDescription().getDetails().keySet()) {
                 ResourceDescriptionItem resourceDescriptionItem = archetype.getDescription().getDetails().get(language);
-                if(!Objects.equals(language, resourceDescriptionItem.getLanguage().getCodeString())){
-                    addMessage(ErrorType.VRDLA, String.format("resource description language %s has its key set wrong: %s", language, resourceDescriptionItem.getLanguage().getCodeString()));
+                if(resourceDescriptionItem.getLanguage() == null || !Objects.equals(language, resourceDescriptionItem.getLanguage().getCodeString())){
+                    addMessage(ErrorType.VRDLA, String.format("resource description language %s has its key set wrong: %s", language, resourceDescriptionItem.getLanguage() == null ? null : resourceDescriptionItem.getLanguage().getCodeString()));
                 }
 
             }

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -18,6 +18,7 @@ import com.nedap.archie.xml.JAXBUtil;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -45,7 +46,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void precedenceOverride() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("simplearithmetic.adls"));
+        parse("simplearithmetic.adls");
 
         ExpressionVariable booleanExtendedTest = (ExpressionVariable) getVariableDeclarationByName(archetype, "boolean_extended_test");
         BinaryOperator operator = (BinaryOperator) booleanExtendedTest.getExpression();
@@ -59,9 +60,14 @@ public class ParsedRulesEvaluationTest {
 
     }
 
+    private void parse(String filename) throws IOException {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream(filename));
+        assertTrue(parser.getErrors().toString(), parser.getErrors().hasNoErrors());
+    }
+
     @Test
     public void simpleArithmetic() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("simplearithmetic.adls"));
+        parse("simplearithmetic.adls");
         assertTrue(parser.getErrors().hasNoErrors());
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
         Observation root = new Observation();
@@ -114,7 +120,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void modelReferences() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("modelreferences.adls"));
+        parse("modelreferences.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -139,7 +145,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void booleanConstraint() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("matches.adls"));
+        parse("matches.adls");
 
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
@@ -163,7 +169,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void multiValuedExpressions() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("multiplicity.adls"));
+        parse("multiplicity.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservations();
@@ -180,7 +186,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void forAllExpression() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("for_all.adls"));
+        parse("for_all.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservations();
@@ -274,7 +280,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void alreadyCorrectCalculatedPathValues() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values.adls"));
+        parse("calculated_path_values.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -296,7 +302,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void calculatedPathValues() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values.adls"));
+        parse("calculated_path_values.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -314,7 +320,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void calculatedPathValuesWithNulls1() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values.adls"));
+        parse("calculated_path_values.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -332,7 +338,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void calculatedPathValuesWithNulls2() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values.adls"));
+        parse("calculated_path_values.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -350,7 +356,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void calculatedPathValuesWithNulls3() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("extended_calculated_path_values.adls"));
+        parse("extended_calculated_path_values.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -375,7 +381,7 @@ public class ParsedRulesEvaluationTest {
      */
     @Test
     public void calculatedPathValues2() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("calculated_path_values_2.adls"));
+        parse("calculated_path_values_2.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -397,7 +403,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void forAllCalculatedValues() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("for_all_calculated_path_values.adls"));
+        parse("for_all_calculated_path_values.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservations();
@@ -415,7 +421,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void existsSucceeded() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("exists.adls"));
+        parse("exists.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservations();
@@ -457,7 +463,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void notExistsSucceeded() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("not_exists.adls"));
+        parse("not_exists.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -477,7 +483,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void notExistsFailed() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("not_exists.adls"));
+        parse("not_exists.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservations();
@@ -496,7 +502,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void existsMixed() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("exists.adls"));
+        parse("exists.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservationsOneEmptySystolic();
@@ -523,7 +529,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void notExistsMixed() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("not_exists.adls"));
+        parse("not_exists.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservationsOneEmptySystolic();
@@ -544,7 +550,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void implies() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("implies.adls"));
+        parse("implies.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = constructTwoBloodPressureObservationsOneEmptySystolicNoDiastolic();
@@ -564,7 +570,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void impliesEvaluatesToNull() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("implies.adls"));
+        parse("implies.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
 
         Pathable root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
@@ -584,7 +590,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void booleanOperandRelOps() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("boolean_operand_relops.adls"));
+        parse("boolean_operand_relops.adls");
         assertTrue(parser.getErrors().hasNoErrors());
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
         Observation root = new Observation();
@@ -603,7 +609,7 @@ public class ParsedRulesEvaluationTest {
 
     @Test
     public void stringLiterals() throws Exception {
-        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("string_literals.adls"));
+        parse("string_literals.adls");
         assertTrue(parser.getErrors().hasNoErrors());
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
         Observation root = new Observation();

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/calculated_path_values_2.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/calculated_path_values_2.adls
@@ -80,7 +80,7 @@ rules
 
 	$diastolic:Real ::= /data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude
 
-	/data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude = $systolic - $diastolic
+	label:/data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude = $systolic - $diastolic
 
 	/data[id2]/events[id3]/data[id4]/items[id8]/value/magnitude = /data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude + 3
 


### PR DESCRIPTION
… as path

See corresponding issue in ADL-ANTLR-grammar. The changes in the rules test is because URL-parsing can clash with rule parsing in case an expression has a label