### PR TITLE
Adapt the RM Object validator to work without an archetype

### DIFF
--- a/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
+++ b/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
@@ -36,11 +36,6 @@ public class RMPathQuery {
 
     //TODO: get diagnostic information about where the finder stopped in the path - could be very useful!
 
-    /**
-     * Deprecated for querying RMObjects. Use RMQueryContext instead.
-     * For querying CObjects there is no other solution yet.
-     */
-    @Deprecated
     public <T> T find(ModelInfoLookup lookup, Object root) {
         Object currentObject = root;
         try {

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
@@ -20,7 +20,7 @@ public class RMObjectValidationMessage {
     }
 
     public RMObjectValidationMessage(ArchetypeConstraint constraint, String actualPath, String message, RMObjectValidationMessageType type) {
-        this(actualPath, constraint.getPath(), constraint.getLogicalPath(), message, type);
+        this(actualPath, constraint == null ? null : constraint.getPath(), constraint == null ? null : constraint.getLogicalPath(), message, type);
     }
 
 

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationUtil.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationUtil.java
@@ -1,0 +1,88 @@
+package com.nedap.archie.rmobjectvalidator;
+
+import com.nedap.archie.adlparser.modelconstraints.ModelConstraintImposer;
+import com.nedap.archie.aom.CAttribute;
+import com.nedap.archie.aom.CComplexObject;
+import com.nedap.archie.aom.CObject;
+import com.nedap.archie.aom.terminology.ArchetypeTerm;
+import com.nedap.archie.rminfo.ModelInfoLookup;
+import com.nedap.archie.rminfo.RMAttributeInfo;
+import com.nedap.archie.rminfo.RMTypeInfo;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class RMObjectValidationUtil {
+
+    /**
+     * Retrieve the terminology name of the observation that an attribute is a part of.
+     *
+     * @param attribute The attribute for which the observation is retrieved
+     * @return The name of the observation
+     */
+    public static String getParentObservationTerm(CAttribute attribute) {
+        String result = "";
+        CObject parent = attribute.getParent();
+        while (result.equals("") && parent != null) {
+            CAttribute attributeParent = parent.getParent();
+            if (attributeParent != null) {
+                parent = attributeParent.getParent();
+                if (parent.getRmTypeName().equals("OBSERVATION")) {
+                    ArchetypeTerm parentTerm = parent.getTerm();
+                    if (parentTerm != null) {
+                        result = parentTerm.getText();
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    public static boolean hasNoneWithWrongType(List<RMObjectValidationMessage> subResult) {
+        return subResult.stream().noneMatch((message) -> message.getType() == RMObjectValidationMessageType.WRONG_TYPE);
+    }
+
+    public static List<CAttribute> getDefaultAttributeConstraints(CObject cObject, List<CAttribute> attributes, ModelInfoLookup lookup, ModelConstraintImposer constraintImposer) {
+        List<CAttribute> result = new ArrayList<>();
+        Set<String> alreadyConstrainedAttributes = attributes.stream()
+                .map(attribute -> attribute.getRmAttributeName())
+                .collect(Collectors.toSet());
+
+        RMTypeInfo typeInfo = lookup.getTypeInfo(cObject.getRmTypeName());
+
+        if(typeInfo != null) {
+            for (RMAttributeInfo defaultAttribute : typeInfo.getAttributes().values()) {
+                if (!defaultAttribute.isComputed()) {
+                    if (!alreadyConstrainedAttributes.contains(defaultAttribute.getRmName())) {
+                        CAttribute attribute = constraintImposer.getDefaultAttribute(cObject.getRmTypeName(), defaultAttribute.getRmName());
+                        attribute.setParent(cObject);
+                        result.add(attribute);
+                    }
+                }
+            }
+        }
+        return result;
+
+    }
+
+    public static List<CAttribute> getDefaultAttributeConstraints(String rmTypeName, List<CAttribute> attributes, ModelInfoLookup lookup, ModelConstraintImposer constraintImposer) {
+
+        CComplexObject fakeParent = new CComplexObject();
+        fakeParent.setRmTypeName(rmTypeName);
+        return getDefaultAttributeConstraints(fakeParent, attributes, lookup, constraintImposer);
+    }
+
+    public static String stripLastPathSegment(String path) {
+        if (path.equals("/")) {
+            return "";
+        }
+        int lastSlashIndex = path.lastIndexOf('/');
+        if (lastSlashIndex == -1) {
+            return path;
+        }
+        return path.substring(0, lastSlashIndex);
+    }
+}

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMMultiplicityValidation.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMMultiplicityValidation.java
@@ -28,7 +28,9 @@ public class RMMultiplicityValidation {
             MultiplicityInterval existence = attribute.getExistence();
             if (existence != null) {
                 if (!existence.has(attributeValue == null ? 0 : 1)) {
-                    String message = RMObjectValidationMessageIds.rm_EXISTENCE_MISMATCH.getMessage(attribute.getRmAttributeName(), attribute.getParent() == null ? "TODO:typename" : attribute.getParent().getRmTypeName(), existence.toString());
+                    String message = RMObjectValidationMessageIds.rm_EXISTENCE_MISMATCH.getMessage(attribute.getRmAttributeName(),
+                            attribute.getParent() == null ? "Unknown type" : attribute.getParent().getRmTypeName(), existence.toString());
+
                     return Lists.newArrayList((new RMObjectValidationMessage(attribute, pathSoFar, message, RMObjectValidationMessageType.REQUIRED)));
                 }
             }

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMMultiplicityValidation.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMMultiplicityValidation.java
@@ -28,7 +28,7 @@ public class RMMultiplicityValidation {
             MultiplicityInterval existence = attribute.getExistence();
             if (existence != null) {
                 if (!existence.has(attributeValue == null ? 0 : 1)) {
-                    String message = RMObjectValidationMessageIds.rm_EXISTENCE_MISMATCH.getMessage(attribute.getRmAttributeName(), attribute.getParent().getRmTypeName(), existence.toString());
+                    String message = RMObjectValidationMessageIds.rm_EXISTENCE_MISMATCH.getMessage(attribute.getRmAttributeName(), attribute.getParent() == null ? "TODO:typename" : attribute.getParent().getRmTypeName(), existence.toString());
                     return Lists.newArrayList((new RMObjectValidationMessage(attribute, pathSoFar, message, RMObjectValidationMessageType.REQUIRED)));
                 }
             }

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMOccurrenceValidation.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMOccurrenceValidation.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.base.MultiplicityInterval;
 import com.nedap.archie.query.RMObjectWithPath;
+import com.nedap.archie.rminfo.MetaModel;
 import com.nedap.archie.rmobjectvalidator.RMObjectValidationMessage;
 import com.nedap.archie.rmobjectvalidator.RMObjectValidationMessageIds;
 import com.nedap.archie.rmobjectvalidator.RMObjectValidationMessageType;
@@ -12,15 +13,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RMOccurrenceValidation {
-    public static List<RMObjectValidationMessage> validate(List<RMObjectWithPath> rmObjects, String pathSoFar, CObject cobject) {
-        if (cobject.getOccurrences() != null) {
-            MultiplicityInterval occurrences = cobject.getOccurrences();
-            if (!occurrences.has(rmObjects.size())) {
+    public static List<RMObjectValidationMessage> validate(MetaModel metaModel, List<RMObjectWithPath> rmObjects, String pathSoFar, CObject cobject) {
+        if(cobject != null) {
+            MultiplicityInterval occurrences = cobject.effectiveOccurrences(metaModel::referenceModelPropMultiplicity);
+            if (occurrences != null && !occurrences.has(rmObjects.size())) {
                 String message = RMObjectValidationMessageIds.rm_OCCURRENCE_MISMATCH.getMessage(rmObjects.size(), occurrences.toString());
                 RMObjectValidationMessageType messageType = occurrences.isMandatory() ? RMObjectValidationMessageType.REQUIRED : RMObjectValidationMessageType.DEFAULT;
                 return Lists.newArrayList(new RMObjectValidationMessage(cobject, pathSoFar, message, messageType));
             }
+
         }
+
         return new ArrayList<>();
     }
 }

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMPrimitiveObjectValidation.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/validations/RMPrimitiveObjectValidation.java
@@ -13,7 +13,11 @@ import java.util.Collections;
 import java.util.List;
 
 public class RMPrimitiveObjectValidation {
+
     public static List<RMObjectValidationMessage> validate(ModelInfoLookup lookup, List<RMObjectWithPath> rmObjects, String pathSoFar, CPrimitiveObject cobject) {
+        if(cobject == null) {
+            return new ArrayList<>();
+        }
         if (cobject.getSocParent() != null) {
             //validate the tuple, not the primitive object directly
             return Collections.emptyList();

--- a/tools/src/test/java/com/nedap/archie/rmobjectvalidatortest/RmObjectValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rmobjectvalidatortest/RmObjectValidatorTest.java
@@ -1,12 +1,17 @@
 package com.nedap.archie.rmobjectvalidatortest;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.archetypevalidator.ArchetypeValidatorTest;
+import com.nedap.archie.rm.datastructures.Cluster;
 import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.datavalues.quantity.DvProportion;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rmobjectvalidator.RMObjectValidationMessage;
+import com.nedap.archie.rmobjectvalidator.RMObjectValidationMessageType;
 import com.nedap.archie.rmobjectvalidator.RMObjectValidator;
 import com.nedap.archie.testutil.TestUtil;
 import org.junit.Test;
@@ -15,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class RmObjectValidatorTest {
@@ -38,6 +44,43 @@ public class RmObjectValidatorTest {
         dvProportion.setNumerator(2D);
         validationMessages = validator.validate(archetype, element);
         assertEquals("There should be 0 errors", 0, validationMessages.size());
+    }
+
+    @Test
+    public void testEmptyElementWithoutArchetype() {
+        Element element = new Element();
+        RMObjectValidator rmObjectValidator = new RMObjectValidator(ArchieRMInfoLookup.getInstance());
+        List<RMObjectValidationMessage> messages = rmObjectValidator.validate(element);
+        assertEquals(2, messages.size());
+        for(RMObjectValidationMessage message:messages) {
+            assertTrue(Sets.newHashSet("/name", "/archetype_node_id").contains(message.getPath()));
+            assertEquals(RMObjectValidationMessageType.REQUIRED, message.getType());
+        }
+    }
+
+    @Test
+    public void testClusterWithoutArchetype() {
+        Cluster cluster = new Cluster();
+        cluster.setName(new DvText("test cluster"));
+        cluster.setArchetypeNodeId("id12");
+        Element element = new Element();
+        cluster.setItems(Lists.newArrayList(element));
+        RMObjectValidator rmObjectValidator = new RMObjectValidator(ArchieRMInfoLookup.getInstance());
+        List<RMObjectValidationMessage> messages = rmObjectValidator.validate(cluster);
+        assertEquals(2, messages.size());
+        for(RMObjectValidationMessage message:messages) {
+            assertTrue(message.getPath(), Sets.newHashSet("/items[1]/name", "/items[1]/archetype_node_id").contains(message.getPath()));
+            assertEquals(RMObjectValidationMessageType.REQUIRED, message.getType());
+        }
+    }
+
+
+    @Test
+    public void testNestedEmptyElementWithoutArchetype() {
+        Element element = new Element();
+        RMObjectValidator rmObjectValidator = new RMObjectValidator(ArchieRMInfoLookup.getInstance());
+        List<RMObjectValidationMessage> validate = rmObjectValidator.validate(element);
+        assertFalse(validate.isEmpty());
     }
 
     private Archetype parse(String filename) throws IOException {

--- a/tools/src/test/java/com/nedap/archie/rmobjectvalidatortest/RmObjectValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rmobjectvalidatortest/RmObjectValidatorTest.java
@@ -74,6 +74,21 @@ public class RmObjectValidatorTest {
         }
     }
 
+    @Test
+    public void testValidClusterWithoutArchetype() {
+        Cluster cluster = new Cluster();
+        cluster.setName(new DvText("test cluster"));
+        cluster.setArchetypeNodeId("id12");
+        Element element = new Element();
+        element.setName(new DvText("test element"));
+        element.setArchetypeNodeId("id15");
+        cluster.setItems(Lists.newArrayList(element));
+        RMObjectValidator rmObjectValidator = new RMObjectValidator(ArchieRMInfoLookup.getInstance());
+        List<RMObjectValidationMessage> messages = rmObjectValidator.validate(cluster);
+        assertEquals(0, messages.size());
+
+    }
+
 
     @Test
     public void testNestedEmptyElementWithoutArchetype() {


### PR DESCRIPTION
Experimental: changed the RM Object validator to work without an archetype. To use:


```
RMObjectValidator rmObjectValidator = new RMObjectValidator(ArchieRMInfoLookup.getInstance());
List<RMObjectValidationMessage> messages = rmObjectValidator.validate(rmObject);
```

Requires a RM implementation with included metadata in the form of a ModelInfoLookup, because it validates an actual implementation, not just a BMM based model.