### PR TITLE
Enable jacoco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
+before_script:
+  - chmod +x gradlew
+script:
+  - ./gradlew check
+  - ./gradlew jacocoRootReport
 cache:
   directories:
     - $HOME/.gradle/wrapper
@@ -10,6 +15,4 @@ cache:
     - $HOME/.gradle/daemon
     - $HOME/.gradle/caches
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  - curl -o codacy.jar https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/2.0.0/codacy-coverage-reporter-2.0.0-assembly.jar
-  - java -cp codacy.jar com.codacy.CodacyCoverageReporter -l Java -r ./build/reports/jacoco/test/jacocoTestReport.xml
+  - curl -s https://codecov.io/bash | bash -s - -f ./build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml

--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ If you want to depend on just the AOM and BMM, without any reference model imple
 ## Build
 
 [![Build Status](https://travis-ci.org/openEHR/archie.svg?branch=master)](https://travis-ci.org/openEHR/archie)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/edf860e2c9a5478e99b3be63531fd7f3)](https://www.codacy.com/app/pieter-bos/archie_2?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=openEHR/archie&amp;utm_campaign=Badge_Grade)
-
-the following is from the old repository and not up to date, but gives an impression:
-[![Codecov Badge](https://img.shields.io/codecov/c/github/nedap/archie.svg)](https://codecov.io/gh/nedap/archie)
+[![codecov](https://codecov.io/gh/openEHR/archie/branch/master/graph/badge.svg)](https://codecov.io/gh/openEHR/archie)
 
 You need Java 8 to build. Check out the source and type:
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ buildscript {
     classpath 'ch.raffael.pegdown-doclet:pegdown-doclet:1.3'
     classpath 'org.owasp:dependency-check-gradle:1.4.5.1'
   }
+
+  
 }
 
 repositories {
@@ -23,6 +25,7 @@ allprojects {
   group = 'com.nedap.healthcare.archie'
   ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
   //archivesBaseName = 'archie'
+
 }
 
 gradle.ext.ossrhUsernameSafe = hasProperty('ossrhUsername') ? ossrhUsername : ""
@@ -35,7 +38,6 @@ subprojects {
   apply plugin: 'java'
   apply plugin: 'ch.raffael.pegdown-doclet'
   apply plugin: 'org.owasp.dependencycheck'
- // apply from: "${gradleScriptDir}/jacoco.gradle"  
   apply from: "${gradleScriptDir}/publish-maven.gradle"  
 
  // plugins {
@@ -110,6 +112,9 @@ subprojects {
   }
 
 }
+
+apply from: "${gradleScriptDir}/jacoco.gradle"  
+
 
 
 

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,6 +1,6 @@
 
-  
-def generatedSources = "**/nedap/archie/adlparser/antlr**"
+//the generated ANTLR sources plus the OpenEHR Test RM implementation do not need coverage
+def excludedPaths = ["**/nedap/archie/adlparser/antlr**", "**/nedap/archie/openehrtestrm/**"]
 
 allprojects {
   apply plugin: 'jacoco'
@@ -19,9 +19,6 @@ subprojects {
   }
 
   jacocoTestReport {
-     // doFirst {
-      //      classDirectories = fileTree(dir: "${buildDir}/classes/main/").exclude(generatedSources)
-     // }
       reports {
           xml.enabled = true
           html.enabled = true
@@ -31,10 +28,9 @@ subprojects {
       classDirectories =  files(sourceSets.main.output)
       afterEvaluate {
         classDirectories = files(classDirectories.files.collect {
-           fileTree(dir: it, exclude: generatedSources)
+           fileTree(dir: it, excludes: excludedPaths)
         })
       }
-      //do not check the generated source 
   }
 
   check.dependsOn jacocoTestReport
@@ -51,6 +47,10 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
         xml.enabled = true
         csv.enabled = false
     }
+
+    //The following is added because otherwise jacoco fails with packages without any test code
+    //as we have for example 'archie-all' that only combines the other projects in a single pom.xml, plus some 
+    //packages that are tested in the tools package, this is required
     onlyIf = {
         true
     }
@@ -59,10 +59,11 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
             it.exists()
         })
     }
+    //end of code needed for packages without tests
 
     afterEvaluate {
       classDirectories = files(classDirectories.files.collect {
-         fileTree(dir: it, exclude:  "**/nedap/archie/adlparser/antlr**")
+         fileTree(dir: it, excludes:  excludedPaths)
       })
     }
 }

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,28 +1,68 @@
-apply plugin: 'jacoco'
 
   
-def generatedSources = ["**/com/nedap/archie/adlparser/antlr**"]
+def generatedSources = "**/nedap/archie/adlparser/antlr**"
 
-test {
+allprojects {
+  apply plugin: 'jacoco'
+}
+
+subprojects {
   jacoco {
-    excludes = generatedSources
+    toolVersion = "0.8.2"  
   }
-   testLogging {
-      events "failed"
-      exceptionFormat "full"
+
+  test {
+     testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
   }
+
+  jacocoTestReport {
+     // doFirst {
+      //      classDirectories = fileTree(dir: "${buildDir}/classes/main/").exclude(generatedSources)
+     // }
+      reports {
+          xml.enabled = true
+          html.enabled = true
+      }
+      additionalSourceDirs = files(sourceSets.main.allSource.srcDirs)
+      sourceDirectories = files(sourceSets.main.allSource.srcDirs)
+      classDirectories =  files(sourceSets.main.output)
+      afterEvaluate {
+        classDirectories = files(classDirectories.files.collect {
+           fileTree(dir: it, exclude: generatedSources)
+        })
+      }
+      //do not check the generated source 
+  }
+
+  check.dependsOn jacocoTestReport
 }
 
-jacocoTestReport {
-    doFirst {
-          classDirectories = fileTree(dir: "${buildDir}/classes/main/").exclude(generatedSources)
-    }
+task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
+    dependsOn = subprojects.test
+    additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories =  files(subprojects.sourceSets.main.output)
+    executionData = files(subprojects.jacocoTestReport.executionData)
     reports {
-        xml.enabled = true
         html.enabled = true
+        xml.enabled = true
+        csv.enabled = false
     }
-    sourceSets sourceSets.main
-    //do not check the generated source 
-}
+    onlyIf = {
+        true
+    }
+    doFirst {
+        executionData = files(executionData.findAll {
+            it.exists()
+        })
+    }
 
-check.dependsOn jacocoTestReport
+    afterEvaluate {
+      classDirectories = files(classDirectories.files.collect {
+         fileTree(dir: it, exclude:  "**/nedap/archie/adlparser/antlr**")
+      })
+    }
+}


### PR DESCRIPTION
Jacoco and codecov.io working again. Generates a single test report that gets uploaded in xml form, to account for the fact that tests in different modules can cover other modules as well - especially the tests in the tools module.