### PR TITLE
set is_single/is_multiple correctly after flattening

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/utils/AOMUtils.java
+++ b/aom/src/main/java/com/nedap/archie/aom/utils/AOMUtils.java
@@ -282,9 +282,9 @@ public class AOMUtils {
     public static BmmProperty getPropertyAtPath(BmmModel bmmModel, String rmTypeName, String path) {
         if(!path.contains("/")) {
             BmmClass classDefinition = bmmModel.getClassDefinition(BmmDefinitions.typeNameToClassKey(rmTypeName));
-            return classDefinition.flattenBmmClass().getProperties().get(path);
-            //this is not a path
+            return classDefinition == null ? null : classDefinition.flattenBmmClass().getProperties().get(path);
         } else if (path.equals("/")) {
+            //this is not a path
             throw new IllegalArgumentException("cannot retrieve attribute information for path '/'");
         }
 

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModel.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModel.java
@@ -50,20 +50,12 @@ public class MetaModel implements MetaModelInterface {
     }
 
     @Override
-    public boolean isMultiple(String typeName, String attributeName) {
-        if(getSelectedBmmModel() != null) {
-            BmmClass classDefinition = getSelectedBmmModel().getClassDefinition(BmmDefinitions.typeNameToClassKey(typeName));
-            if (classDefinition != null) {
-                //TODO: don't flatten on request, create a flattened properties cache just like the eiffel code for much better performance
-                BmmClass flatClassDefinition = classDefinition.flattenBmmClass();
-                BmmProperty bmmProperty = flatClassDefinition.getProperties().get(attributeName);
-                return isMultiple(bmmProperty);
-            }
-        } else {
-            RMAttributeInfo attributeInfo = selectedModel.getAttributeInfo(typeName, attributeName);
-            return attributeInfo != null && attributeInfo.isMultipleValued();
+    public boolean isMultiple(String typeName, String attributeNameOrPath) {
+        MultiplicityInterval multiplicityInterval = referenceModelPropMultiplicity(typeName, attributeNameOrPath);
+        if(multiplicityInterval == null) {
+            return false;// by default, false if unknown property
         }
-        return false;
+        return multiplicityInterval.isUpperUnbounded() || multiplicityInterval.getUpper() > 1;
     }
 
     private boolean isMultiple(BmmProperty bmmProperty) {

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModelInterface.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModelInterface.java
@@ -4,7 +4,11 @@ import com.nedap.archie.aom.CPrimitiveObject;
 import com.nedap.archie.base.MultiplicityInterval;
 
 public interface MetaModelInterface {
-    boolean isMultiple(String typeName, String attributeName);
+    /**
+     * determine if a property on a type is multiple or not. If the property cannot be found, returns false.
+     * Works both on properties on a type, or on path based lookup.
+     */
+    boolean isMultiple(String typeName, String rmAttributeNameOrPath);
 
     boolean rmTypesConformant(String childTypeName, String parentTypeName);
 

--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.flattener;
 
+import com.nedap.archie.adlparser.modelconstraints.ReflectionConstraintImposer;
 import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.utils.ArchetypeParsePostProcesser;
 
@@ -104,7 +105,7 @@ public class Flattener implements IAttributeFlattenerSupport {
         }
 
         metaModels.selectModel(toFlatten);
-       // new ReflectionConstraintImposer(lookup).setSingleOrMultiple(toFlatten.getDefinition());
+        
         //validate that we can legally flatten first
         String parentId = toFlatten.getParentArchetypeId();
         if(parentId == null) {
@@ -213,6 +214,11 @@ public class Flattener implements IAttributeFlattenerSupport {
         result.setGenerated(true);
 
         ArchetypeParsePostProcesser.fixArchetype(result);
+
+        //set the single/multiple attributes correctly
+        new ReflectionConstraintImposer(metaModels.getSelectedModel())
+                .setSingleOrMultiple(result.getDefinition());
+
         return result;
     }
 

--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -105,7 +105,7 @@ public class Flattener implements IAttributeFlattenerSupport {
         }
 
         metaModels.selectModel(toFlatten);
-        
+
         //validate that we can legally flatten first
         String parentId = toFlatten.getParentArchetypeId();
         if(parentId == null) {

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -46,7 +46,7 @@ public class ArchetypeValidatorTest {
         ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);
         List<ValidationMessage> messages = validationResult.getErrors();
         System.out.println(messages);
-        assertEquals(1, messages.size());
+        assertEquals(messages.toString(), 1, messages.size());
         assertEquals(ErrorType.VCARM, messages.get(0).getType());
         assertNull(validationResult.getFlattened());
     }


### PR DESCRIPTION
Set is_single/is_multiple correctly after flattening, so that at least operational templates have this always set correctly.

Also fix setting single/multiple for differential path based attributes.