### PR TITLE
Remove type parameters from ItemStructure and Cluster

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Cluster.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Cluster.java
@@ -24,35 +24,35 @@ import java.util.Objects;
         "items"
 })
 @XmlRootElement
-public class Cluster<Type extends Item> extends Item {
+public class Cluster extends Item {
 
-    private List<Type> items = new ArrayList<>();
+    private List<Item> items = new ArrayList<>();
 
     public Cluster() {
     }
 
-    public Cluster(String archetypeNodeId, DvText name, List<Type> items) {
+    public Cluster(String archetypeNodeId, DvText name, List<Item> items) {
         super(archetypeNodeId, name);
         setItems(items);
     }
 
-    public Cluster(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, List<Type> items) {
+    public Cluster(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, List<Item> items) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
         setItems(items);
     }
 
-    public List<Type> getItems() {
+    public List<Item> getItems() {
         return items;
     }
 
-    public void setItems(List<Type> items) {
+    public void setItems(List<Item> items) {
         this.items = items;
 
         setThisAsParent(items, "items");
 
     }
 
-    public void addItem(Type item) {
+    public void addItem(Item item) {
         items.add(item);
         setThisAsParent(item, "items");
     }
@@ -62,7 +62,7 @@ public class Cluster<Type extends Item> extends Item {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
-        Cluster<?> cluster = (Cluster<?>) o;
+        Cluster cluster = (Cluster) o;
         return Objects.equals(items, cluster.items);
     }
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemList.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemList.java
@@ -43,6 +43,7 @@ public class ItemList extends ItemStructure {
         setItems(items);
     }
 
+    @Override
     public List<Element> getItems() {
         return items;
     }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemList.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemList.java
@@ -24,7 +24,7 @@ import java.util.Objects;
         "items"
 })
 @XmlRootElement(name = "item_list")
-public class ItemList extends ItemStructure<Element> {
+public class ItemList extends ItemStructure {
 
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 @XmlType(name = "ITEM_SINGLE", propOrder = {
         "item"
 })
-public class ItemSingle extends ItemStructure<Element> {
+public class ItemSingle extends ItemStructure {
 
     private Element item;
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemStructure.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemStructure.java
@@ -19,7 +19,7 @@ import java.util.List;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ITEM_STRUCTURE")
-public abstract class ItemStructure<Type extends Item> extends DataStructure {
+public abstract class ItemStructure extends DataStructure {
 
     public ItemStructure() {
     }
@@ -36,7 +36,7 @@ public abstract class ItemStructure<Type extends Item> extends DataStructure {
      * In the default model it's in the subclasses, but defined here as well because it has a lot of uses
      */
     @RMPropertyIgnore
-    public abstract List<Type> getItems();
+    public abstract List<? extends Item> getItems();
 
 
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemTable.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemTable.java
@@ -25,7 +25,7 @@ import java.util.Objects;
         "rows"
 })
 @XmlRootElement(name = "item_table")
-public class ItemTable extends ItemStructure<Element> {
+public class ItemTable extends ItemStructure {
 
     @Nullable
     private List<Cluster> rows = new ArrayList<>();
@@ -68,9 +68,9 @@ public class ItemTable extends ItemStructure<Element> {
             return null;
         }
         List<Element> result = new ArrayList<>();
-        for (Cluster<Element> row : rows) {
-            for (Element element : row.getItems()) {
-                result.add(element);
+        for (Cluster row : rows) {
+            for (Item element : row.getItems()) {
+                result.add((Element) element);
             }
         }
         return result;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
@@ -24,7 +24,7 @@ import java.util.Objects;
         "items"
 })
 @XmlRootElement(name = "item_tree")
-public class ItemTree extends ItemStructure<Item> {
+public class ItemTree extends ItemStructure {
     @Nullable
     private List<Item> items = new ArrayList<>();
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemTree.java
@@ -41,6 +41,7 @@ public class ItemTree extends ItemStructure {
         setItems(items);
     }
 
+    @Override
     public List<Item> getItems() {
         return items;
     }

--- a/tools/src/test/java/com/nedap/archie/adlparser/RMPathQueryTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/RMPathQueryTest.java
@@ -6,6 +6,7 @@ import com.nedap.archie.query.RMPathQuery;
 import com.nedap.archie.query.RMObjectWithPath;
 import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.composition.Composition;
+import com.nedap.archie.rm.datastructures.ItemTree;
 import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.ModelInfoLookup;
@@ -69,7 +70,8 @@ public class RMPathQueryTest {
         {
             //add another cluster to the RM Object, with the same archetype id (very possible!)
             Composition composition2 = (Composition) testUtil.constructEmptyRMObject(archetype.getDefinition());
-            composition.getContext().getOtherContext().getItems().addAll(composition2.getContext().getOtherContext().getItems());
+            ItemTree otherContext = (ItemTree) composition.getContext().getOtherContext();
+            otherContext.getItems().addAll(composition2.getContext().getOtherContext().getItems());
         }
 
         ModelInfoLookup modelInfoLookup = ArchieRMInfoLookup.getInstance();

--- a/tools/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
+++ b/tools/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
@@ -8,6 +8,7 @@ import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.composition.Composition;
+import com.nedap.archie.rm.datastructures.ItemTree;
 import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.ModelInfoLookup;
@@ -72,7 +73,8 @@ public class RMQueryContextTest {
         {
             //add another cluster to the RM Object, with the same archetype id (very possible!)
             Composition composition2 = (Composition) testUtil.constructEmptyRMObject(archetype.getDefinition());
-            composition.getContext().getOtherContext().getItems().addAll(composition2.getContext().getOtherContext().getItems());
+            ItemTree otherContext = (ItemTree) composition.getContext().getOtherContext();
+            otherContext.getItems().addAll(composition2.getContext().getOtherContext().getItems());
         }
 
         RMQueryContext queryContext = getQueryContext();
@@ -101,7 +103,8 @@ public class RMQueryContextTest {
         {
             //add another cluster to the RM Object, with the same archetype id (very possible!)
             Composition composition2 = (Composition) testUtil.constructEmptyRMObject(archetype.getDefinition());
-            composition.getContext().getOtherContext().getItems().addAll(composition2.getContext().getOtherContext().getItems());
+            ItemTree otherContext = (ItemTree) composition.getContext().getOtherContext();
+            otherContext.getItems().addAll(composition2.getContext().getOtherContext().getItems());
         }
 
         RMQueryContext queryContext = getQueryContext();


### PR DESCRIPTION
Remove the type parameters from ItemStructure and Cluster classes.

### Reasons
#### The type parameters are not in the openEHR specifications
The openEHR specifications for [ITEM_STRUCTURE](https://specifications.openehr.org/releases/RM/latest/data_structures.html#_item_structure_class) and [CLUSTER](https://specifications.openehr.org/releases/RM/latest/data_structures.html#_cluster_class) do not contain type parameters. Archie is deviating from the specification here.

#### Very limited usability
The type parameter for ItemStructure is only used for the `getItems` method. The added benefit of the type parameter is very low. Must use cases still work without the type parameter, e.g. these all still work:

```java
ItemList itemList = new ItemList();
List<Element> elements = itemList.getItems();

ItemSingle itemSingle = new ItemSingle();
List<Element> elements2 = itemList.getItems();

ItemTable itemTable = new ItemTable();
List<Element> elements3 = itemList.getItems();

ItemTree itemTree = new ItemTree();
List<Item> items = itemTree.getItems();
```

The only use case I can think of for the type parameter of Cluster was the list of Clusters in ItemTable. However it was only used internally and not in the public API of this class, resulting in no added benefit.

#### Inconsistent usage in archie
The type parameters are used inconsistently in archie. The type parameters are mostly used in directly related classes, but in other places the type parameters are often left out, resulting in incomplete types such as `History<ItemStructure>` (in Observation). This leads to a lot of "Raw use of paramterized class" warnings in IDEs such as IntelliJ. This PR fixes 132 of those warnings.

#### Unable to use without warnings
Due to the inconsistent usage of the type parameters in archie, it is (as far as I know) impossible to call some of the APIs using these types without compiler warnings or errors.

E.g. it is impossible to call `Observation.setData` without a "Raw use of parameterized class" or "Unchecked assignment" warning.

#### Confusing
Due to the unspecified nature and the inconsistent usage of the type parameters it is unclear for users of archie how the type parameters should be used correctly.

### Drawbacks
#### Backwards incompatible
This is a backwards incompatible change to the API of archie. Users of the library probably need to make some minor modifications to use the new version. This should mostly be limited to the removal of type parameters, a small and easy changes. E.g.:

```diff
-Cluster<Item> cluster;
+Cluster cluster;
```

#### Some unsupported use cases
There might be some unsupported use cases. E.g. this is no longer possible:

```java
ItemStructure<Element> noTree = new ItemSingle(); // or ItemList or ItemTable
List<Element> elements4 = noTree.getItems();
```

However I don't think this is actually used.

### Alternatives:
#### Make usage in archie consistent
An alternative would be making the usage of the type parameters in archie consistent. I don't think this is worth the effort because of the limited usability. This will also make archie further deviate form the openEHR specifications. This change would also be backwards incompatible, possibly requiring even more changes in the programs using archie.

#### Keep current situation
Another possibility is keeping the current situation. I don't think we should want this because of the warnings and confusion it causes.
