### PR TITLE
Fix bug where wrong term is returned for a C_ARCHETYPE-ROOT with miss…

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/OperationalTemplate.java
+++ b/aom/src/main/java/com/nedap/archie/aom/OperationalTemplate.java
@@ -60,6 +60,7 @@ public class OperationalTemplate extends AuthoredArchetype {
      * Get the last used archetype reference in the path of the given cObject.
      * If stripLastPartOfPath == true, ignore the last pathsegment, usable for finding
      * the id code of an archetype root
+     * Returns null if the root archetype is found.
      * @param object
      * @param stripLastPartOfPath
      * @return
@@ -73,6 +74,9 @@ public class OperationalTemplate extends AuthoredArchetype {
             //the first path segment can point to a archetype root. We do not want to include that
             //but need the path from the parent archetype
             pathSegments = pathSegments.subList(1, pathSegments.size());
+        } else if (stripLastPartOfPath) {
+            //points to the root node
+            return null;
         }
         for(PathSegment segment:pathSegments) {
             if(segment.hasArchetypeRef()) {
@@ -114,7 +118,6 @@ public class OperationalTemplate extends AuthoredArchetype {
             ArchetypeTerminology terminology = getComponentTerminologies().get(archetypeId);
             if(terminology != null) {
                 return terminology.getTermDefinition(language, code);
-                return term;
             } else {
                 //TODO: check if we should do this or just return null
                 throw new IllegalStateException("Expected an archetype terminology for archetype id " + archetypeId);

--- a/aom/src/main/java/com/nedap/archie/aom/OperationalTemplate.java
+++ b/aom/src/main/java/com/nedap/archie/aom/OperationalTemplate.java
@@ -60,6 +60,11 @@ public class OperationalTemplate extends AuthoredArchetype {
         //getting the entire path
         List<PathSegment> pathSegments = object.getPathSegments();
         Collections.reverse(pathSegments);
+        if(pathSegments.size() > 1) {
+            //the first path segment can point to a archetype root. We do not want to include that
+            //but need the path from the parent archetype
+            pathSegments = pathSegments.subList(1, pathSegments.size());
+        }
         for(PathSegment segment:pathSegments) {
             if(segment.hasArchetypeRef()) {
                 //this is [archetypeId] instead of [idcode]
@@ -91,13 +96,6 @@ public class OperationalTemplate extends AuthoredArchetype {
             ArchetypeTerminology terminology = getComponentTerminologies().get(archetypeId);
             if(terminology != null) {
                 ArchetypeTerm term = terminology.getTermDefinition(language, code);
-                if(term == null && object instanceof CArchetypeRoot) {
-                    if(object.getParent() != null && object.getParent().getParent() != null) {
-                        ArchetypeTerm parentTerm = getTerm(object.getParent().getParent(), code, language);
-                        if(parentTerm != null) return parentTerm;
-                    }
-                    return terminology.getTermDefinition(language, ((CArchetypeRoot) object).getArchetypeRef());
-                }
                 return term;
             } else {
                 //TODO: check if we should do this or just return null

--- a/tools/src/test/java/com/nedap/archie/aom/ArchetypeTerminologyTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/ArchetypeTerminologyTest.java
@@ -1,0 +1,59 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.ArchieLanguageConfiguration;
+import com.nedap.archie.archetypevalidator.ValidationResult;
+import com.nedap.archie.flattener.Flattener;
+import com.nedap.archie.flattener.FlattenerConfiguration;
+import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
+import com.nedap.archie.flattener.specexamples.FlattenerTestUtil;
+import org.junit.After;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ArchetypeTerminologyTest {
+
+    @After
+    public void tearDown() {
+        ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage(null);
+    }
+    
+    @Test
+    public void termForUseArchetype() throws IOException {
+        //getting the term for a use archetype is a bit of a tricky situation - it's not for the 'id1' code,
+        //it's for the code in the parent. So do some specific test here
+        InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
+        repository.addArchetype(FlattenerTestUtil.parse("/com/nedap/archie/aom/openEHR-EHR-COMPOSITION.parent.v1.0.0.adls"));
+        repository.addArchetype(FlattenerTestUtil.parse("/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls"));
+
+        //check that they are valid, just to be sure
+        repository.compile(BuiltinReferenceModels.getMetaModels());
+        repository.getAllValidationResults().forEach(s -> assertTrue(s.getErrors().toString(), s.getErrors().isEmpty()));
+
+        //create operational template
+        Flattener flattener = new Flattener(repository, BuiltinReferenceModels.getMetaModels(), FlattenerConfiguration.forOperationalTemplate());
+        OperationalTemplate opt = (OperationalTemplate) flattener.flatten(repository.getArchetype("openEHR-EHR-COMPOSITION.parent.v1.0.0"));
+
+        //and check the getTerm() functionality
+        CArchetypeRoot useArchetype = opt.itemAtPath("/content[id2]");
+        ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("nl");
+        assertEquals("included archetype nl", useArchetype.getTerm().getText());
+        ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("en");
+        assertEquals("included archetype en", useArchetype.getTerm().getText());
+
+        //now to check if it uses the component terminology where possible
+        CComplexObject element = opt.itemAtPath("/content[id2]/data[id3]/items[id2]");
+        ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("nl");
+        assertEquals("an element", element.getTerm().getText()); //no dutch translation, should fallback to English
+        ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("en");
+        assertEquals("an element", element.getTerm().getText());
+
+
+    }
+    
+    
+}

--- a/tools/src/test/java/com/nedap/archie/json/JacksonRMRoundTripTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/JacksonRMRoundTripTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertThat;
  *
  * Created by pieter.bos on 30/06/16.
  */
-public class JacksonRMRoundTripTest {
+public class    JacksonRMRoundTripTest {
 
     private ADLParser parser;
     private Archetype archetype;

--- a/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-COMPOSITION.parent.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-COMPOSITION.parent.v1.0.0.adls
@@ -1,0 +1,55 @@
+archetype (adl_version=2.0.6; rm_release=1.0.4)
+    openEHR-EHR-COMPOSITION.parent.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+        ["nl"] = <
+            language = <[ISO_639-1::nl]>
+        >
+    >
+
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"parent composition archetype for test">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"draft">
+
+
+definition
+	COMPOSITION[id1] matches {
+	    content matches {
+	        use_archetype GENERIC_ENTRY[id2, openEHR-EHR-GENERIC_ENTRY.included.v1]
+	    }
+	}
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"root node en">
+                description = <"root node en">
+            >
+            ["id2"] = <
+                text = <"included archetype en">
+                description = <"included archetype en">
+            >
+        >
+        ["nl"] = <
+            ["id1"] = <
+                text = <"root node nl">
+                description = <"root node nl">
+            >
+             ["id2"] = <
+                text = <"included archetype nl">
+                description = <"rincluded archetype nl">
+            >
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls
@@ -1,0 +1,44 @@
+archetype (adl_version=2.0.6; rm_release=1.0.4)
+    openEHR-EHR-GENERIC_ENTRY.included.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"pto be included generic entry archetype for test">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"draft">
+
+
+definition
+	GENERIC_ENTRY[id1] matches {
+	    data matches {
+	        ITEM_TREE[id3] matches {
+	            items matches {
+	                ELEMENT[id2]
+	            }
+	        }
+	    }
+	}
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"root node generic entry en">
+                description = <"root node generic entry en">
+            >
+            ["id2"] = <
+                text = <"an element">
+                description = <"an element described">
+            >
+        >
+    >


### PR DESCRIPTION
…ing language

to reproduce:
- create composition archetype with two languages, say "en" and "nl", original language "en"
- Create a C_ARCHETYPE root like `use_archetype OBSERVATION[id5, "some_other_archetype"]`, or a cluster, doesn't matter
- some_other_archetype has only one language "en", which is also its original language
- call getTerm on the C_ARCHETYPE_ROOT, with the language "nl"

Result:
- it returns the term from the root node (id1) of the composition archetype, in English.

Expected result:
- the english term from id5 from the root archetype, from the fallback to the original language of CObject.getTerm()

Cause:
OperationalTemplate, line 96, `ArchetypeTerm parentTerm = getTerm(object.getParent().getParent(), code, language);`, gets called recursively until a term is found. 

This fixes that by removing the recursive call with a solution that strips the last part of the path before getting the archetype id that is the direct root of a given node.

One could argue this pattern should not be a valid archetype. However, that would be very inconvenient, since you have to align every translation of every used language. That will not work, so instead just handling this is much better.