### PR TITLE
Fix archetype concept ID parsing

### DIFF
--- a/grammars/src/main/antlr/BaseLexer.g4
+++ b/grammars/src/main/antlr/BaseLexer.g4
@@ -80,9 +80,11 @@ SYM_FALSE : [Ff][Aa][Ll][Ss][Ee] ;
 
 ARCHETYPE_HRID      : ARCHETYPE_HRID_ROOT '.v' VERSION_ID ;
 ARCHETYPE_REF       : ARCHETYPE_HRID_ROOT '.v' INTEGER ( '.' DIGIT+ )* ;
-fragment ARCHETYPE_HRID_ROOT : (NAMESPACE '::')? IDENTIFIER '-' IDENTIFIER '-' IDENTIFIER '.' LABEL ;
+fragment ARCHETYPE_HRID_ROOT : (NAMESPACE '::')? IDENTIFIER '-' IDENTIFIER '-' IDENTIFIER '.' ARCHETYPE_CONCEPT_ID ;
 VERSION_ID          : DIGIT+ '.' DIGIT+ '.' DIGIT+ ( ( '-rc' | '-alpha' ) ( '.' DIGIT+ )? )? ;
 fragment IDENTIFIER : ALPHA_CHAR WORD_CHAR* ;
+fragment ARCHETYPE_CONCEPT_ID : ALPHA_CHAR ( NAME_CHAR* ALPHANUM_CHAR )? ;
+
 
 // --------------------- composed primitive types -------------------
 


### PR DESCRIPTION
archetype concept ID used LABEL from URI. That has been changed because of lots of bugs in the URI matcher, but that also changed ARCHETYPE_HRID.

So, create a new fragment specific to ARCHETYPE_HRID, that fixes the parser to comply with the specification again.