### PR TITLE
Cast rules to for all statements

### DIFF
--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -169,7 +169,7 @@ public class Flattener implements IAttributeFlattenerSupport {
             prohibitZeroOccurrencesConstraints(result);
         }
 
-        rulesFlattener.combineRules(child, result, "prefix", "", "", true /* override statements with same tag */);//TODO: actually set a unique prefix
+        rulesFlattener.combineRules(child, result, "", "", "", true /* override statements with same tag */);//TODO: actually set a unique prefix
         if(createOperationalTemplate) {
             optCreator.fillSlots((OperationalTemplate) result);
 

--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -169,7 +169,10 @@ public class Flattener implements IAttributeFlattenerSupport {
             prohibitZeroOccurrencesConstraints(result);
         }
 
-        rulesFlattener.combineRules(child, result, "", "", "", true /* override statements with same tag */);//TODO: actually set a unique prefix
+        String prefix = child.getArchetypeId().getConceptId() + "_";
+        //Use empty tagPrefix here. If not empty, overridden rules in specialized archetype will not overwrite base rules,
+        //but be added to the rules section additionally to the base rules.
+        rulesFlattener.combineRules(child, result, prefix, "", "", true /* override statements with same tag */);
         if(createOperationalTemplate) {
             optCreator.fillSlots((OperationalTemplate) result);
 

--- a/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
@@ -69,17 +69,41 @@ public class RulesFlattener {
         return -1;
     }
 
+
     private void addVariableAndTagPrefix(RuleStatement clonedStatement, String variablePrefix, String tagPrefix, String pathPrefix) {
         if(clonedStatement instanceof Assertion) {
             Assertion assertion = (Assertion) clonedStatement;
             if(!Strings.isNullOrEmpty(assertion.getTag())) {
                 assertion.setTag(tagPrefix + assertion.getTag());
             }
+            if (!(assertion.getExpression() instanceof ForAllStatement)) {
+                setVariableReferencePrefix(assertion.getExpression(),"item");
+                assertion.setExpression(new ForAllStatement("item",new ModelReference(),assertion.getExpression()));
+            }
             addVariableAndTagPrefixToExpression(assertion.getExpression(), variablePrefix, pathPrefix);
         } else if (clonedStatement instanceof ExpressionVariable) {
             ExpressionVariable declaration = (ExpressionVariable) clonedStatement;
             declaration.setName(variablePrefix + declaration.getName());
             addVariableAndTagPrefixToExpression(declaration.getExpression(), variablePrefix, pathPrefix);
+        }
+    }
+
+
+    private void setVariableReferencePrefix(Expression expression, String variablePrefix) {
+        if (expression instanceof  BinaryOperator) {
+            setVariableReferencePrefix(((BinaryOperator) expression).getLeftOperand(),variablePrefix);
+            setVariableReferencePrefix(((BinaryOperator) expression).getRightOperand(),variablePrefix);
+        } else if (expression instanceof UnaryOperator){
+            setVariableReferencePrefix(((UnaryOperator) expression).getOperand(),variablePrefix);
+        } else if (expression instanceof Function) {
+            Function function = (Function) expression;
+            if( function.getArguments() != null ) {
+                for(Expression argument : function.getArguments()) {
+                    setVariableReferencePrefix(argument, variablePrefix);
+                }
+            }
+        } else if (expression instanceof ModelReference) {
+            ((ModelReference) expression).setVariableReferencePrefix(variablePrefix);
         }
     }
 

--- a/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
@@ -77,8 +77,14 @@ public class RulesFlattener {
                 assertion.setTag(tagPrefix + assertion.getTag());
             }
             if (!(assertion.getExpression() instanceof ForAllStatement)) {
-                setVariableReferencePrefix(assertion.getExpression(),"item");
-                assertion.setExpression(new ForAllStatement("item",new ModelReference(""),assertion.getExpression()));
+                //Cast expression to ForAllStatement. The variableReferencePrefix is set for all operands within this
+                //expression so that they are recognized as operands of a ForAllStatement, i.e. the prefix will be used
+                //instead of the full path within the flattened rule section. Note that the prefix "item" is
+                //concatenated with a unique variablePrefix within addVariableAndTagPrefixToExpression. Furthermore,
+                //note that the ForAllStatement is constructed with an empty path as the pathPrefix is set within
+                //addVariableAndTagPrefixToExpression.
+                setVariableReferencePrefix(assertion.getExpression(), "item");
+                assertion.setExpression(new ForAllStatement("item", new ModelReference(""), assertion.getExpression()));
             }
             addVariableAndTagPrefixToExpression(assertion.getExpression(), variablePrefix, pathPrefix);
         } else if (clonedStatement instanceof ExpressionVariable) {
@@ -91,10 +97,10 @@ public class RulesFlattener {
 
     private void setVariableReferencePrefix(Expression expression, String variablePrefix) {
         if (expression instanceof  BinaryOperator) {
-            setVariableReferencePrefix(((BinaryOperator) expression).getLeftOperand(),variablePrefix);
-            setVariableReferencePrefix(((BinaryOperator) expression).getRightOperand(),variablePrefix);
+            setVariableReferencePrefix(((BinaryOperator) expression).getLeftOperand(), variablePrefix);
+            setVariableReferencePrefix(((BinaryOperator) expression).getRightOperand(), variablePrefix);
         } else if (expression instanceof UnaryOperator){
-            setVariableReferencePrefix(((UnaryOperator) expression).getOperand(),variablePrefix);
+            setVariableReferencePrefix(((UnaryOperator) expression).getOperand(), variablePrefix);
         } else if (expression instanceof Function) {
             Function function = (Function) expression;
             if( function.getArguments() != null ) {

--- a/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
@@ -78,7 +78,7 @@ public class RulesFlattener {
             }
             if (!(assertion.getExpression() instanceof ForAllStatement)) {
                 setVariableReferencePrefix(assertion.getExpression(),"item");
-                assertion.setExpression(new ForAllStatement("item",new ModelReference(),assertion.getExpression()));
+                assertion.setExpression(new ForAllStatement("item",new ModelReference(""),assertion.getExpression()));
             }
             addVariableAndTagPrefixToExpression(assertion.getExpression(), variablePrefix, pathPrefix);
         } else if (clonedStatement instanceof ExpressionVariable) {

--- a/tools/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
@@ -60,7 +60,7 @@ public class RulesFlattenerTest {
         assertEquals("diastolic", diastolic.getName());
         assertEquals("blood_pressure", bloodPressure.getTag());
         assertEquals("flattened_path_arguments", flattenedPathArguments.getName());
-        assertEquals(BinaryOperator.class, biggerThan90.getExpression().getClass());
+        assertEquals(ForAllStatement.class, biggerThan90.getExpression().getClass());
     }
 
     @Test
@@ -79,10 +79,10 @@ public class RulesFlattenerTest {
         assertEquals("specialized_rules_systolic", systolic.getName());
         assertEquals("specialized_rules_diastolic", diastolic.getName());
         assertEquals("specialized_rules_blood_pressure", bloodPressure.getTag());
-        assertEquals(BinaryOperator.class, biggerThan90.getExpression().getClass());
+        assertEquals(ForAllStatement.class, biggerThan90.getExpression().getClass());
         assertEquals("/content[id5]/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", ((ModelReference) ((Function) flattenedPathArguments.getExpression()).getArguments().get(0)).getPath());
         assertEquals("/content[id5]/data[id2]/events[id3]/data[id4]/items[id6]/value/magnitude", ((ModelReference) ((Function) flattenedPathArguments.getExpression()).getArguments().get(1)).getPath());
-        assertEquals("/content[id5]/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", ((ModelReference)((BinaryOperator)biggerThan90.getExpression()).getLeftOperand()).getPath());
+        assertEquals("/content[id5]", ((ModelReference)((ForAllStatement)biggerThan90.getExpression()).getLeftOperand()).getPath());
 
         //test that we can actually parse the output
         ADLParser parser = new ADLParser();


### PR DESCRIPTION
All Rules are casted to ForAllStatements. This allows to evaluate the same rule for multiple Clusters within a flattened archetype.