### PR TITLE
Fill empty occurrences in OPT creator - configurable of course

### DIFF
--- a/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/Flattener.java
@@ -115,6 +115,7 @@ public class Flattener implements IAttributeFlattenerSupport {
                 result = template;
                 //make an operational template by just filling complex object proxies and archetype slots
                 optCreator.fillSlots(template);
+                fillOptEmptyOccurrences(result);
                 TerminologyFlattener.filterLanguages(template, config.isRemoveLanguagesFromMetaData(), config.getLanguagesToKeep());
                 result = template;
             } else {
@@ -169,6 +170,7 @@ public class Flattener implements IAttributeFlattenerSupport {
         //1. redefine structure
         //2. fill archetype slots if we are creating an operational template
         flattenDefinition(result, child);
+
         if(config.isCreateOperationalTemplate() && config.isRemoveZeroOccurrencesObjects()) {
             optCreator.removeZeroOccurrencesConstraints(result);
         } else {
@@ -183,6 +185,7 @@ public class Flattener implements IAttributeFlattenerSupport {
             optCreator.fillSlots((OperationalTemplate) result);
 
         }
+        fillOptEmptyOccurrences(result);
         TerminologyFlattener.flattenTerminology(result, child);
 
         if(config.isCreateOperationalTemplate()) {
@@ -225,6 +228,12 @@ public class Flattener implements IAttributeFlattenerSupport {
                 .setSingleOrMultiple(result.getDefinition());
 
         return result;
+    }
+
+    private void fillOptEmptyOccurrences(Archetype result) {
+        if(config.isCreateOperationalTemplate() && config.isFillEmptyOccurrences()) {
+            optCreator.fillEmptyOccurrences(result);
+        }
     }
 
     /** Zero occurrences and existence constraint processing when flattening. Does not remove attributes*/

--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -47,6 +47,11 @@ public class FlattenerConfiguration {
      */
     private boolean closeArchetypeSlots = true;
 
+    /**
+     * Only for Operational templates: replace any empty occurrences with effectiveOccurrences.
+     */
+    private boolean fillEmptyOccurrences = true;
+
     private FlattenerConfiguration() {
 
     }
@@ -144,5 +149,13 @@ public class FlattenerConfiguration {
 
     public void setRemoveZeroOccurrencesInParents(boolean removeZeroOccurrencesInParents) {
         this.removeZeroOccurrencesInParents = removeZeroOccurrencesInParents;
+    }
+
+    public boolean isFillEmptyOccurrences() {
+        return fillEmptyOccurrences;
+    }
+
+    public void setFillEmptyOccurrences(boolean fillEmptyOccurrences) {
+        this.fillEmptyOccurrences = fillEmptyOccurrences;
     }
 }

--- a/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
@@ -82,6 +82,25 @@ class OperationalTemplateCreator {
         }
     }
 
+    /** Zero occurrences and existence constraint processing when creating OPT templates. Removes attributes */
+    public void fillEmptyOccurrences(Archetype archetype) {
+        Stack<CObject> workList = new Stack<>();
+        workList.push(archetype.getDefinition());
+        while (!workList.isEmpty()) {
+            CObject object = workList.pop();
+            if( (object instanceof CComplexObject || object instanceof ArchetypeSlot || object instanceof CComplexObjectProxy)
+                    && object.getOccurrences() == null) {
+                object.setOccurrences(object.effectiveOccurrences(flattener.getMetaModels()::referenceModelPropMultiplicity));
+            }
+            for (CAttribute attribute : object.getAttributes()) {
+
+                for (CObject child : attribute.getChildren()) {
+                    workList.push(child);
+                }
+            }
+        }
+    }
+
 
     private void closeArchetypeSlots(OperationalTemplate archetype) {
         if(!getConfig().isCloseArchetypeSlots()) {

--- a/tools/src/test/java/com/nedap/archie/flattener/OperationalTemplateCreatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/OperationalTemplateCreatorTest.java
@@ -1,0 +1,71 @@
+package com.nedap.archie.flattener;
+
+import com.google.common.collect.Lists;
+import com.nedap.archie.adlparser.ADLParser;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CAttribute;
+import com.nedap.archie.aom.CComplexObject;
+import com.nedap.archie.aom.CObject;
+import com.nedap.archie.aom.OperationalTemplate;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import javax.json.JsonPatch;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Stack;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class OperationalTemplateCreatorTest {
+
+    @Test
+    public void fillEmptyOccurrences() throws Exception {
+        try(InputStream stream = getClass().getResourceAsStream("openEHR-EHR-CLUSTER.cluster_with_annotations.v1.adls")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModels()).parse(stream);
+            Flattener flattener = new Flattener(new SimpleArchetypeRepository(), BuiltinReferenceModels.getMetaModels(), FlattenerConfiguration.forOperationalTemplate());
+            OperationalTemplate template = (OperationalTemplate) flattener.flatten(archetype);
+
+            Stack<CObject> workList = new Stack<>();
+            workList.push(template.getDefinition());
+            while(!workList.isEmpty()) {
+                CObject cObject = workList.pop();
+                if(cObject instanceof CComplexObject) {
+                    assertNotNull(cObject.getOccurrences());
+                    CObject objectInOriginal = archetype.itemAtPath(cObject.getPath());
+                    assertEquals(objectInOriginal.effectiveOccurrences(ArchieRMInfoLookup.getInstance()::referenceModelPropMultiplicity), cObject.getOccurrences());
+                }
+                for(CAttribute attribute:cObject.getAttributes()) {
+                    workList.addAll(attribute.getChildren());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void dontFillEmptyOccurrencesUnlessSet() throws Exception {
+        try(InputStream stream = getClass().getResourceAsStream("openEHR-EHR-CLUSTER.cluster_with_annotations.v1.adls")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModels()).parse(stream);
+            FlattenerConfiguration flattenerConfiguration = FlattenerConfiguration.forOperationalTemplate();
+            flattenerConfiguration.setFillEmptyOccurrences(false);
+            Flattener flattener = new Flattener(new SimpleArchetypeRepository(), BuiltinReferenceModels.getMetaModels(), flattenerConfiguration);
+            OperationalTemplate template = (OperationalTemplate) flattener.flatten(archetype);
+
+            Stack<CObject> workList = new Stack<>();
+            workList.push(template.getDefinition());
+            while(!workList.isEmpty()) {
+                CObject cObject = workList.pop();
+                if(cObject instanceof CComplexObject) {
+                    //this archetype has no occurrences at all
+                    assertNull(cObject.getOccurrences());
+                }
+                for(CAttribute attribute:cObject.getAttributes()) {
+                    workList.addAll(attribute.getChildren());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# BREAKING CHANGE ALERT

currently in Archie in the OPT occurrences is not automatically filled. This is much better if it is, so implementations do not have to use effectiveOccurrences() - which is much more tricky, especially if serialized to JSON first.

So, this PR adds this. It's configurable through the FlattenerConfiguration. It is enabled by default, as it should be. That means that every user of the Flattener that does not want this, should disable it again. And probably move to a situation where they can enable it again in the future later on :)