### PR TITLE
Travis CI: Force dist to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 jdk:
   - oraclejdk8
   - oraclejdk9
+# Force dist to trusty, as oraclejdk8 is not available on newer dists.
+dist: trusty
 before_script:
   - chmod +x gradlew
 script:


### PR DESCRIPTION
Force `dist` to `trusty` in Travis CI configuration. `oraclejdk8` is not available on newer dists, which makes the tests fail.