### PR TITLE
Windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 sudo: false
 jdk:
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
 cache:
   directories:
     - $HOME/.gradle/wrapper

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
 cache:
   directories:
     - $HOME/.gradle/wrapper

--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
@@ -52,7 +52,7 @@ public class ADLParser {
     }
 
     public Archetype parse(InputStream stream) throws IOException {
-        return parse(CharStreams.fromStream(new BOMInputStream(stream)));
+        return parse(CharStreams.fromStream(new BOMInputStream(stream), Charset.availableCharsets().get("UTF-8")));
     }
 
     public Archetype parse(CharStream stream) {

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ repositories {
 }
 
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.3'
+wrapper {
+    gradleVersion = '4.10'
 }
 
 allprojects {
@@ -44,6 +44,9 @@ subprojects {
 
   sourceCompatibility = '1.8'
   targetCompatibility = '1.8'
+
+  compileJava.options.encoding = "UTF-8"
+  compileTestJava.options.encoding = "UTF-8"
 
   repositories {
       mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,12 @@ subprojects {
     }
     compile('commons-lang:commons-lang:2.6')
 
+    //java 10 no longer has these included by default, so explicit dependency is needed.
+    compile 'javax.xml.bind:jaxb-api:2.3.0'
+    compile 'com.sun.xml.bind:jaxb-core:2.3.0'
+    compile 'com.sun.xml.bind:jaxb-impl:2.3.0'
+    compile 'javax.activation:activation:1.1.1'
+
     testCompile 'junit:junit:4.12'
     testCompile 'org.slf4j:slf4j-simple:1.7.25'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ subprojects {
     //java 10 no longer has these included by default, so explicit dependency is needed.
     compile 'javax.xml.bind:jaxb-api:2.3.0'
     compile 'com.sun.xml.bind:jaxb-core:2.3.0'
-    compile 'com.sun.xml.bind:jaxb-impl:2.3.0'
+    runtime 'com.sun.xml.bind:jaxb-impl:2.3.0'
     compile 'javax.activation:activation:1.1.1'
 
     testCompile 'junit:junit:4.12'

--- a/grammars/build.gradle
+++ b/grammars/build.gradle
@@ -5,7 +5,7 @@ ext.antlrVersion = '4.7.1'
 
 generateGrammarSource { //antlr4
   outputDirectory = new File("${project.buildDir}/generated-src/antlr/main/com/nedap/archie/adlparser/antlr".toString())
-    arguments = ['-visitor', '-package', 'com.nedap.archie.adlparser.antlr'] + arguments
+    arguments = ['-visitor', '-package', 'com.nedap.archie.adlparser.antlr', '-encoding', 'utf-8'] + arguments
 }
 
 classes {

--- a/grammars/src/main/antlr/base_patterns.g4
+++ b/grammars/src/main/antlr/base_patterns.g4
@@ -49,12 +49,12 @@ fragment CARET_REGEXP_CHAR: ~[^\n\r] | ESCAPE_SEQ | '\\^';
 // ---------- whitespace & comments ----------
 
 SYM_TEMPLATE_OVERLAY : H_CMT_LINE (WS|LINE)* SYM_TEMPLATE_OVERLAY_ONLY;
-fragment H_CMT_LINE : '--------' '-'*? ('\r' ? '\n' | '\r')  ;  // special type of comment for splitting template overlays
+fragment H_CMT_LINE : '--------' '-'*? ('\n'|'\r''\n'|'\r')  ;  // special type of comment for splitting template overlays
 fragment SYM_TEMPLATE_OVERLAY_ONLY     : [Tt][Ee][Mm][Pp][Ll][Aa][Tt][Ee]'_'[Oo][Vv][Ee][Rr][Ll][Aa][Yy] ;
 
 WS         : [ \t\r]+    -> channel(HIDDEN) ;
-LINE       : ('\r' ? '\n' | '\r')        -> channel(HIDDEN) ;     // increment line count
-CMT_LINE   : '--' .*? '\n'  -> skip ;  // (increment line count)
+LINE       : '\n'        -> channel(HIDDEN) ;     // increment line count
+CMT_LINE   : '--' .*? ('\n'|'\r''\n'|'\r')  -> skip ;  // (increment line count)
 
 // ---------- ISO8601 Date/Time values ----------
 

--- a/grammars/src/main/antlr/base_patterns.g4
+++ b/grammars/src/main/antlr/base_patterns.g4
@@ -49,11 +49,11 @@ fragment CARET_REGEXP_CHAR: ~[^\n\r] | ESCAPE_SEQ | '\\^';
 // ---------- whitespace & comments ----------
 
 SYM_TEMPLATE_OVERLAY : H_CMT_LINE (WS|LINE)* SYM_TEMPLATE_OVERLAY_ONLY;
-fragment H_CMT_LINE : '--------' '-'*? '\n'  ;  // special type of comment for splitting template overlays
+fragment H_CMT_LINE : '--------' '-'*? ('\r' ? '\n' | '\r')  ;  // special type of comment for splitting template overlays
 fragment SYM_TEMPLATE_OVERLAY_ONLY     : [Tt][Ee][Mm][Pp][Ll][Aa][Tt][Ee]'_'[Oo][Vv][Ee][Rr][Ll][Aa][Yy] ;
 
 WS         : [ \t\r]+    -> channel(HIDDEN) ;
-LINE       : '\n'        -> channel(HIDDEN) ;     // increment line count
+LINE       : ('\r' ? '\n' | '\r')        -> channel(HIDDEN) ;     // increment line count
 CMT_LINE   : '--' .*? '\n'  -> skip ;  // (increment line count)
 
 // ---------- ISO8601 Date/Time values ----------


### PR DESCRIPTION
UTF-8 plus line endings problems fixed in java file encoding and antlr grammar files.

Explicit dependency on JAXB library plus implementation to fix building with JDK 10, since JAXB is no longer included by default.
