### PR TITLE
Create getUniquePath and related utility functions

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Composition.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Composition.java
@@ -103,6 +103,7 @@ public class Composition extends Locatable {
 
     public void setContext(@Nullable EventContext context) {
         this.context = context;
+        setThisAsParent(context, "context");
     }
 
     public List<ContentItem> getContent() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rmutil/PathableUtil.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rmutil/PathableUtil.java
@@ -1,0 +1,73 @@
+package com.nedap.archie.rmutil;
+
+import com.nedap.archie.paths.PathSegment;
+import com.nedap.archie.paths.PathUtil;
+import com.nedap.archie.query.RMObjectAttributes;
+import com.nedap.archie.rm.archetyped.Pathable;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.rminfo.ModelInfoLookup;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class PathableUtil {
+    /**
+     * Determine the unique path segments from the toplevel-RM object.
+     * <p>
+     * Adds index when necessary.
+     */
+    public static List<PathSegment> getUniquePathSegments(Pathable pathable) {
+        Pathable parent = pathable.getParent();
+        if (parent == null) {
+            return new ArrayList<>();
+        }
+
+        List<PathSegment> segments = getUniquePathSegments(parent);
+
+        segments.add(getUniquePathSegment(pathable));
+        return segments;
+    }
+
+    private static PathSegment getUniquePathSegment(Pathable pathable) {
+        List<PathSegment> unindexedPathSegments = pathable.getPathSegments();
+        PathSegment unindexedPathSegment = unindexedPathSegments.get(unindexedPathSegments.size() - 1);
+
+        Pathable parent = pathable.getParent();
+        String parentAttributeName = unindexedPathSegment.getNodeName();
+
+        ModelInfoLookup modelInfoLookup = ArchieRMInfoLookup.getInstance();
+        Object attributeValue = RMObjectAttributes.getAttributeValueFromRMObject(parent, parentAttributeName, modelInfoLookup);
+        Integer index = null;
+
+        if (attributeValue instanceof Collection) {
+            Collection collection = (Collection) attributeValue;
+
+            if (collection.size() > 1) {
+                int i = 1;
+                for (Object elem : collection) {
+                    if (elem == pathable) {
+                        index = i;
+                        break;
+                    }
+                    i++;
+                }
+
+                if (index == null) {
+                    throw new RuntimeException("Cannot find object in parent object");
+                }
+            }
+        }
+
+        return new PathSegment(unindexedPathSegment.getNodeName(), unindexedPathSegment.getNodeId(), index);
+    }
+
+    /**
+     * Determine the unique path from the toplevel-RM object.
+     * <p>
+     * Adds index when necessary.
+     */
+    public static String getUniquePath(Pathable pathable) {
+        return PathUtil.getPath(getUniquePathSegments(pathable));
+    }
+}

--- a/path-queries/src/main/java/com/nedap/archie/query/RMObjectAttributes.java
+++ b/path-queries/src/main/java/com/nedap/archie/query/RMObjectAttributes.java
@@ -1,0 +1,34 @@
+package com.nedap.archie.query;
+
+import com.nedap.archie.rminfo.ModelInfoLookup;
+import com.nedap.archie.rminfo.RMAttributeInfo;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class RMObjectAttributes {
+    /**
+     * Get the value of an attribute of a RM object.
+     *
+     * @param object        RM object.
+     * @param attributeName The name of the attribute.
+     * @return The value of the attribute.
+     * @throws IllegalArgumentException When no attribute exists with the given attribute name.
+     */
+    public static Object getAttributeValueFromRMObject(Object object, String attributeName, ModelInfoLookup modelInfoLookup) {
+        Object result;
+
+        RMAttributeInfo attributeInfo = modelInfoLookup.getAttributeInfo(object.getClass(), attributeName);
+
+        if (attributeInfo == null) {
+            throw new IllegalArgumentException("Attribute does not exist in RM object");
+        }
+
+        try {
+            result = attributeInfo.getGetMethod().invoke(object);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+        return result;
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/query/RMObjectAttributesTest.java
+++ b/tools/src/test/java/com/nedap/archie/query/RMObjectAttributesTest.java
@@ -1,0 +1,69 @@
+package com.nedap.archie.query;
+
+import com.nedap.archie.ArchieLanguageConfiguration;
+import com.nedap.archie.adlparser.ADLParser;
+import com.nedap.archie.adlparser.modelconstraints.RMConstraintImposer;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.rm.archetyped.Pathable;
+import com.nedap.archie.rm.composition.Composition;
+import com.nedap.archie.rm.composition.EventContext;
+import com.nedap.archie.rm.datastructures.Cluster;
+import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datastructures.ItemStructure;
+import com.nedap.archie.rm.datavalues.DataValue;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.rminfo.ModelInfoLookup;
+import com.nedap.archie.testutil.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.nedap.archie.query.RMObjectAttributes.getAttributeValueFromRMObject;
+import static org.junit.Assert.assertSame;
+
+public class RMObjectAttributesTest {
+
+    private TestUtil testUtil;
+    private Archetype archetype;
+    private Pathable root;
+
+    @Before
+    public void setup() throws Exception {
+        ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("en");
+        archetype = new ADLParser(new RMConstraintImposer()).parse(getClass().getResourceAsStream("/basic.adl"));
+        testUtil = new TestUtil();
+    }
+
+    @Test
+    public void testGetAttributeValueFromRMObject() {
+        root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        Composition composition = (Composition) root;
+
+        ModelInfoLookup modelInfoLookup = ArchieRMInfoLookup.getInstance();
+
+        EventContext expectedContext = composition.getContext();
+        Object actualContext = getAttributeValueFromRMObject(composition, "context", modelInfoLookup);
+        assertSame(expectedContext, actualContext);
+
+        ItemStructure expectedOtherContext = expectedContext.getOtherContext();
+        Object actualOtherContext = getAttributeValueFromRMObject(actualContext, "other_context", modelInfoLookup);
+        assertSame(expectedOtherContext, actualOtherContext);
+
+        List expectedItems = expectedOtherContext.getItems();
+        Object actualItems = getAttributeValueFromRMObject(actualOtherContext, "items", modelInfoLookup);
+        assertSame(expectedItems, actualItems);
+
+        Cluster cluster = (Cluster) expectedItems.get(0);
+
+        List expectedClusterItems = cluster.getItems();
+        Object actualClusterItems = getAttributeValueFromRMObject(cluster, "items", modelInfoLookup);
+        assertSame(expectedClusterItems, actualClusterItems);
+
+        Element element = (Element) expectedClusterItems.get(1);
+
+        DataValue expectedValue = element.getValue();
+        Object actualValue = getAttributeValueFromRMObject(element, "value", modelInfoLookup);
+        assertSame(expectedValue,actualValue);
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/rmutil/PathableUtilTest.java
+++ b/tools/src/test/java/com/nedap/archie/rmutil/PathableUtilTest.java
@@ -1,0 +1,75 @@
+package com.nedap.archie.rmutil;
+
+import com.nedap.archie.ArchieLanguageConfiguration;
+import com.nedap.archie.adlparser.ADLParser;
+import com.nedap.archie.adlparser.modelconstraints.RMConstraintImposer;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.query.RMObjectWithPath;
+import com.nedap.archie.query.RMPathQuery;
+import com.nedap.archie.query.RMQueryContext;
+import com.nedap.archie.rm.archetyped.Pathable;
+import com.nedap.archie.rm.composition.Composition;
+import com.nedap.archie.rm.datastructures.Cluster;
+import com.nedap.archie.rm.datastructures.ItemTree;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.rminfo.ModelInfoLookup;
+import com.nedap.archie.testutil.TestUtil;
+import com.nedap.archie.xml.JAXBUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class PathableUtilTest {
+
+    private TestUtil testUtil;
+    private Archetype archetype;
+    private Pathable root;
+
+    @Before
+    public void setup() throws Exception {
+        ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("en");
+        archetype = new ADLParser(new RMConstraintImposer()).parse(getClass().getResourceAsStream("/basic.adl"));
+        testUtil = new TestUtil();
+    }
+
+    private RMQueryContext getQueryContext() {
+        return new RMQueryContext(ArchieRMInfoLookup.getInstance(), root, JAXBUtil.getArchieJAXBContext());
+    }
+
+    @Test
+    public void withSimplePaths() throws Exception {
+        root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        Composition composition = (Composition) root;
+
+        {
+            //add another cluster to the RM Object, with the same archetype id (very possible!)
+            Composition composition2 = (Composition) testUtil.constructEmptyRMObject(archetype.getDefinition());
+            Cluster secondCluster = (Cluster) composition2.getContext().getOtherContext().getItems().get(0);
+            ItemTree clusterList = (ItemTree) composition.getContext().getOtherContext();
+            clusterList.addItem(secondCluster);
+        }
+
+        RMQueryContext queryContext = getQueryContext();
+
+        ModelInfoLookup modelInfoLookup = ArchieRMInfoLookup.getInstance();
+
+        List<RMObjectWithPath> context = new RMPathQuery("/context").findList(modelInfoLookup, composition);
+        assertEquals(1, context.size());
+        assertEquals("/context", context.get(0).getPath());
+        assertEquals("/context",
+                PathableUtil.getUniquePath((Pathable) context.get(0).getObject()));
+
+        //now check that retrieving this retrieves more than one, even with the same ID.
+        List<RMObjectWithPath> items = queryContext.findListWithPaths("/context/other_context[id2]/items");
+        assertEquals(2, items.size());
+        assertEquals("/context/other_context[id2]/items[id3,1]", items.get(0).getPath());
+        assertEquals("/context/other_context[id2]/items[id3,1]",
+                PathableUtil.getUniquePath((Pathable) items.get(0).getObject()));
+        assertEquals("/context/other_context[id2]/items[id3,2]", items.get(1).getPath());
+        assertEquals("/context/other_context[id2]/items[id3,2]",
+                PathableUtil.getUniquePath((Pathable) items.get(1).getObject()));
+    }
+}

--- a/utils/src/main/java/com/nedap/archie/paths/PathUtil.java
+++ b/utils/src/main/java/com/nedap/archie/paths/PathUtil.java
@@ -23,7 +23,7 @@ public class PathUtil {
                 result.append("[");
                 result.append(segment.getNodeId());
                 if(segment.hasNumberIndex()) {
-                    result.append(", ");
+                    result.append(",");
                     result.append(segment.getIndex().toString());
                 }
                 result.append("]");


### PR DESCRIPTION
Create utility functions getUniquePath, getUniquePathSegments and getAttributeValueFromRMObject

These functions can be used to determine the unique path of an object, similar to the UniqueNodePathBuilder but without constructing a DOM.