### PR TITLE
Clean up DateTimeFormatters

### DIFF
--- a/aom/src/main/java/com/nedap/archie/xml/adapters/DateTimeXmlAdapter.java
+++ b/aom/src/main/java/com/nedap/archie/xml/adapters/DateTimeXmlAdapter.java
@@ -1,13 +1,12 @@
 package com.nedap.archie.xml.adapters;
 
-import com.nedap.archie.datetime.DateTimeFormatters;
 import com.nedap.archie.datetime.DateTimeParsers;
+import com.nedap.archie.datetime.DateTimeSerializerFormatters;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 
 /**
@@ -25,11 +24,7 @@ public class DateTimeXmlAdapter extends XmlAdapter<String, TemporalAccessor> {
         if(value instanceof LocalDateTime || value instanceof ZonedDateTime || value instanceof OffsetDateTime) {
             return value.toString();
         }
-        if(value.isSupported(ChronoField.MICRO_OF_SECOND) && value.get(ChronoField.MICRO_OF_SECOND) != 0l) {
-            return DateTimeFormatters.ISO_8601_DATE_TIME.format(value);
-        } else {
-            return DateTimeFormatters.ISO_8601_DATE_TIME_WITHOUT_MICROS.format(value);
-        }
+        return DateTimeSerializerFormatters.ISO_8601_DATE_TIME.format(value);
     }
 
 

--- a/aom/src/main/java/com/nedap/archie/xml/adapters/DateXmlAdapter.java
+++ b/aom/src/main/java/com/nedap/archie/xml/adapters/DateXmlAdapter.java
@@ -1,7 +1,7 @@
 package com.nedap.archie.xml.adapters;
 
-import com.nedap.archie.datetime.DateTimeFormatters;
 import com.nedap.archie.datetime.DateTimeParsers;
+import com.nedap.archie.datetime.DateTimeSerializerFormatters;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.time.LocalDate;
@@ -23,6 +23,6 @@ public class DateXmlAdapter extends XmlAdapter<String, Temporal> {
         if(value instanceof LocalDate || value instanceof YearMonth) {
             return value.toString();
         }
-        return value != null ? DateTimeFormatters.ISO_8601_DATE.format(value):null;
+        return value != null ? DateTimeSerializerFormatters.ISO_8601_DATE.format(value):null;
     }
 }

--- a/utils/src/main/java/com/nedap/archie/datetime/DateTimeFormatters.java
+++ b/utils/src/main/java/com/nedap/archie/datetime/DateTimeFormatters.java
@@ -6,161 +6,86 @@ import java.time.temporal.ChronoField;
 
 public class DateTimeFormatters {
 
-    public static final DateTimeFormatter ISO8601_TIME_ZONE;
-    static {
-        ISO8601_TIME_ZONE = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                //time zone stuff
-                .optionalStart()
-                .appendOffsetId()
-                .optionalEnd()
-                .optionalStart()
-                .appendOffset("+HH:MM", "0000")
-                .optionalEnd()
-                .optionalStart()
-                .appendOffset("+HHMM", "0000")
-                .optionalEnd()
-                .toFormatter();
-        //--end of time zone stuff
+    public static final DateTimeFormatter ISO_8601_DATE = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(ChronoField.YEAR)
+            .optionalStart()
+            .appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR)
+            .optionalStart()
+            .appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH)
+            .optionalEnd()
+            .optionalEnd()
+            .toFormatter();
 
-    }
+    public static final DateTimeFormatter ISO8601_TIME_ZONE = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .optionalStart()
+            .appendOffsetId()
+            .optionalEnd()
+            .optionalStart()
+            .appendOffset("+HH:MM", "0000")
+            .optionalEnd()
+            .optionalStart()
+            .appendOffset("+HHMM", "0000")
+            .optionalEnd()
+            .toFormatter();
 
-    public static final DateTimeFormatter ISO8601_OPTIONAL_MICROSECONDS;
-    static {
-        ISO8601_OPTIONAL_MICROSECONDS = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                // microseconds, decimal fraction, ISO 31-0: comma [,] or full stop [.]
-                .optionalStart() //micro seconds ,
-                .appendLiteral(',')
-                .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, false)
-                .optionalEnd() //micro seconds ,
-                .optionalStart() //micro seconds .
-                .appendFraction(ChronoField.MICRO_OF_SECOND, 1, 6, true)
-                .optionalEnd() //micro seconds .
-                .toFormatter();
-        //--end of time zone stuff
+    public static final DateTimeFormatter ISO8601_OPTIONAL_MICROSECONDS = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            // microseconds, decimal fraction, ISO 31-0: comma [,] or full stop [.]
+            .optionalStart() //micro seconds ,
+            .appendLiteral(',')
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, false)
+            .optionalEnd() //micro seconds ,
+            .optionalStart() //micro seconds .
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 1, 6, true)
+            .optionalEnd() //micro seconds .
+            .toFormatter();
 
-    }
+    public static final DateTimeFormatter ISO_8601_TIME = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(ChronoField.HOUR_OF_DAY)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .append(ISO8601_OPTIONAL_MICROSECONDS)
+            .optionalEnd()
+            .optionalEnd()
+            .append(ISO8601_TIME_ZONE)
+            .toFormatter();
 
     public static final DateTimeFormatter ISO_8601_DATE_TIME = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
-            .appendValue(ChronoField.YEAR)
-            .appendLiteral('-')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 2)
-            .appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .append(ISO_8601_DATE)
             .appendLiteral('T')
-            .appendValue(ChronoField.HOUR_OF_DAY, 2)
-            .optionalStart()
-            .appendLiteral(':')
-            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
-            .optionalStart()
-            .appendLiteral(':')
-            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-            .optionalEnd()
-            .optionalEnd()
-            .append(ISO8601_TIME_ZONE)
+            .append(ISO_8601_TIME)
             .toFormatter();
 
-    public static final DateTimeFormatter ISO_8601_DATE_TIME_WITH_OPTIONAL_MICROS = new DateTimeFormatterBuilder()
+    public static final DateTimeFormatter ISO_8601_DATE_COMPACT = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
-            .appendValue(ChronoField.YEAR)
-            .appendLiteral('-')
-            .appendValue(ChronoField.MONTH_OF_YEAR)
-            .appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH)
-            .appendLiteral('T')
+            .appendValue(ChronoField.YEAR, 4)
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .toFormatter();
+
+    public static final DateTimeFormatter ISO_8601_TIME_COMPACT = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
             .appendValue(ChronoField.HOUR_OF_DAY, 2)
-            .optionalStart() //minutes
-            .appendLiteral(':')
             .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
-            .optionalStart() //seconds
-            .appendLiteral(':')
             .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
             .append(ISO8601_OPTIONAL_MICROSECONDS)
-            .optionalEnd() //seconds
-            .optionalEnd() //minutes
             .append(ISO8601_TIME_ZONE)
             .toFormatter();
-
 
     public static final DateTimeFormatter ISO_8601_DATE_TIME_COMPACT = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
-            .appendValue(ChronoField.YEAR, 4).appendValue(ChronoField.MONTH_OF_YEAR, 2).appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .append(ISO_8601_DATE_COMPACT)
             .appendLiteral('T')
-            .appendValue(ChronoField.HOUR_OF_DAY, 2).appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-            .append(ISO8601_OPTIONAL_MICROSECONDS)
-            .append(ISO8601_TIME_ZONE)
+            .append(ISO_8601_TIME_COMPACT)
             .toFormatter();
-
-    public static final DateTimeFormatter ISO_8601_DATE_TIME_WITHOUT_MICROS = new DateTimeFormatterBuilder()
-            .parseCaseInsensitive()
-            .appendValue(ChronoField.YEAR)
-            .appendLiteral('-')
-            .appendValue(ChronoField.MONTH_OF_YEAR, 2)
-            .appendLiteral('-')
-            .appendValue(ChronoField.DAY_OF_MONTH, 2)
-            .appendLiteral('T')
-            .appendValue(ChronoField.HOUR_OF_DAY, 2)
-            .optionalStart()
-            .appendLiteral(':')
-            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
-            .optionalStart()
-            .appendLiteral(':')
-            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-            .optionalEnd()
-            .optionalEnd()
-            .append(ISO8601_TIME_ZONE)
-            .toFormatter();
-
-
-    public static final DateTimeFormatter ISO_8601_TIME;
-    static {
-        ISO_8601_TIME = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .appendValue(ChronoField.HOUR_OF_DAY)
-                .optionalStart()
-                .appendLiteral(':')
-                .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
-                .optionalStart()
-                .appendLiteral(':')
-                .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-                .append(ISO8601_OPTIONAL_MICROSECONDS)
-                .optionalEnd()
-                .optionalEnd()
-                .append(ISO8601_TIME_ZONE)
-                .toFormatter();
-    }
-
-    public static final DateTimeFormatter ISO_8601_DATE;
-    static {
-        ISO_8601_DATE = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .appendValue(ChronoField.YEAR)
-                .optionalStart()
-                .appendLiteral('-')
-                .appendValue(ChronoField.MONTH_OF_YEAR)
-                .optionalStart()
-                .appendLiteral('-')
-                .appendValue(ChronoField.DAY_OF_MONTH)
-                .optionalEnd()
-                .optionalEnd()
-                .toFormatter();
-    }
-
-    public static final DateTimeFormatter ISO_8601_DATE_COMPACT;
-    static {
-        ISO_8601_DATE_COMPACT = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .appendValue(ChronoField.YEAR, 4).appendValue(ChronoField.MONTH_OF_YEAR, 2).appendValue(ChronoField.DAY_OF_MONTH, 2)
-                .toFormatter();
-    }
-
-    public static final DateTimeFormatter ISO_8601_TIME_COMPACT;
-    static {
-        ISO_8601_TIME_COMPACT = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .appendValue(ChronoField.HOUR_OF_DAY, 2).appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendValue(ChronoField.SECOND_OF_MINUTE, 2)
-                .toFormatter();
-    }
 }

--- a/utils/src/main/java/com/nedap/archie/datetime/DateTimeParsers.java
+++ b/utils/src/main/java/com/nedap/archie/datetime/DateTimeParsers.java
@@ -21,13 +21,13 @@ public class DateTimeParsers {
 
     public static TemporalAccessor parseDateTimeValue(String text) {
         try {
-            return DateTimeFormatters.ISO_8601_DATE_TIME_WITH_OPTIONAL_MICROS.parseBest(text, OffsetDateTime::from, LocalDateTime::from);
+            return DateTimeFormatters.ISO_8601_DATE_TIME.parseBest(text, OffsetDateTime::from, LocalDateTime::from);
         } catch (DateTimeParseException e) {
             try {
                 //Not parseable as a standard public object from datetime. We do not implement our own yet (we could!)
                 //so fallback to the Parsed object. The Parsed object is package-private, so cannot be added as a reference
                 //to the parseBest query, unfortunately.
-                return DateTimeFormatters.ISO_8601_DATE_TIME_WITH_OPTIONAL_MICROS.parse(text);
+                return DateTimeFormatters.ISO_8601_DATE_TIME.parse(text);
             } catch (DateTimeParseException e1) {
                 try {
                     //some more interesting date_time expression without hyphens...

--- a/utils/src/main/java/com/nedap/archie/datetime/DateTimeSerializerFormatters.java
+++ b/utils/src/main/java/com/nedap/archie/datetime/DateTimeSerializerFormatters.java
@@ -1,0 +1,50 @@
+package com.nedap.archie.datetime;
+
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DecimalStyle;
+import java.time.temporal.ChronoField;
+
+public class DateTimeSerializerFormatters {
+
+    public static final DateTimeFormatter ISO_8601_DATE = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(ChronoField.YEAR)
+            .optionalStart()
+            .appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+            .optionalStart()
+            .appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .optionalEnd()
+            .optionalEnd()
+            .toFormatter();
+
+    public static final DateTimeFormatter ISO_8601_TIME = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalStart()
+            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+            .optionalEnd()
+            .optionalEnd()
+            .optionalEnd()
+            .optionalStart()
+            .appendOffsetId()
+            .optionalEnd()
+            .toFormatter()
+            .withDecimalStyle(DecimalStyle.STANDARD.withDecimalSeparator(','));
+
+    public static final DateTimeFormatter ISO_8601_DATE_TIME = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_8601_DATE)
+            .appendLiteral('T')
+            .append(ISO_8601_TIME)
+            .toFormatter()
+            .withDecimalStyle(DecimalStyle.STANDARD.withDecimalSeparator(','));
+}

--- a/utils/src/main/java/com/nedap/archie/json/DateTimeSerializer.java
+++ b/utils/src/main/java/com/nedap/archie/json/DateTimeSerializer.java
@@ -4,15 +4,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.nedap.archie.datetime.DateTimeFormatters;
+import com.nedap.archie.datetime.DateTimeSerializerFormatters;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 
 /**
@@ -26,11 +20,7 @@ public class DateTimeSerializer extends JsonSerializer<TemporalAccessor> {
         if(temporalAccessor == null) {
             jsonGenerator.writeString("");
         }
-        if(temporalAccessor.isSupported(ChronoField.MICRO_OF_SECOND) && temporalAccessor.get(ChronoField.MICRO_OF_SECOND) != 0l) {
-            jsonGenerator.writeString(DateTimeFormatters.ISO_8601_DATE_TIME.format(temporalAccessor));
-        } else {
-            jsonGenerator.writeString(DateTimeFormatters.ISO_8601_DATE_TIME_WITHOUT_MICROS.format(temporalAccessor));
-        }
+        jsonGenerator.writeString(DateTimeSerializerFormatters.ISO_8601_DATE_TIME.format(temporalAccessor));
     }
 
 }

--- a/utils/src/test/java/com/nedap/archie/datetime/DateTimeSerializerFormattersTest.java
+++ b/utils/src/test/java/com/nedap/archie/datetime/DateTimeSerializerFormattersTest.java
@@ -1,0 +1,56 @@
+package com.nedap.archie.datetime;
+
+import org.junit.Test;
+
+import java.time.*;
+import java.time.temporal.TemporalAccessor;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateTimeSerializerFormattersTest {
+
+    @Test
+    public void serializeLocalDate() {
+        assertEquals("2015-01-01", serializeDate(LocalDate.of(2015, 1, 1)));
+        assertEquals("2019-01-14", serializeDate(LocalDate.of(2019, 1, 14)));
+    }
+
+    @Test
+    public void serializeLocalDateTime() {
+        assertEquals("2015-01-01T12:00:00", serializeDateTime(LocalDateTime.of(2015, 1, 1, 12, 0, 0, 0)));
+        assertEquals("2015-01-01T12:01:00", serializeDateTime(LocalDateTime.of(2015, 1, 1, 12, 1, 0, 0)));
+        assertEquals("2015-01-01T12:01:01", serializeDateTime(LocalDateTime.of(2015, 1, 1, 12, 1, 1, 0)));
+        assertEquals("2015-01-01T12:01:01,1", serializeDateTime(LocalDateTime.of(2015, 1, 1, 12, 1, 1, 100000000)));
+    }
+
+    @Test
+    public void serializeOffsetDateTime() {
+        assertEquals("2015-01-01T12:00:00+01:00", serializeDateTime(OffsetDateTime.of(2015, 1, 1, 12, 0, 0, 0, ZoneOffset.of("+0100"))));
+        assertEquals("2015-01-01T12:01:01+01:00", serializeDateTime(OffsetDateTime.of(2015, 1, 1, 12, 1, 1, 0, ZoneOffset.of("+0100"))));
+        assertEquals("2015-01-01T12:01:01,1+01:00", serializeDateTime(OffsetDateTime.of(2015, 1, 1, 12, 1, 1, 100000000, ZoneOffset.of("+0100"))));
+        assertEquals("2015-01-01T12:01:01,123+01:00", serializeDateTime(OffsetDateTime.of(2015, 1, 1, 12, 1, 1, 123000000, ZoneOffset.of("+0100"))));
+        assertEquals("2015-01-01T12:01:01,123-02:00", serializeDateTime(OffsetDateTime.of(2015, 1, 1, 12, 1, 1, 123000000, ZoneOffset.of("-0200"))));
+        assertEquals("2015-01-01T12:01:01Z", serializeDateTime(OffsetDateTime.of(2015, 1, 1, 12, 1, 1, 0, ZoneOffset.of("Z"))));
+        assertEquals("2015-01-01T12:01:01,123Z", serializeDateTime(OffsetDateTime.of(2015, 1, 1, 12, 1, 1, 123000000, ZoneOffset.of("Z"))));
+        assertEquals("2015-12-02T17:41:56,809Z", serializeDateTime(OffsetDateTime.of(2015, 12, 02, 17, 41, 56, 809000000, ZoneOffset.of("Z"))));
+        assertEquals("2019-01-14T18:36:49,294666Z", serializeDateTime(OffsetDateTime.of(2019, 01, 14, 18, 36, 49, 294666666, ZoneOffset.of("Z"))));
+    }
+
+    @Test
+    public void serializeYear() {
+        assertEquals("2015", serializeDate(Year.of(2015)));
+    }
+
+    @Test
+    public void serializeYearMonth() {
+        assertEquals("2015-01", serializeDate(YearMonth.of(2015, 1)));
+    }
+
+    private String serializeDate(TemporalAccessor value) {
+        return DateTimeSerializerFormatters.ISO_8601_DATE.format(value);
+    }
+
+    private String serializeDateTime(TemporalAccessor value) {
+        return DateTimeSerializerFormatters.ISO_8601_DATE_TIME.format(value);
+    }
+}


### PR DESCRIPTION
This PR depends on #129 and is not fully backwards compatible.

Clean up DateTimeFormatters class

* Reorder formatters to allow reuse
* Combined ISO_8601_DATE_TIME, ISO_8601_DATE_TIME_WITH_OPTIONAL_MICROS and ISO_8601_DATE_TIME_WITHOUT_MICROS to new ISO_8601_DATE_TIME which allows optional microseconds.
* Consistent code formatting