### PR TITLE
Automatically set single/multiple in the parser

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
@@ -27,7 +27,7 @@ import java.nio.charset.Charset;
 public class ADLParser {
 
     private final MetaModels metaModels;
-    private ModelConstraintImposer modelConstraintImposer;
+    private final ModelConstraintImposer modelConstraintImposer;
     private ANTLRParserErrors errors;
 
     private Lexer lexer;
@@ -43,7 +43,8 @@ public class ADLParser {
     private boolean logEnabled = true;
 
     public ADLParser() {
-        metaModels = null;
+        this.metaModels = null;
+        this.modelConstraintImposer = null;
     }
 
     /**
@@ -55,6 +56,7 @@ public class ADLParser {
     @Deprecated
     public ADLParser(ModelConstraintImposer modelConstraintImposer) {
         this.modelConstraintImposer = modelConstraintImposer;
+        this.metaModels = null;
     }
 
 
@@ -65,6 +67,7 @@ public class ADLParser {
      */
     public ADLParser(MetaModels models) {
         this.metaModels = models;
+        this.modelConstraintImposer = null;
     }
 
     public Archetype parse(String adl) throws IOException {
@@ -87,7 +90,7 @@ public class ADLParser {
         parser.addErrorListener(errorListener);
         tree = parser.adl(); // parse
 
-        ADLListener listener = new ADLListener(errors);
+        ADLListener listener = new ADLListener(errors, metaModels);
         walker= new ParseTreeWalker();
         walker.walk(listener, tree);
         Archetype result = listener.getArchetype();

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -6,6 +6,7 @@ import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.adlparser.antlr.AdlBaseListener;
 import com.nedap.archie.adlparser.antlr.AdlParser;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
+import com.nedap.archie.rminfo.MetaModels;
 import com.nedap.archie.serializer.odin.OdinObjectParser;
 import com.nedap.archie.serializer.odin.AdlOdinToJsonConverter;
 import com.nedap.archie.aom.*;
@@ -30,9 +31,9 @@ public class ADLListener extends AdlBaseListener {
     private CComplexObjectParser subTreeWalker;
     private TerminologyParser terminologyParser;
 
-    public ADLListener(ANTLRParserErrors errors) {
+    public ADLListener(ANTLRParserErrors errors, MetaModels metaModels) {
         this.errors = errors;
-        subTreeWalker = new CComplexObjectParser(errors);
+        subTreeWalker = new CComplexObjectParser(errors, metaModels);
         terminologyParser = new TerminologyParser(errors);
     }
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -5,6 +5,7 @@ import com.nedap.archie.adlparser.antlr.AdlParser.*;
 import com.nedap.archie.aom.*;
 import com.nedap.archie.base.Cardinality;
 import com.nedap.archie.base.MultiplicityInterval;
+import com.nedap.archie.rminfo.MetaModels;
 import com.nedap.archie.rules.Assertion;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
@@ -19,10 +20,12 @@ import java.util.List;
 public class CComplexObjectParser extends BaseTreeWalker {
 
     private final PrimitivesConstraintParser primitivesConstraintParser;
+    private final MetaModels metaModels;
 
-    public CComplexObjectParser(ANTLRParserErrors errors) {
+    public CComplexObjectParser(ANTLRParserErrors errors, MetaModels metaModels) {
         super(errors);
         primitivesConstraintParser = new PrimitivesConstraintParser(errors);
+        this.metaModels = metaModels;
     }
 
     public RulesSection parseRules(Rules_sectionContext context) {
@@ -83,7 +86,8 @@ public class CComplexObjectParser extends BaseTreeWalker {
             }
             parent.addAttribute(attribute);
             if(attribute.getCardinality() != null) {
-                attribute.setMultiple(true); //this seems to be the only way to set single or multiple without the RM. Maybe existence as well?
+                //Sort of sensible default. Will be overwritten in ADLParser with the actual value from the RM
+                attribute.setMultiple(true);
             }
         } else if (attributeDefContext.c_attribute_tuple() != null) {
             parent.addAttributeTuple(parseAttributeTuple(parent, attributeDefContext.c_attribute_tuple()));

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
@@ -152,9 +152,13 @@ public class CComplexObjectSerializer<T extends CComplexObject> extends Constrai
     private void appendCardinality(Cardinality card) {
         buildOccurrences(builder, card.getInterval());
         List<String> tags = new ArrayList<>();
+        //TODO: this should compare against the RM and only serialize if different, OR we should make ordered nullable
+        //and add a preprocessor that removes all default values
         if (!card.isOrdered()) {
             tags.add("unordered");
         }
+        //TODO: this should compare against the RM and only serialize if different, OR we should make unique nullable
+        //and add a preprocessor that removes all default values
         if (card.isUnique()) {
             tags.add("unique");
         }


### PR DESCRIPTION
- [ ] document
- [ ] add test
- [ ] set ordered/unique?

if we add ordered/unique as default values, then the ADL serializer must be changed as well, to not serialize default values but to do a RM lookup - it now only serializes unordered and unique.