### PR TITLE
Jackson 2.10

### DIFF
--- a/archie-utils/src/main/java/com/nedap/archie/json/JacksonUtil.java
+++ b/archie-utils/src/main/java/com/nedap/archie/json/JacksonUtil.java
@@ -93,6 +93,7 @@ public class JacksonUtil {
         objectMapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
         objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);

--- a/archie-utils/src/main/java/com/nedap/archie/json/JacksonUtil.java
+++ b/archie-utils/src/main/java/com/nedap/archie/json/JacksonUtil.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.nedap.archie.aom.ResourceDescription;
@@ -154,7 +155,8 @@ public class JacksonUtil {
         private Set<Class> classesToNotAddTypeProperty;
         public ArchieTypeResolverBuilder(RMJacksonConfiguration configuration)
         {
-            super(ObjectMapper.DefaultTyping.NON_FINAL);
+            super(ObjectMapper.DefaultTyping.NON_FINAL, BasicPolymorphicTypeValidator.builder()
+                    .allowIfBaseType(OpenEHRBase.class).build());
             classesToNotAddTypeProperty = new HashSet<>();
             if(!configuration.isAlwaysIncludeTypeProperty()) {
                 List<RMTypeInfo> allTypes = ArchieRMInfoLookup.getInstance().getAllTypes();

--- a/bmm/src/main/java/org/openehr/bmm/v2/persistence/jackson/BmmJacksonUtil.java
+++ b/bmm/src/main/java/org/openehr/bmm/v2/persistence/jackson/BmmJacksonUtil.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.nedap.archie.base.OpenEHRBase;
 
@@ -75,7 +76,7 @@ public class BmmJacksonUtil {
      */
     static class BmmTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
         public BmmTypeResolverBuilder() {
-            super(ObjectMapper.DefaultTyping.NON_FINAL);
+            super(ObjectMapper.DefaultTyping.NON_FINAL, BasicPolymorphicTypeValidator.builder().allowIfBaseType(OpenEHRBase.class).build());
         }
 
         @Override

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ subprojects {
   }
 
   ext.reflectionsVersion = '0.9.11'
-  ext.jacksonVersion = '2.9.10'
+  ext.jacksonVersion = '2.10.2'
 
   dependencies {
     compile 'org.slf4j:slf4j-api:1.7.28'

--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -66,7 +66,9 @@ public class Flattener implements IAttributeFlattenerSupport {
      */
     public Flattener createOperationalTemplate(boolean makeTemplate) {
         config.setCreateOperationalTemplate(makeTemplate);
-        config.setRemoveZeroOccurrencesObjects(true);
+        if(makeTemplate) {
+            config.setRemoveZeroOccurrencesObjects(true);
+        }
         return this;
     }
 

--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -66,6 +66,7 @@ public class Flattener implements IAttributeFlattenerSupport {
      */
     public Flattener createOperationalTemplate(boolean makeTemplate) {
         config.setCreateOperationalTemplate(makeTemplate);
+        config.setRemoveZeroOccurrencesObjects(true);
         return this;
     }
 
@@ -166,7 +167,7 @@ public class Flattener implements IAttributeFlattenerSupport {
         //1. redefine structure
         //2. fill archetype slots if we are creating an operational template
         flattenDefinition(result, child);
-        if(config.isCreateOperationalTemplate()) {
+        if(config.isCreateOperationalTemplate() && config.isRemoveZeroOccurrencesObjects()) {
             optCreator.removeZeroOccurrencesConstraints(result);
         } else {
             prohibitZeroOccurrencesConstraints(result);

--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -141,7 +141,7 @@ public class Flattener implements IAttributeFlattenerSupport {
 
         if(parent.getParentArchetypeId() != null) {
             //parent needs flattening first
-            parent = getNewFlattener().flatten(parent);
+            parent = getNewFlattenerForParent().flatten(parent);
         }
 
 
@@ -380,7 +380,13 @@ public class Flattener implements IAttributeFlattenerSupport {
         }
     }
 
-    protected Flattener getNewFlattener() {
+    /**
+     * Get a new flattener to flatten parent archetypes. Works the same as {@link #getNewFlattener()}, except that
+     * it will remove zero occurrences constraints in parents if so configured.
+     *
+     * @return
+     */
+    protected Flattener getNewFlattenerForParent() {
         Flattener result = new Flattener(repository, metaModels, config)
                 .createOperationalTemplate(false); //do not create operational template except at the end.
         if(config.isRemoveZeroOccurrencesInParents()) {
@@ -389,6 +395,18 @@ public class Flattener implements IAttributeFlattenerSupport {
             result.removeZeroOccurrencesConstraints(true);
         }
         return result;
+    }
+
+    /**
+     * Get a new flattener with the same configuration as this, except that it will not create operational templates
+     * <br/>
+     * The not creating operational templates is because the operational template creator needs to be done only for the
+     * final result, not the intermediate steps
+     * @return
+     */
+    protected Flattener getNewFlattener() {
+        return new Flattener(repository, metaModels, config)
+                .createOperationalTemplate(false); //do not create operational template except at the end.
     }
 
     private Flattener useComplexObjectForArchetypeSlotReplacement(boolean useComplexObjectForArchetypeSlotReplacement) {

--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -1,13 +1,66 @@
 package com.nedap.archie.flattener;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.nedap.archie.util.KryoUtil;
+
 public class FlattenerConfiguration {
 
+    /**
+     * If true, create an operational template
+     * default false
+     */
     private boolean createOperationalTemplate = false;
-    private boolean removeLanguagesFromMetaData = false;
+    /**
+     * If true, replaces the archetype root with a C_COMPLEX_OBJECT with the archetype_ref set
+     * If false, leaves the ArchetypeRoot in place, with the children as attributes, since archetype root itself is a C_COMPLEX_OBJECT
+     * Default false
+     */
     private boolean useComplexObjectForArchetypeSlotReplacement = false;
+    /**
+     * Remove all zero occurrences objects. Default false, except for OperationalTemplates
+     */
     private boolean removeZeroOccurrencesObjects = false;
+    /**
+     * Remove zero occurrences objects in parents. Useful for modeling tools, where you cannot undo a zero occurrences if it's defined in a parent, so don't need to know
+     */
+    private boolean removeZeroOccurrencesInParents = false;
 
+
+    /**
+     * Set to true to remove languages from the metadata and translations. Only for operational templates. Default false
+     */
+    private boolean removeLanguagesFromMetaData = false;
+    /**
+     * The languages to not remove. Only works when removeLanguagesFromMetadata=true && createOperationalTemplate == true
+     */
     private String[] languagesToKeep = null;
+
+    /**
+     * Only for Operational templates: replace the use node constructs with their replacements. Default true.
+     */
+    private boolean replaceUseNode = true;
+
+    /**
+     * Only for Operational templates: replace the archetype roots with the corresponding structure. Defaults to true
+     */
+    private boolean fillArchetypeRoots = true;
+    /**
+     * Only for Operational templates: remove any closed archetype slots from the archetype.
+     */
+    private boolean closeArchetypeSlots = true;
+
+    public static FlattenerConfiguration forFlattened() {
+        return new FlattenerConfiguration();
+    }
+
+    public static FlattenerConfiguration forOperationalTemplate() {
+        FlattenerConfiguration result = new FlattenerConfiguration();
+        result.setCreateOperationalTemplate(true);
+        result.setRemoveZeroOccurrencesObjects(true);
+        return result;
+    }
+
+
 
     public boolean isCreateOperationalTemplate() {
         return createOperationalTemplate;
@@ -50,12 +103,44 @@ public class FlattenerConfiguration {
     }
 
     public FlattenerConfiguration clone() {
-        FlattenerConfiguration cloned = new FlattenerConfiguration();
-        cloned.setCreateOperationalTemplate(createOperationalTemplate);
-        cloned.setRemoveLanguagesFromMetaData(removeLanguagesFromMetaData);
-        cloned.setUseComplexObjectForArchetypeSlotReplacement(useComplexObjectForArchetypeSlotReplacement);
-        cloned.setRemoveZeroOccurrencesObjects(removeZeroOccurrencesObjects);
-        cloned.setLanguagesToKeep(languagesToKeep.clone());
-        return cloned;
+        Kryo kryo = null;
+        try {
+            kryo = KryoUtil.getPool().borrow();
+            return kryo.copy(this);
+        } finally {
+            KryoUtil.getPool().release(kryo);
+        }
+    }
+
+    public boolean isReplaceUseNode() {
+        return replaceUseNode;
+    }
+
+    public void setReplaceUseNode(boolean replaceUseNode) {
+        this.replaceUseNode = replaceUseNode;
+    }
+
+    public boolean isFillArchetypeRoots() {
+        return fillArchetypeRoots;
+    }
+
+    public void setFillArchetypeRoots(boolean fillArchetypeRoots) {
+        this.fillArchetypeRoots = fillArchetypeRoots;
+    }
+
+    public boolean isCloseArchetypeSlots() {
+        return closeArchetypeSlots;
+    }
+
+    public void setCloseArchetypeSlots(boolean closeArchetypeSlots) {
+        this.closeArchetypeSlots = closeArchetypeSlots;
+    }
+
+    public boolean isRemoveZeroOccurrencesInParents() {
+        return removeZeroOccurrencesInParents;
+    }
+
+    public void setRemoveZeroOccurrencesInParents(boolean removeZeroOccurrencesInParents) {
+        this.removeZeroOccurrencesInParents = removeZeroOccurrencesInParents;
     }
 }

--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -21,11 +21,9 @@ public class FlattenerConfiguration {
      */
     private boolean removeZeroOccurrencesObjects = false;
     /**
-     * Remove zero occurrences objects in parents. Useful for modeling tools, where you cannot undo a zero occurrences if it's defined in a parent, so don't need to know
+     * Remove zero occurrences objects in parents. Useful for modeling tools, where you cannot undo a zero occurrences if it's defined in a parent, so don't need to know that it exists
      */
     private boolean removeZeroOccurrencesInParents = false;
-
-
     /**
      * Set to true to remove languages from the metadata and translations. Only for operational templates. Default false
      */

--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -17,7 +17,7 @@ public class FlattenerConfiguration {
      */
     private boolean useComplexObjectForArchetypeSlotReplacement = false;
     /**
-     * Remove all zero occurrences objects. Default false, except for OperationalTemplates
+     * Remove all zero occurrences objects. Default false, except for OperationalTemplates, where it is default true.
      */
     private boolean removeZeroOccurrencesObjects = false;
     /**
@@ -46,6 +46,10 @@ public class FlattenerConfiguration {
      * Only for Operational templates: remove any closed archetype slots from the archetype.
      */
     private boolean closeArchetypeSlots = true;
+
+    private FlattenerConfiguration() {
+
+    }
 
     public static FlattenerConfiguration forFlattened() {
         return new FlattenerConfiguration();

--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -1,0 +1,61 @@
+package com.nedap.archie.flattener;
+
+public class FlattenerConfiguration {
+
+    private boolean createOperationalTemplate = false;
+    private boolean removeLanguagesFromMetaData = false;
+    private boolean useComplexObjectForArchetypeSlotReplacement = false;
+    private boolean removeZeroOccurrencesObjects = false;
+
+    private String[] languagesToKeep = null;
+
+    public boolean isCreateOperationalTemplate() {
+        return createOperationalTemplate;
+    }
+
+    public void setCreateOperationalTemplate(boolean createOperationalTemplate) {
+        this.createOperationalTemplate = createOperationalTemplate;
+    }
+
+    public boolean isRemoveLanguagesFromMetaData() {
+        return removeLanguagesFromMetaData;
+    }
+
+    public void setRemoveLanguagesFromMetaData(boolean removeLanguagesFromMetaData) {
+        this.removeLanguagesFromMetaData = removeLanguagesFromMetaData;
+    }
+
+    public boolean isUseComplexObjectForArchetypeSlotReplacement() {
+        return useComplexObjectForArchetypeSlotReplacement;
+    }
+
+    public void setUseComplexObjectForArchetypeSlotReplacement(boolean useComplexObjectForArchetypeSlotReplacement) {
+        this.useComplexObjectForArchetypeSlotReplacement = useComplexObjectForArchetypeSlotReplacement;
+    }
+
+    public boolean isRemoveZeroOccurrencesObjects() {
+        return removeZeroOccurrencesObjects;
+    }
+
+    public void setRemoveZeroOccurrencesObjects(boolean removeZeroOccurrencesObjects) {
+        this.removeZeroOccurrencesObjects = removeZeroOccurrencesObjects;
+    }
+
+    public String[] getLanguagesToKeep() {
+        return languagesToKeep;
+    }
+
+    public void setLanguagesToKeep(String[] languagesToKeep) {
+        this.languagesToKeep = languagesToKeep;
+    }
+
+    public FlattenerConfiguration clone() {
+        FlattenerConfiguration cloned = new FlattenerConfiguration();
+        cloned.setCreateOperationalTemplate(createOperationalTemplate);
+        cloned.setRemoveLanguagesFromMetaData(removeLanguagesFromMetaData);
+        cloned.setUseComplexObjectForArchetypeSlotReplacement(useComplexObjectForArchetypeSlotReplacement);
+        cloned.setRemoveZeroOccurrencesObjects(removeZeroOccurrencesObjects);
+        cloned.setLanguagesToKeep(languagesToKeep.clone());
+        return cloned;
+    }
+}

--- a/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
@@ -83,6 +83,9 @@ class OperationalTemplateCreator {
 
 
     private void closeArchetypeSlots(OperationalTemplate archetype) {
+        if(!getConfig().isCloseArchetypeSlots()) {
+            return;
+        }
         Stack<CObject> workList = new Stack<>();
         workList.push(archetype.getDefinition());
         while(!workList.isEmpty()) {
@@ -103,7 +106,9 @@ class OperationalTemplateCreator {
     }
 
     private void fillArchetypeRoots(OperationalTemplate result) {
-
+        if(!getConfig().isFillArchetypeRoots()) {
+            return;
+        }
         Stack<CObject> workList = new Stack<>();
         workList.push(result.getDefinition());
         while(!workList.isEmpty()) {
@@ -120,7 +125,9 @@ class OperationalTemplateCreator {
     }
 
     private void fillComplexObjectProxies(OperationalTemplate result) {
-
+        if(!getConfig().isReplaceUseNode()) {
+            return;
+        }
         Stack<CObject> workList = new Stack<>();
         workList.push(result.getDefinition());
         List<ComplexObjectProxyReplacement> replacements = new ArrayList<>();
@@ -210,6 +217,10 @@ class OperationalTemplateCreator {
             //templateResult.addTerminologyExtract(child.getNodeId(), archetype.getTerminology().);
         }
 
+    }
+
+    private FlattenerConfiguration getConfig() {
+        return flattener.getConfiguration();
     }
 
 

--- a/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
@@ -50,6 +50,7 @@ class OperationalTemplateCreator {
     }
 
     public void fillSlots(OperationalTemplate archetype) { //should this be OperationalTemplate?
+        //TODO: closing archetype slots should be moved to AFTER including other archetypes
         closeArchetypeSlots(archetype);
         fillArchetypeRoots(archetype);
         fillComplexObjectProxies(archetype);

--- a/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
@@ -60,11 +60,11 @@ class OperationalTemplateCreator {
     public void removeZeroOccurrencesConstraints(Archetype archetype) {
         Stack<CObject> workList = new Stack<>();
         workList.push(archetype.getDefinition());
-        while(!workList.isEmpty()) {
+        while (!workList.isEmpty()) {
             CObject object = workList.pop();
             List<CAttribute> attributesToRemove = new ArrayList<>();
-            for(CAttribute attribute:object.getAttributes()) {
-                if(attribute.getExistence() != null && attribute.getExistence().getUpper() == 0 && !attribute.getExistence().isUpperUnbounded()) {
+            for (CAttribute attribute : object.getAttributes()) {
+                if (attribute.getExistence() != null && attribute.getExistence().getUpper() == 0 && !attribute.getExistence().isUpperUnbounded()) {
                     attributesToRemove.add(attribute);
                 } else {
                     List<CObject> objectsToRemove = new ArrayList<>();


### PR DESCRIPTION
switches to jackson version 2.10. 
Updates type resolver builder to use the new PolymorphicTypeValidator, to only accept OpenEHRBase descendants for AOM, RM and BMM classes. And that just works!

Also includes changes from the flexible_flattener branch, but that should be merged very soon