### PR TITLE
Fix path lookup with ADL 1.4-style at-codes as node ids

### DIFF
--- a/path-queries/build.gradle
+++ b/path-queries/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 	compile project(':grammars')
 	compile project(':base')
 	compile project(':aom') //modelInfoLookup is here and should be split and moved
+	testCompile project(':openehr-rm')
 }

--- a/path-queries/src/test/java/com/nedap/archie/query/RMPathQueryTest.java
+++ b/path-queries/src/test/java/com/nedap/archie/query/RMPathQueryTest.java
@@ -1,0 +1,40 @@
+package com.nedap.archie.query;
+
+import com.nedap.archie.rm.datastructures.Cluster;
+import com.nedap.archie.rm.datastructures.Element;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RMPathQueryTest {
+
+    @Test
+    public void adl2NodeIdMatch() {
+        Cluster cluster = new Cluster();
+        cluster.setArchetypeNodeId("id1");
+        Element elementId2 = new Element();
+        elementId2.setArchetypeNodeId("id2");
+        Element elementId3_1 = new Element();
+        elementId3_1.setArchetypeNodeId("id3.1");
+
+        cluster.addItem(elementId2);
+        cluster.addItem(elementId3_1);
+        assertEquals(elementId2, cluster.itemAtPath("/items[id2]"));
+        assertEquals(elementId3_1, cluster.itemAtPath("/items[id3.1]"));
+    }
+
+    @Test
+    public void adl14NodeIdMatch() {
+        Cluster cluster = new Cluster();
+        cluster.setArchetypeNodeId("at0000");
+        Element elementAt0001 = new Element();
+        elementAt0001.setArchetypeNodeId("at0001");
+        Element elementAt0002_3 = new Element();
+        elementAt0002_3.setArchetypeNodeId("at0002.3");
+
+        cluster.addItem(elementAt0001);
+        cluster.addItem(elementAt0002_3);
+        assertEquals(elementAt0001, cluster.itemAtPath("/items[at0001]"));
+        assertEquals(elementAt0002_3, cluster.itemAtPath("/items[at0002.3]"));
+    }
+}

--- a/utils/src/main/java/com/nedap/archie/paths/PathSegment.java
+++ b/utils/src/main/java/com/nedap/archie/paths/PathSegment.java
@@ -12,7 +12,7 @@ public class PathSegment {
     private final static Joiner expressionJoiner = Joiner.on(",").skipNulls();
 
     private static final Pattern archetypeRefPattern = Pattern.compile("(.*::)?.*-.*-.*\\..*\\.v.*");
-    private static final Pattern nodeIdPattern = Pattern.compile("id(\\.?\\d)+");
+    private static final Pattern nodeIdPattern = Pattern.compile("id(\\.?\\d)+|at(\\.?\\d)+");
 
     private String nodeName;
     private String nodeId;


### PR DESCRIPTION
Fixes the same issue as https://github.com/openEHR/archie/pull/117 , but by recognizing at-codes instead of using a fallback.