### PR TITLE
Fix MultiplicityInterval.toString

### DIFF
--- a/base/src/main/java/com/nedap/archie/base/MultiplicityInterval.java
+++ b/base/src/main/java/com/nedap/archie/base/MultiplicityInterval.java
@@ -109,13 +109,28 @@ public class MultiplicityInterval extends Interval<Integer> {
         return has(1) && !has(2);
     }
 
+    @Override
     public String toString() {
-        if(isOpen()) {
-            return getLower() + MULTIPLICITY_RANGE_MARKER + MULTIPLICITY_UNBOUNDED_MARKER;
+        Integer lower = getLower();
+        Integer upper = getUpper();
+        StringBuilder result = new StringBuilder();
+        if (isLowerUnbounded()) {
+            result.append(MULTIPLICITY_UNBOUNDED_MARKER);
         } else {
-            return getLower() + MULTIPLICITY_RANGE_MARKER + getUpper();
+            if (!isLowerIncluded()) {
+                result.append(">");
+            }
+            result.append(lower);
         }
+        result.append(MULTIPLICITY_RANGE_MARKER);
+        if (isUpperUnbounded()) {
+            result.append(MULTIPLICITY_UNBOUNDED_MARKER);
+        } else {
+            if(!isUpperIncluded()) {
+                result.append("<");
+            }
+            result.append(upper);
+        }
+        return result.toString();
     }
-
-
 }

--- a/base/src/test/java/com/nedap/archie/base/MultiplicityIntervalTest.java
+++ b/base/src/test/java/com/nedap/archie/base/MultiplicityIntervalTest.java
@@ -1,0 +1,22 @@
+package com.nedap.archie.base;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MultiplicityIntervalTest {
+    @Test
+    public void testToString() {
+        assertEquals("0..0", MultiplicityInterval.createProhibited().toString());
+        assertEquals("3..*", MultiplicityInterval.createUpperUnbounded(3).toString());
+        assertEquals("1..1", MultiplicityInterval.createMandatory().toString());
+        assertEquals("0..1", MultiplicityInterval.createOptional().toString());
+        assertEquals("0..*", MultiplicityInterval.unbounded().toString());
+        assertEquals("0..*", MultiplicityInterval.createOpen().toString());
+        assertEquals("2..4", MultiplicityInterval.createBounded(2, 4).toString());
+
+        // These situations should not happen:
+        assertEquals(">2..<4",new MultiplicityInterval(2, false, false, 4, false, false).toString());
+        assertEquals("*..*",new MultiplicityInterval(null, false, true, null, false, true).toString());
+    }
+}


### PR DESCRIPTION
MultiplicityInterval.toString did not implement all cases. For example, the interval `1..*` was displayed as `1..0`. This adds a full implementation.