### PR TITLE
Generate node ids that can be converted to ADL 1.4

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/Archetype.java
+++ b/aom/src/main/java/com/nedap/archie/aom/Archetype.java
@@ -298,15 +298,15 @@ public class Archetype extends AuthoredResource {
     }
 
     public String generateNextIdCode() {
-        return generateNextCode(AdlCodeDefinitions.ID_CODE_LEADER, getUsedIdCodes());
+        return generateNextCode(AdlCodeDefinitions.ID_CODE_LEADER, getAllUsedCodes());
     }
 
     public String generateNextValueCode() {
-        return generateNextCode(AdlCodeDefinitions.VALUE_CODE_LEADER, getUsedValueCodes());
+        return generateNextCode(AdlCodeDefinitions.VALUE_CODE_LEADER, getAllUsedCodes());
     }
 
     public String generateNextValueSetCode() {
-        return generateNextCode(AdlCodeDefinitions.VALUE_SET_CODE_LEADER, getUsedValueSetCodes());
+        return generateNextCode(AdlCodeDefinitions.VALUE_SET_CODE_LEADER, getAllUsedCodes());
 
     }
 

--- a/aom/src/test/java/com/nedap/archie/aom/ArchetypeTest.java
+++ b/aom/src/test/java/com/nedap/archie/aom/ArchetypeTest.java
@@ -16,14 +16,19 @@ public class ArchetypeTest {
     @Test
     public void testLevel0GenerateIdCode() {
         Archetype archetype = createLevel0Archetype();
+        //the generator will generate the same codes until their corresponding objects are added to the archetype
         assertEquals("id3", archetype.generateNextIdCode());
+        assertEquals("at3", archetype.generateNextValueCode());
+        assertEquals("ac3", archetype.generateNextValueSetCode());
     }
 
     @Test
     public void testLevel1GenerateIdCode() {
         Archetype archetype = createLevel1Archetype();
+        //the generator will generate the same codes until their corresponding objects are added to the archetype
         assertEquals("id0.3", archetype.generateNextIdCode());
-
+        assertEquals("at0.3", archetype.generateNextValueCode());
+        assertEquals("ac0.3", archetype.generateNextValueSetCode());
     }
 
     private Archetype createLevel0Archetype() {
@@ -55,4 +60,6 @@ public class ArchetypeTest {
         archetype.setDefinition(definition);
         return archetype;
     }
+
+
 }


### PR DESCRIPTION
ADL 1.4 files can always be ocnverted to ADL 2, even though archie has no support for that yet. However, if people want to convert ADL 2 archetypes to ADL 1.4, node ids can present a problem.

This is due to the fact that for ADL 1.4, the id codes are always in the format atxxxx, for value sets, values and node ids. 
In ADL 2, these are split in three separate idx, atx and acx ranges.

This problem can be prevented by making sure the node ids, value ids and value set ids (id, ac, and at-codes) are generated from a single sequence, so that if id1 exists, at1 and ac1 must not exist.

This PR changes the node id generator to never generate duplicate codes.