### PR TITLE
Fix error with ODIN null serialization, and null description in the A…

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/ResourceDescription.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ResourceDescription.java
@@ -1,6 +1,8 @@
 package com.nedap.archie.aom;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.nedap.archie.base.terminology.TerminologyCode;
+import org.openehr.odin.jackson.serializers.TermCodeAsStringConverter;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/aom/src/main/java/com/nedap/archie/aom/ResourceDescription.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ResourceDescription.java
@@ -1,8 +1,6 @@
 package com.nedap.archie.aom;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.nedap.archie.base.terminology.TerminologyCode;
-import org.openehr.odin.jackson.serializers.TermCodeAsStringConverter;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/jackson/ArchetypeODINMapperFactory.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/jackson/ArchetypeODINMapperFactory.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.serializer.adl.jackson;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.nedap.archie.aom.ResourceDescription;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import org.openehr.odin.jackson.ODINMapper;
@@ -12,6 +13,7 @@ public class ArchetypeODINMapperFactory {
         SimpleModule module = new SimpleModule();
         module.addSerializer(ArchetypeTerm.class, new ArchetypeTermOdinSerializer());
         module.setMixInAnnotation(ArchetypeTerminology.class, ArchetypeTerminologyMixin.class);
+        module.setMixInAnnotation(ResourceDescription.class, ResourceDescriptionMixin.class);
         result.disableDefaultTyping();//no typing info for archetype ODIN needed
         result.registerModule(module);
         return result;

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/jackson/ArchetypeTermOdinSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/jackson/ArchetypeTermOdinSerializer.java
@@ -17,8 +17,10 @@ public class ArchetypeTermOdinSerializer extends JsonSerializer<ArchetypeTerm> {
             gen.writeStartObject();
             gen.writeFieldName("text");
             gen.writeString(value.getText());
-            gen.writeFieldName("description");
-            gen.writeString(value.getDescription());
+            if(value.getDescription() != null) {
+                gen.writeFieldName("description");
+                gen.writeString(value.getDescription());
+            }
             gen.writeEndObject();
     }
 

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/jackson/ResourceDescriptionMixin.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/jackson/ResourceDescriptionMixin.java
@@ -1,0 +1,11 @@
+package com.nedap.archie.serializer.adl.jackson;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.nedap.archie.base.terminology.TerminologyCode;
+import org.openehr.odin.jackson.serializers.TermCodeAsStringConverter;
+
+public class ResourceDescriptionMixin {
+
+    @JsonSerialize(converter = TermCodeAsStringConverter.class)
+    private TerminologyCode lifecycleState;
+}

--- a/odin/src/main/java/org/openehr/odin/jackson/ODINGenerator.java
+++ b/odin/src/main/java/org/openehr/odin/jackson/ODINGenerator.java
@@ -622,10 +622,10 @@ public class ODINGenerator extends GeneratorBase
     {
         _verifyValueWrite("write null value");
         //TODO! no null support in ODIN. Just don't serialize the field
-        writeStartObject();
+        writeFieldStart();
         //nothing to append - there is no explicit null
         //and nothing in the standard to address this!
-        writeEndObject();
+        writeFieldEnd();
     }
 
     /*

--- a/odin/src/main/java/org/openehr/odin/jackson/serializers/TermCodeAsStringConverter.java
+++ b/odin/src/main/java/org/openehr/odin/jackson/serializers/TermCodeAsStringConverter.java
@@ -1,0 +1,23 @@
+package org.openehr.odin.jackson.serializers;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.Converter;
+import com.nedap.archie.base.terminology.TerminologyCode;
+
+public class TermCodeAsStringConverter implements Converter<TerminologyCode, String> {
+    @Override
+    public String convert(TerminologyCode value) {
+        return value.getCodeString();
+    }
+
+    @Override
+    public JavaType getInputType(TypeFactory typeFactory) {
+        return typeFactory.constructType(TerminologyCode.class);
+    }
+
+    @Override
+    public JavaType getOutputType(TypeFactory typeFactory) {
+        return typeFactory.constructType(String.class);
+    }
+}


### PR DESCRIPTION
…rchetypeTermOdinSerializer

Resulted in an exception. Fixing just the ODINGenerator would still result in strange values (```description = <>``` instead of omitting it) , so two fixes in one