### PR TITLE
Make the OpenEHR AOM profile patterns work with 1.0.2 OpenEHR BMM

### DIFF
--- a/referencemodels/src/main/resources/aom_profiles/openehr_aom_profile.arp
+++ b/referencemodels/src/main/resources/aom_profiles/openehr_aom_profile.arp
@@ -15,7 +15,7 @@ profile_name = <"openEHR">
 -- This is used to match the 'schema_id' generated in BMM_SCHEMA class based on model 
 -- publisher, model name, model release as defined in .bmm files.
 --
-rm_schema_pattern = <"openehr_ehr_extract_.*|openehr_rm_.*|openehr_adltest_.*|openehr_proc_.*">
+rm_schema_pattern = <"openehr_ehr_.*|openehr_demographic_.*|openehr_ehr_extract_.*|openehr_rm_.*|openehr_adltest_.*|openehr_proc_.*">
 
 ----------------------------------------------------------------------------------------
 -- id of terminologies and code sets to use


### PR DESCRIPTION
Minor fix so the bmm of openehr 1.0.2 can be linked with the correct AOM Profile files again.