### PR TITLE
Fix casting bug in Round

### DIFF
--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/functions/Round.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/functions/Round.java
@@ -33,7 +33,7 @@ public class Round implements FunctionImplementation {
         result.setType(PrimitiveType.Integer);
 
         for(Value valueObject : arguments.get(0).getValues()) {
-            result.addValue(new Value(Math.round(Double.parseDouble(valueObject.getValue().toString()))));
+            result.addValue(new Value(Math.round(((Number) valueObject.getValue()).doubleValue())));
         }
 
         return result;

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/functions/Round.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/functions/Round.java
@@ -33,7 +33,7 @@ public class Round implements FunctionImplementation {
         result.setType(PrimitiveType.Integer);
 
         for(Value valueObject : arguments.get(0).getValues()) {
-            result.addValue(new Value(Math.round((Double) valueObject.getValue())));
+            result.addValue(new Value(Math.round(Double.parseDouble(valueObject.getValue().toString()))));
         }
 
         return result;

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FunctionsTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FunctionsTest.java
@@ -163,8 +163,10 @@ public class FunctionsTest {
         ruleEvaluation.evaluate(root, archetype.getRules().getRules());
         ValueList roundedUp = ruleEvaluation.getVariableMap().get("round_up");
         ValueList roundedDown = ruleEvaluation.getVariableMap().get("round_down");
+        ValueList roundedNonDecimal = ruleEvaluation.getVariableMap().get("round_non_decimal");
         assertEquals("round should round up", 2L, (long) roundedUp.getValues().get(0).getValue());
         assertEquals("round should round down", 1L, (long) roundedDown.getValues().get(0).getValue());
+        assertEquals("round non-decimal should also work", 3L, (long) roundedNonDecimal.getValues().get(0).getValue());
     }
 
     @Test

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/functions.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/functions.adls
@@ -83,6 +83,7 @@ rules
 
     $round_up:Integer ::= round(3.0 / 2.0)
     $round_down:Integer ::= round(4.0 / 3.0)
+    $round_non_decimal:Integer ::= round(3)
     $round_multiple:Integer ::= round(/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude)
 
     $ceil_path:Integer ::= ceil(/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude / 2.0)


### PR DESCRIPTION
If the valueObject.getValue() was a Long, it would throw an error.

Changed the casting to the number being parsed from a String