### PR TITLE
 Allow null_flavour to be set from rules without validation errors 

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
@@ -40,7 +40,7 @@ public class UpdatedValueHandler {
     private static Map<String, Object> fixCodePhrase(Object rmObject, Archetype archetype, String pathOfParent) {
         try {
             //special case: if at-code has been set, we need to do more!
-            if (pathOfParent.endsWith("value/defining_code")) {
+            if (pathOfParent.endsWith("value/defining_code") || pathOfParent.endsWith("null_flavour/defining_code")) {
                 return fixDvCodedText(rmObject, archetype, pathOfParent);
             } else if (pathOfParent.endsWith("symbol/defining_code")) {
                 return fixDvOrdinal(rmObject, archetype, pathOfParent);

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -49,7 +49,7 @@ public class FixableAssertionsCheckerTest {
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("There are four values that must be set", 5, evaluate.getSetPathValues().size());
+        assertEquals("There are seven values that must be set", 7, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
@@ -57,6 +57,8 @@ public class FixableAssertionsCheckerTest {
         assertEquals("Option 1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/value").getValue());
         assertEquals("at6", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string").getValue());
         assertEquals(0l, evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/value").getValue());
+        assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/code_string").getValue());
+        assertEquals("Option 1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/value").getValue());
 
         //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
         assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
@@ -64,10 +66,13 @@ public class FixableAssertionsCheckerTest {
         assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/value"));
         assertEquals("at6", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string"));
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
+        assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/code_string"));
+        assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/value"));
 
         //and of course the DV_ORDINAL and DV_CODED_TEXT should be constructed correctly, with the correct numeric respectively a textual value
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
         assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/value"));
+        assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/value"));
 
 
         evaluate = ruleEvaluation.evaluate(ruleEvaluation.getRMRoot(), archetype.getRules().getRules());

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/fixable_matches.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/fixable_matches.adls
@@ -31,33 +31,33 @@ definition
 							ITEM_TREE[id4] matches {
 								items cardinality matches {1..*; unordered} matches {
 									ELEMENT[id5] matches {
-									    value matches {
-                                            DV_TEXT[id64]
-                                        }
+										value matches {
+											DV_TEXT[id64]
+										}
 									}
 									ELEMENT[id6] matches {
-                                        value matches {
-                                            DV_CODED_TEXT[id54] matches {
-                                                defining_code matches {[ac1]}
-                                            }
+										value matches {
+											DV_CODED_TEXT[id54] matches {
+												defining_code matches {[ac1]}
+											}
 										}
 									}
 									ELEMENT[id7] matches {
-                                        value matches {
-                                            DV_ORDINAL[id75] matches {
-                                                [value, symbol] matches {
-                                                    [{0}, {[at6]}],
-                                                    [{1}, {[at7]}],
-                                                    [{2}, {[at8]}]
-                                                }
-                                            }
-                                        }
-                                    }
+										value matches {
+											DV_ORDINAL[id75] matches {
+												[value, symbol] matches {
+													[{0}, {[at6]}],
+													[{1}, {[at7]}],
+													[{2}, {[at8]}]
+												}
+											}
+										}
+									}
 									ELEMENT[id8] matches {
-                                        null_flavour matches {
-                                            DV_CODED_TEXT[id80] matches {
-                                                defining_code matches {[ac1]}
-                                            }
+										null_flavour matches {
+											DV_CODED_TEXT[id80] matches {
+												defining_code matches {[ac1]}
+											}
 										}
 									}
 								}
@@ -83,15 +83,15 @@ terminology
 				description = <"The local measurement of arterial blood pressure which is a surrogate for arterial. pressure in the systemic circulation.  Most commonly, use of the term 'blood pressure' refers to measurement of brachial artery pressure in the upper arm.">
 			>
 			["at1"] = <
-                text = <"Option 1">
-                description = <"Option 1">
-            >
+				text = <"Option 1">
+				description = <"Option 1">
+			>
 		>
-    >
-    value_sets = <
-        ["ac1"] = <
-            id = <"ac1">
-            members = <"at1", "at2", "at3">
-        >
-    >
+	>
+	value_sets = <
+		["ac1"] = <
+			id = <"ac1">
+			members = <"at1", "at2", "at3">
+		>
+	>
 

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/fixable_matches.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/fixable_matches.adls
@@ -53,6 +53,13 @@ definition
                                             }
                                         }
                                     }
+									ELEMENT[id8] matches {
+                                        null_flavour matches {
+                                            DV_CODED_TEXT[id80] matches {
+                                                defining_code matches {[ac1]}
+                                            }
+										}
+									}
 								}
 							}
 						}
@@ -66,6 +73,7 @@ rules
 	/data[id2]/events[id3]/data[id4]/items[id5]/value/value matches {"test string"}
 	/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code matches {[at1]}
 	/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol matches {[at6]}
+	/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code matches {[at1]}
 
 terminology
 	term_definitions = <


### PR DESCRIPTION
Allow null_flavour to be set from rules without raising validation errors, similar to normal DV_CODED_TEXT elements.

Also fixes some indentation errors.