### PR TITLE
Model fixes to 0 5

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/AuthoredResource.java
+++ b/aom/src/main/java/com/nedap/archie/aom/AuthoredResource.java
@@ -6,6 +6,7 @@ import com.nedap.archie.base.terminology.TerminologyCode;
 import com.nedap.archie.xml.adapters.ResourceDescriptionAdapter;
 import com.nedap.archie.xml.adapters.TranslationDetailsAdapter;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -32,8 +33,10 @@ import java.util.Map;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public abstract class AuthoredResource extends ArchetypeModelObject {
 
+    @Nullable
     private Boolean controlled;
     private String uid;
+    @Nullable
     private ResourceDescription description;
 
     private LanguageSection content = new LanguageSection();

--- a/aom/src/main/java/com/nedap/archie/rminfo/RMAttributeInfo.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/RMAttributeInfo.java
@@ -29,9 +29,14 @@ public class RMAttributeInfo {
         this.setMethod = setMethod;
         this.addMethod = addMethod;
         this.computed = this.setMethod == null && this.addMethod == null;
-        this.isMultipleValued = type instanceof Class && Collection.class.isAssignableFrom(type);
-        this.typeInCollection = typeInCollection;
-        this.typeNameInCollection = typeNameInCollection;
+        this.isMultipleValued = (type instanceof Class && Collection.class.isAssignableFrom(type)) || type.isArray();
+        if(type.isArray()) {
+            this.typeInCollection = type.getComponentType();
+            this.typeNameInCollection = this.typeInCollection.getSimpleName();
+        } else {
+            this.typeInCollection = typeInCollection;
+            this.typeNameInCollection = typeNameInCollection;
+        }
     }
 
     public String getRmName() {

--- a/aom/src/main/java/com/nedap/archie/rminfo/ReflectionModelInfoLookup.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/ReflectionModelInfoLookup.java
@@ -167,7 +167,7 @@ public abstract class ReflectionModelInfoLookup implements ModelInfoLookup {
         return Modifier.isPublic(method.getModifiers());
     }
 
-    private void addRMAttributeInfo(Class clazz, RMTypeInfo typeInfo, TypeToken typeToken, Method getMethod, Map<String, Field> fieldsByName) {
+    protected void addRMAttributeInfo(Class clazz, RMTypeInfo typeInfo, TypeToken typeToken, Method getMethod, Map<String, Field> fieldsByName) {
         String attributeName = namingStrategy.getAttributeName(getMethod);
         String javaFieldName = null;
         if(getMethod.getName().startsWith("is")) {
@@ -189,6 +189,7 @@ public abstract class ReflectionModelInfoLookup implements ModelInfoLookup {
             logger.debug("No get method found for attribute {} on class {}", attributeName, clazz.getSimpleName());
         }
 
+
         TypeToken fieldType = typeToken.resolveType(getMethod.getGenericReturnType());;
 
         Class rawFieldType = fieldType.getRawType();
@@ -200,7 +201,7 @@ public abstract class ReflectionModelInfoLookup implements ModelInfoLookup {
                     rawFieldType,
                     typeInCollection,
                     this.namingStrategy.getTypeName(typeInCollection),
-                    (field != null && field.getAnnotation(Nullable.class) != null) || getMethod.getAnnotation(Nullable.class) != null,
+                    isNullable(clazz, getMethod, field),
                     getMethod,
                     setMethod,
                     addMethod
@@ -211,6 +212,10 @@ public abstract class ReflectionModelInfoLookup implements ModelInfoLookup {
         //} else {
         //    logger.info("property without a set method ignored for field {} on class {}", attributeName, clazz.getSimpleName());
        // }
+    }
+
+    protected boolean isNullable(Class clazz, Method getMethod, Field field) {
+        return (field != null && field.getAnnotation(Nullable.class) != null) || getMethod.getAnnotation(Nullable.class) != null;
     }
 
 
@@ -230,6 +235,26 @@ public abstract class ReflectionModelInfoLookup implements ModelInfoLookup {
             logger.debug("No get method found for field {} on class {}", field.getName(), clazz.getSimpleName());
         }
 
+        if(attributeName.startsWith("is")) {
+            //special case
+            String fieldNameWithoutPrefix = javaFieldName.substring(2);
+            String withoutPrefixUpperCased = upperCaseFirstChar(fieldNameWithoutPrefix);
+            if (getMethod == null) {
+                getMethod = getMethod(clazz, "is" + withoutPrefixUpperCased);
+            }
+            if (getMethod != null) {
+                if(setMethod == null) {
+                    setMethod = getMethod(clazz, "set" + withoutPrefixUpperCased, getMethod.getReturnType());
+                }
+                if(addMethod == null) {
+                    addMethod = getAddMethod(clazz, typeToken, attributeName, withoutPrefixUpperCased, getMethod);
+                }
+            } else {
+                logger.debug("No get method found for attribute {} on class {}", attributeName, clazz.getSimpleName());
+            }
+
+        }
+
         TypeToken fieldType = null;
         if (getMethod != null) {
             fieldType = typeToken.resolveType(getMethod.getGenericReturnType());
@@ -246,7 +271,7 @@ public abstract class ReflectionModelInfoLookup implements ModelInfoLookup {
                     rawFieldType,
                     typeInCollection,
                     namingStrategy.getTypeName(typeInCollection),
-                    field.getAnnotation(Nullable.class) != null,
+                    isNullable(clazz, getMethod, field),
                     getMethod,
                     setMethod,
                     addMethod

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/Activity.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/Activity.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 public class Activity extends Locatable {
 
     private ItemStructure description;
+    @Nullable
     private DvParsable timing;
     @Nullable
     @XmlElement(name = "action_archetype_id", required = true)

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/IsmTransition.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/IsmTransition.java
@@ -4,6 +4,7 @@ import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rm.datavalues.DvText;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -25,11 +26,14 @@ public class IsmTransition extends Pathable {
 
     @XmlElement(name = "current_state")
     private DvCodedText currentState;
+    @Nullable
     private DvCodedText transition;
 
     @XmlElement(name = "careflow_step")
+    @Nullable
     private DvCodedText careflowStep;
 
+    @Nullable
     private List<DvText> reason = new ArrayList();
     
     public DvCodedText getCurrentState() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Archetyped.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Archetyped.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rm.archetyped;
 
 import com.nedap.archie.aom.ArchetypeHRID;
+import com.nedap.archie.rm.RMObject;
 import com.nedap.archie.rm.support.identification.ArchetypeID;
 
 import javax.annotation.Nullable;
@@ -20,7 +21,7 @@ import javax.xml.bind.annotation.XmlType;
         "templateId",
         "rmVersion"
 })
-public class Archetyped {
+public class Archetyped extends RMObject {
 
     @XmlElement(name="archetype_id")
     private ArchetypeID archetypeId; //TODO: this is a different class in the RM. why?!

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Link.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Link.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.rm.archetyped;
 
+import com.nedap.archie.rm.RMObject;
 import com.nedap.archie.rm.datavalues.DvEHRURI;
 import com.nedap.archie.rm.datavalues.DvText;
 
@@ -12,7 +13,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "LINK")
-public class Link {
+public class Link extends RMObject {
 
     private DvText meaning;
     private DvText type;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/ImportedVersion.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/ImportedVersion.java
@@ -39,4 +39,8 @@ public class ImportedVersion extends Version {
     public boolean isBranch() {
         return item == null ? null : item.isBranch();//TODO: this is probably not right
     }
+
+    public OriginalVersion getItem() {
+        return item;
+    }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/OriginalVersion.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/OriginalVersion.java
@@ -2,7 +2,6 @@ package com.nedap.archie.rm.changecontrol;
 
 import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rm.generic.Attestation;
-import com.nedap.archie.rm.support.identification.HierObjectId;
 import com.nedap.archie.rm.support.identification.ObjectVersionId;
 
 
@@ -16,12 +15,15 @@ import java.util.List;
 public class OriginalVersion<Type> extends Version<Type> {
 
     private ObjectVersionId uid;
+    @Nullable
     private ObjectVersionId precedingVersionUid;
     @Nullable
-    private List<ObjectVersionId> otherInputVersionIds = new ArrayList<>();
+    private List<ObjectVersionId> otherInputVersionUids = new ArrayList<>();
 
     private DvCodedText lifecycleState;
+    @Nullable
     private List<Attestation> attestations = new ArrayList<>();
+    @Nullable
     private Type data;
 
 
@@ -44,12 +46,12 @@ public class OriginalVersion<Type> extends Version<Type> {
     }
 
     @Nullable
-    public List<ObjectVersionId> getOtherInputVersionIds() {
-        return otherInputVersionIds;
+    public List<ObjectVersionId> getOtherInputVersionUids() {
+        return otherInputVersionUids;
     }
 
-    public void setOtherInputVersionIds(@Nullable List<ObjectVersionId> otherInputVersionIds) {
-        this.otherInputVersionIds = otherInputVersionIds;
+    public void setOtherInputVersionUids(@Nullable List<ObjectVersionId> otherInputVersionUids) {
+        this.otherInputVersionUids = otherInputVersionUids;
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/OriginalVersion.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/OriginalVersion.java
@@ -18,7 +18,7 @@ public class OriginalVersion<Type> extends Version<Type> {
     @Nullable
     private ObjectVersionId precedingVersionUid;
     @Nullable
-    private List<ObjectVersionId> otherInputVersionUids = new ArrayList<>();
+    private List<ObjectVersionId> otherInputVersionIds = new ArrayList<>();
 
     private DvCodedText lifecycleState;
     @Nullable
@@ -46,12 +46,12 @@ public class OriginalVersion<Type> extends Version<Type> {
     }
 
     @Nullable
-    public List<ObjectVersionId> getOtherInputVersionUids() {
-        return otherInputVersionUids;
+    public List<ObjectVersionId> getOtherInputVersionIds() {
+        return otherInputVersionIds;
     }
 
-    public void setOtherInputVersionUids(@Nullable List<ObjectVersionId> otherInputVersionUids) {
-        this.otherInputVersionUids = otherInputVersionUids;
+    public void setOtherInputVersionIds(@Nullable List<ObjectVersionId> otherInputVersionIds) {
+        this.otherInputVersionIds = otherInputVersionIds;
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/Version.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/Version.java
@@ -6,6 +6,8 @@ import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rm.generic.AuditDetails;
 import com.nedap.archie.rm.support.identification.ObjectVersionId;
 
+import javax.annotation.Nullable;
+
 /**
  * Version class. You will need to create a subclass to make this work.
  *
@@ -13,6 +15,7 @@ import com.nedap.archie.rm.support.identification.ObjectVersionId;
  */
 public abstract class Version<Type> extends RMObject {
     private ObjectRef contribution;
+    @Nullable
     private String signature;
     private AuditDetails commitAudit;
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/VersionedObject.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/VersionedObject.java
@@ -42,11 +42,11 @@ public class VersionedObject<Type> extends RMObject {
         this.ownerId = ownerId;
     }
 
-    public DvDateTime getTimeCreations() {
+    public DvDateTime getTimeCreated() {
         return timeCreated;
     }
 
-    public void setTimeCreations(DvDateTime timeCreated) {
+    public void setTimeCreated(DvDateTime timeCreated) {
         this.timeCreated = timeCreated;
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Action.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Action.java
@@ -4,6 +4,7 @@ import com.nedap.archie.rm.IsmTransition;
 import com.nedap.archie.rm.datastructures.ItemStructure;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDateTime;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -28,6 +29,7 @@ public class Action extends CareEntry {
     @XmlElement(name="ism_transition")
     private IsmTransition ismTransition;
     @XmlElement(name="instruction_details")
+    @Nullable
     private InstructionDetails instructionDetails;
 
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Composition.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Composition.java
@@ -40,6 +40,7 @@ public class Composition extends Locatable {
     @Nullable
     private EventContext context;
 
+    @Nullable
     private List<ContentItem> content = new ArrayList<>();
 
     @JsonProperty

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Entry.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Entry.java
@@ -23,7 +23,7 @@ import java.util.List;
         "subject",
         "provider",
         "otherParticipations",
-        "workFlowId"
+        "workflowId"
 })
 public abstract class Entry extends ContentItem {
 
@@ -31,8 +31,8 @@ public abstract class Entry extends ContentItem {
     private CodePhrase encoding;
     @Nullable
 
-    @XmlElement(name = "work_flow_id")
-    private ObjectRef workFlowId;
+    @XmlElement(name = "workflow_id")
+    private ObjectRef workflowId;
     private PartyProxy subject;
     @Nullable
     private PartyProxy provider;
@@ -87,11 +87,11 @@ public abstract class Entry extends ContentItem {
     }
 
     @Nullable    
-    public ObjectRef getWorkFlowId() {
-        return workFlowId;
+    public ObjectRef getWorkflowId() {
+        return workflowId;
     }
 
-    public void setWorkFlowId(@Nullable ObjectRef workFlowId) {
-        this.workFlowId = workFlowId;
+    public void setWorkflowId(@Nullable ObjectRef workflowId) {
+        this.workflowId = workflowId;
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Entry.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Entry.java
@@ -23,7 +23,7 @@ import java.util.List;
         "subject",
         "provider",
         "otherParticipations",
-        "workflowId"
+        "workFlowId"
 })
 public abstract class Entry extends ContentItem {
 
@@ -31,8 +31,8 @@ public abstract class Entry extends ContentItem {
     private CodePhrase encoding;
     @Nullable
 
-    @XmlElement(name = "workflow_id")
-    private ObjectRef workflowId;
+    @XmlElement(name = "work_flow_id")
+    private ObjectRef workFlowId;
     private PartyProxy subject;
     @Nullable
     private PartyProxy provider;
@@ -87,11 +87,11 @@ public abstract class Entry extends ContentItem {
     }
 
     @Nullable    
-    public ObjectRef getWorkflowId() {
-        return workflowId;
+    public ObjectRef getWorkFlowId() {
+        return workFlowId;
     }
 
-    public void setWorkflowId(@Nullable ObjectRef workflowId) {
-        this.workflowId = workflowId;
+    public void setWorkFlowId(@Nullable ObjectRef workFlowId) {
+        this.workFlowId = workFlowId;
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/EventContext.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/EventContext.java
@@ -46,6 +46,7 @@ public class EventContext extends Pathable {
     @XmlElement(name="health_care_facility")
     private PartyIdentified healthCareFacility;
 
+    @Nullable
     private List<Participation> participations = new ArrayList<>();
 
     public DvDateTime getStartTime() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Instruction.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Instruction.java
@@ -33,6 +33,7 @@ public class Instruction extends CareEntry {
     @Nullable
     @XmlElement(name = "wf_definition")
     private DvParsable wfDefinition;
+    @Nullable
     private List<Activity> activities = new ArrayList<>();
 
     public DvText getNarrative() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/History.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/History.java
@@ -32,6 +32,7 @@ public final class History<Type extends ItemStructure> extends DataStructure {
     @Nullable
     private Type summary;
 
+    @Nullable
     private List<Event<Type>> events = new ArrayList<>();
 
     public DvDateTime getOrigin() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
@@ -15,20 +15,20 @@ import java.util.List;
 @XmlType(name = "ITEM_SINGLE", propOrder = {
         "item"
 })
-public class ItemSingle extends ItemStructure<Item> {
+public class ItemSingle extends ItemStructure<Element> {
 
-    private Item item;
+    private Element item;
 
-    public Item getItem() {
+    public Element getItem() {
         return item;
     }
 
-    public void setITem(Item item) {
+    public void setITem(Element item) {
         this.item = item;
     }
 
     @Override
-    public List<Item> getItems() {
+    public List<Element> getItems() {
         return Lists.newArrayList(item);
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
@@ -23,7 +23,7 @@ public class ItemSingle extends ItemStructure<Element> {
         return item;
     }
 
-    public void setITem(Element item) {
+    public void setItem(Element item) {
         this.item = item;
     }
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvIdentifier.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvIdentifier.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.rm.datavalues;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
@@ -16,9 +17,12 @@ import javax.xml.bind.annotation.XmlType;
 })
 public class DvIdentifier extends DataValue {
 
+    @Nullable
     private String issuer;
+    @Nullable
     private String assigner;
     private String id;
+    @Nullable
     private String type;
 
     public String getIssuer() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvState.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvState.java
@@ -11,7 +11,7 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DV_STATE", propOrder = {
         "value",
-        "terminal"
+        "isTerminal"
 })
 public class DvState extends DataValue implements SingleValuedDataValue<DvCodedText> {
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvState.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvState.java
@@ -16,15 +16,15 @@ import javax.xml.bind.annotation.XmlType;
 public class DvState extends DataValue implements SingleValuedDataValue<DvCodedText> {
 
     @XmlElement(name = "is_terminal")
-    private boolean terminal;
+    private boolean isTerminal;
     private DvCodedText value;
     
     public boolean isTerminal() {
-        return terminal;
+        return isTerminal;
     }
 
     public void setTerminal(boolean terminal) {
-        this.terminal = terminal;
+        this.isTerminal = terminal;
     }
 
     public DvCodedText getValue() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvEncapsulated.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvEncapsulated.java
@@ -3,6 +3,7 @@ package com.nedap.archie.rm.datavalues.encapsulated;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DataValue;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
@@ -16,7 +17,9 @@ import javax.xml.bind.annotation.XmlType;
         "language"
 })
 public abstract class DvEncapsulated extends DataValue {
+    @Nullable
     private CodePhrase charset;
+    @Nullable
     private CodePhrase language;
 
     public CodePhrase getCharset() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvMultimedia.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvMultimedia.java
@@ -50,7 +50,6 @@ public class DvMultimedia extends DvEncapsulated {
     @Nullable
     private DvMultimedia thumbnail;
 
-    @Nullable
     
     public String getAlternateText() {
         return alternateText;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rm.datavalues.quantity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DvCodedText;
 
 import javax.annotation.Nullable;
@@ -35,7 +36,7 @@ public class DvQuantity extends DvAmount<Double> {
     @Deprecated
     @JsonIgnore
     @Nullable
-    private transient DvCodedText property;
+    private transient CodePhrase property;
 
     @Nullable
     public Long getPrecision() {
@@ -64,12 +65,12 @@ public class DvQuantity extends DvAmount<Double> {
     }
 
     @Deprecated
-    public DvCodedText getProperty() {
+    public CodePhrase getProperty() {
         return property;
     }
 
     @Deprecated
-    public void setProperty(DvCodedText property) {
+    public void setProperty(CodePhrase property) {
         this.property = property;
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
@@ -36,7 +36,7 @@ public class DvQuantity extends DvAmount<Double> {
     @Deprecated
     @JsonIgnore
     @Nullable
-    private transient CodePhrase property;
+    private transient DvCodedText property;
 
     @Nullable
     public Long getPrecision() {
@@ -65,12 +65,12 @@ public class DvQuantity extends DvAmount<Double> {
     }
 
     @Deprecated
-    public CodePhrase getProperty() {
+    public DvCodedText getProperty() {
         return property;
     }
 
     @Deprecated
-    public void setProperty(CodePhrase property) {
+    public void setProperty(DvCodedText property) {
         this.property = property;
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/Actor.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/Actor.java
@@ -3,6 +3,7 @@ package com.nedap.archie.rm.demographic;
 import com.nedap.archie.rm.support.identification.PartyRef;
 import com.nedap.archie.rm.datavalues.DvText;
 
+import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
@@ -16,7 +17,9 @@ import java.util.List;
 @XmlType(name="ACTOR")
 public abstract class Actor extends Party {
 
+    @Nullable
     private List<DvText> languages = new ArrayList<>();
+    @Nullable
     private List<PartyRef> roles = new ArrayList();
 
     public List<DvText> getLanguages() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/Contact.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/Contact.java
@@ -20,6 +20,7 @@ import java.util.List;
 @XmlType(name="CONTACT")
 public class Contact extends Locatable {
 
+    @Nullable
     private List<Address> addresses = new ArrayList<>();
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/Party.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/Party.java
@@ -2,6 +2,7 @@ package com.nedap.archie.rm.demographic;
 
 import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rm.datastructures.ItemStructure;
+import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.support.identification.LocatableRef;
 
 import javax.annotation.Nullable;
@@ -94,5 +95,12 @@ public abstract class Party extends Locatable {
     public void addRelationship(PartyRelationship relationship) {
         this.relationships.add(relationship);
         this.setThisAsParent(relationship, "relationships");
+    }
+
+    /**
+     * Type of party, such as PERSON, ORGANISATION, etc. Role name, e.g. general practitioner , nurse , private citizen . Taken from inherited name attribute.
+     */
+    public DvText getType() {
+        return getName();
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/Ehr.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/Ehr.java
@@ -27,7 +27,6 @@ public class Ehr extends RMObject {
     private HierObjectId systemId;
     private HierObjectId ehrId;
 
-    @Nullable
     private List<ObjectRef> contributions = new ArrayList<>();
     private ObjectRef ehrStatus;
     private ObjectRef ehrAccess;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/AuditDetails.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/AuditDetails.java
@@ -20,7 +20,7 @@ public class AuditDetails extends RMObject {
 
     private String systemId;
     @XmlElement(name="time_committed")
-    private DvDateTime timeCommited;
+    private DvDateTime timeCommitted;
     private DvCodedText changeType;
     @Nullable
     private DvText description;
@@ -34,12 +34,12 @@ public class AuditDetails extends RMObject {
         this.systemId = systemId;
     }
 
-    public DvDateTime getTimeCommited() {
-        return timeCommited;
+    public DvDateTime getTimeCommitted() {
+        return timeCommitted;
     }
 
-    public void setTimeCommited(DvDateTime timeCommited) {
-        this.timeCommited = timeCommited;
+    public void setTimeCommitted(DvDateTime timeCommitted) {
+        this.timeCommitted = timeCommitted;
     }
 
     public DvCodedText getChangeType() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/AuditDetails.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/AuditDetails.java
@@ -20,7 +20,7 @@ public class AuditDetails extends RMObject {
 
     private String systemId;
     @XmlElement(name="time_committed")
-    private DvDateTime timeCommitted;
+    private DvDateTime timeCommited;
     private DvCodedText changeType;
     @Nullable
     private DvText description;
@@ -34,12 +34,12 @@ public class AuditDetails extends RMObject {
         this.systemId = systemId;
     }
 
-    public DvDateTime getTimeCommitted() {
-        return timeCommitted;
+    public DvDateTime getTimeCommited() {
+        return timeCommited;
     }
 
-    public void setTimeCommitted(DvDateTime timeCommitted) {
-        this.timeCommitted = timeCommitted;
+    public void setTimeCommited(DvDateTime timeCommited) {
+        this.timeCommited = timeCommited;
     }
 
     public DvCodedText getChangeType() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
@@ -12,24 +12,47 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(name = "UID_BASED_ID")
 public abstract class UIDBasedId extends ObjectId {
 
-    private UID root;
-    @Nullable
-    private String extension;
+    public static final String UUID_REGEXP = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
 
     public UID getRoot() {
-        return root;
-    }
-
-    public void setRoot(UID root) {
-        this.root = root;
+        String value = getValue();
+        if(value == null) {
+            return null;
+        }
+        int index = value.indexOf("::");
+        String resultString = null;
+        if(index < 0) {
+            resultString = value;
+        } else {
+            resultString = value.substring(index);
+        }
+        if(resultString.matches(UUID_REGEXP)) {
+            UID result = new UUID();
+            result.setValue(resultString);
+            return result;
+        } else if (resultString.matches("([0-9]\\.?)+")) {
+            IsoOID result = new IsoOID();
+            result.setValue(resultString);
+            return result;
+        } else {
+            InternetId result = new InternetId();
+            result.setValue(resultString);
+            return result;
+        }
     }
 
     @Nullable
     public String getExtension() {
-        return extension;
+        String value = getValue();
+        if(value == null) {
+            return null;
+        }
+        int index = value.indexOf("::");
+        if(index < 0) {
+            return "";
+        } else {
+            return value.substring(index + 2);
+        }
     }
 
-    public void setExtension(@Nullable String extension) {
-        this.extension = extension;
-    }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -1,8 +1,11 @@
 package com.nedap.archie.rminfo;
 
 import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.ArchetypeHRID;
+import com.nedap.archie.aom.AuthoredResource;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.aom.CPrimitiveObject;
+import com.nedap.archie.aom.TranslationDetails;
 import com.nedap.archie.aom.primitives.*;
 
 import com.nedap.archie.base.Interval;
@@ -29,6 +32,8 @@ import com.nedap.archie.rm.security.*;
 import com.nedap.archie.rm.support.identification.*;
 import com.nedap.archie.rm.support.*;
 
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
@@ -169,6 +174,25 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
         addClass(Section.class);
         addClass(Activity.class);
         addClass(TerminologyId.class);
+        addClass(Link.class);
+        addClass(Archetyped.class);
+        addClass(ArchetypeHRID.class);
+        addClass(AuthoredResource.class);
+        addClass(TranslationDetails.class);
+    }
+
+    @Override
+    protected boolean isNullable(Class clazz, Method getMethod, Field field) {
+        if(field != null) {
+            if (Party.class.isAssignableFrom(clazz) && field.getName().equalsIgnoreCase("uid")) {
+                return false;
+            }
+        } else if (getMethod != null) {
+            if (Party.class.isAssignableFrom(clazz) && getMethod.getName().equalsIgnoreCase("getUid")) {
+                return false;
+            }
+        }
+        return (field != null && field.getAnnotation(Nullable.class) != null) || getMethod.getAnnotation(Nullable.class) != null;
     }
 
     public static ArchieRMInfoLookup getInstance() {

--- a/referencemodels/src/main/resources/bmm/openEHR/Proposed/BMM/openehr_rm_demographic_104.bmm
+++ b/referencemodels/src/main/resources/bmm/openEHR/Proposed/BMM/openehr_rm_demographic_104.bmm
@@ -77,6 +77,7 @@ class_definitions = <
 					type = <"PARTY_IDENTITY">
 				>
 				cardinality = <|>=1|>
+				is_mandatory = <True>
 			>
 			["contacts"] = (P_BMM_CONTAINER_PROPERTY) <
 				name = <"contacts">


### PR DESCRIPTION
Backport of model fixes in #69 to the 0.5-branch, so that people can enjoy a more correctly functioning 1.0.4 RM without having to wait for version 0.6, and implement the breaking changes needed to use 0.6.

Some fixes that are backwards incompatible due to field renames might be excluded from this PR and pushed to 0.6.

- [x] check and remove any backwards-incompatible fixes