### PR TITLE
Fix NullPointerException in DvCodedText.toString

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datatypes/CodePhrase.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datatypes/CodePhrase.java
@@ -93,4 +93,8 @@ public class CodePhrase extends RMObject {
     public int hashCode() {
         return Objects.hash(terminologyId, codeString);
     }
+
+    public String toString() {
+        return terminologyId + "::" + codeString;
+    }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvCodedText.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvCodedText.java
@@ -60,8 +60,7 @@ public class DvCodedText extends DvText {
     }
 
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("code_string", definingCode.getCodeString())
-                .add("terminology_id", definingCode.getTerminologyId())
+        return MoreObjects.toStringHelper(this).add("defining_code", definingCode)
                 .add("value", getValue())
                 .toString();
     }

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/datatypes/CodePhraseTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/datatypes/CodePhraseTest.java
@@ -19,4 +19,13 @@ public class CodePhraseTest {
         Assert.assertNotEquals(codePhraseOne, codePhraseThree);
         Assert.assertNotEquals(codePhraseOne, codePhraseFour);
     }
+
+    @Test
+    public void testToString() {
+        CodePhrase codePhraseOne = new CodePhrase();
+        CodePhrase codePhraseTwo = new CodePhrase("hl7::gender");
+
+        assertEquals("null::null", codePhraseOne.toString());
+        assertEquals("hl7::gender", codePhraseTwo.toString());
+    }
 }

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/datavalues/DvCodedTextTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/datavalues/DvCodedTextTest.java
@@ -17,4 +17,13 @@ public class DvCodedTextTest {
         assertEquals(dvCodedTextOne, dvCodedTextTwo);
         assertNotEquals(dvCodedTextOne, dvCodedTextThree);
     }
+
+    @Test
+    public void testToString() {
+        DvCodedText dvCodedTextOne = new DvCodedText();
+        DvCodedText dvCodedTextTwo = new DvCodedText("some text", new CodePhrase("icd10:123"));
+
+        assertEquals("DvCodedText{defining_code=null, value=null}", dvCodedTextOne.toString());
+        assertEquals("DvCodedText{defining_code=UNKNOWN::icd10:123, value=some text}", dvCodedTextTwo.toString());
+    }
 }


### PR DESCRIPTION
Fix NullPointerException in DvCodedText.toString when `defining_code` was `null`.  Also add CodePhrase.toString method.