### PR TITLE
Remove licence field from resource description item. Should not be th…

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/ResourceDescriptionItem.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ResourceDescriptionItem.java
@@ -16,7 +16,6 @@ public class ResourceDescriptionItem extends ArchetypeModelObject {
     private String use;
     private String misuse;
     private String copyright;
-    private String licence;
     private Map<String, URI> originalResourceUri;
     private Map<String, String> otherDetails;//TODO: string -> object?
 
@@ -84,4 +83,5 @@ public class ResourceDescriptionItem extends ArchetypeModelObject {
     public void setCopyright(String copyright) {
         this.copyright = copyright;
     }
+
 }


### PR DESCRIPTION
…ere, had no getter/setter and was private

There was a licence field in ResourceDescriptionItem. It was private without getter and setter and has no other usages. According to the specs, it should not be present. So this pull request removes it.

Should have no impact on users, unless they used reflection to access a private field without getters and setters :)