### PR TITLE
Remove redundant throws clause

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
@@ -70,7 +70,7 @@ public class ADLParser {
         this.modelConstraintImposer = null;
     }
 
-    public Archetype parse(String adl) throws IOException {
+    public Archetype parse(String adl) {
         return parse(CharStreams.fromString(adl));
     }
 


### PR DESCRIPTION
Remove redundant throws clause in ADLParser.parse(String). IOException is never thrown in the method.