### PR TITLE
Correctly select the AOM Profile for other models than OpenEHR

### DIFF
--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
@@ -121,18 +121,37 @@ public class MetaModels implements MetaModelInterface {
             selectedBmmModel = validationResult == null ? null : validationResult.getModel();
         }
 
-        for(AomProfile profile:aomProfiles.getProfiles()) {
-            if(profile.getProfileName().equalsIgnoreCase(rmPublisher)) {
-                this.selectedAomProfile = profile;
-                break;
-            }
+        AomProfile profile = getAomProfileWithSchemaId(selectedBmmModel);
+        if(profile == null) {
+            profile = getAomProfileOnPublisher(rmPublisher);
         }
+        this.selectedAomProfile = profile;
 
         if(selectedModel == null && selectedBmmModel == null) {
             throw new ModelNotFoundException(String.format("model for %s.%s version %s not found", rmPublisher, rmPackage, rmRelease));
         }
         this.selectedModel = new MetaModel(selectedModel, selectedBmmModel, selectedAomProfile);
 
+    }
+
+    private AomProfile getAomProfileWithSchemaId(BmmModel selectedBmmModel) {
+        if(selectedBmmModel != null) {
+            for (AomProfile profile : aomProfiles.getProfiles()) {
+                if (profile.getRmSchemaPattern().stream().anyMatch(pat -> selectedBmmModel.getSchemaId().matches(pat))) {
+                    return this.selectedAomProfile = profile;
+                }
+            }
+        }
+        return null;
+    }
+
+    private AomProfile getAomProfileOnPublisher(String rmPublisher) {
+        for(AomProfile profile:aomProfiles.getProfiles()) {
+           if(profile.getProfileName().equalsIgnoreCase(rmPublisher)) {
+                return this.selectedAomProfile = profile;
+            }
+        }
+        return null;
     }
 
     public ModelInfoLookup getSelectedModelInfoLookup() {

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
@@ -138,7 +138,7 @@ public class MetaModels implements MetaModelInterface {
         if(selectedBmmModel != null) {
             for (AomProfile profile : aomProfiles.getProfiles()) {
                 if (profile.getRmSchemaPattern().stream().anyMatch(pat -> selectedBmmModel.getSchemaId().matches(pat))) {
-                    return this.selectedAomProfile = profile;
+                    return profile;
                 }
             }
         }
@@ -148,7 +148,7 @@ public class MetaModels implements MetaModelInterface {
     private AomProfile getAomProfileOnPublisher(String rmPublisher) {
         for(AomProfile profile:aomProfiles.getProfiles()) {
            if(profile.getProfileName().equalsIgnoreCase(rmPublisher)) {
-                return this.selectedAomProfile = profile;
+                return profile;
             }
         }
         return null;

--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModels.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * the entire MetaModels, or for a specific call, with the overrideModelVersion() method, and the two-parameter
  * selectModel() method.
  *
+ * Note that this class is NOT thread-safe and is to be used by a single thread only.
+ *
  */
 public class MetaModels implements MetaModelInterface {
 
@@ -121,11 +123,10 @@ public class MetaModels implements MetaModelInterface {
             selectedBmmModel = validationResult == null ? null : validationResult.getModel();
         }
 
-        AomProfile profile = getAomProfileWithSchemaId(selectedBmmModel);
-        if(profile == null) {
-            profile = getAomProfileOnPublisher(rmPublisher);
+        this.selectedAomProfile = getAomProfileWithSchemaId(selectedBmmModel);
+        if(this.selectedAomProfile == null) {
+            this.selectedAomProfile = getAomProfileOnPublisher(rmPublisher);
         }
-        this.selectedAomProfile = profile;
 
         if(selectedModel == null && selectedBmmModel == null) {
             throw new ModelNotFoundException(String.format("model for %s.%s version %s not found", rmPublisher, rmPackage, rmRelease));


### PR DESCRIPTION
The AOM profile was incorrectly selected just on publisher. Change this to selecting on BMM Schema id - with a fallback to publisher.