### PR TITLE
Add nullcheck and allow underscores in archetype concept ids again

### DIFF
--- a/base/src/main/java/com/nedap/archie/antlr/errors/ANTLRParserErrors.java
+++ b/base/src/main/java/com/nedap/archie/antlr/errors/ANTLRParserErrors.java
@@ -20,12 +20,20 @@ public class ANTLRParserErrors {
         errors.add(new ANTLRParserMessage(error));
     }
 
-    public void addError(String error, String shortMessage, int line, int charPositionInLine, int length, String offendingSymbol) {
+    public void addError(String error, String shortMessage, int line, int charPositionInLine) {
+        errors.add(new ANTLRParserMessage(error, shortMessage, line, charPositionInLine));
+    }
+
+    public void addError(String error, String shortMessage, int line, int charPositionInLine, Integer length, String offendingSymbol) {
         errors.add(new ANTLRParserMessage(error, shortMessage, line, charPositionInLine, length, offendingSymbol));
     }
 
     public void addWarning(String error) {
         warnings.add(new ANTLRParserMessage(error));
+    }
+
+    public void addWarning(String error, String shortMessage, int line, int charPositionInLine) {
+        warnings.add(new ANTLRParserMessage(error, shortMessage, line, charPositionInLine));
     }
 
     public void addWarning(String error, String shortMessage, int line, int charPositionInLine, int length, String offendingSymbol) {

--- a/base/src/main/java/com/nedap/archie/antlr/errors/ANTLRParserMessage.java
+++ b/base/src/main/java/com/nedap/archie/antlr/errors/ANTLRParserMessage.java
@@ -18,6 +18,13 @@ public class ANTLRParserMessage {
         this.message = message;
     }
 
+    public ANTLRParserMessage(String message, String shortMessage, Integer lineNumber, Integer columnNumber) {
+        this.message = message;
+        this.shortMessage = shortMessage;
+        this.lineNumber = lineNumber;
+        this.columnNumber = columnNumber;
+    }
+
     public ANTLRParserMessage(String message, String shortMessage, Integer lineNumber, Integer columnNumber, Integer length, String offendingSymbol) {
         this.message = message;
         this.shortMessage = shortMessage;

--- a/base/src/main/java/com/nedap/archie/antlr/errors/ArchieErrorListener.java
+++ b/base/src/main/java/com/nedap/archie/antlr/errors/ArchieErrorListener.java
@@ -45,8 +45,12 @@ public class ArchieErrorListener implements ANTLRErrorListener {
         if(logEnabled) {
             logger.warn(error);
         }
-        String offendingSymbolString = offendingSymbol.toString();
-        errors.addError(error, msg, line, charPositionInLine, offendingSymbolString.length(), offendingSymbolString);
+        if (offendingSymbol != null) {
+            String offendingSymbolString = offendingSymbol.toString();
+            errors.addError(error, msg, line, charPositionInLine, offendingSymbolString.length(), offendingSymbolString);
+        } else {
+            errors.addError(error, msg, line, charPositionInLine);
+        }
     }
 
     @Override

--- a/grammars/src/main/antlr/BaseLexer.g4
+++ b/grammars/src/main/antlr/BaseLexer.g4
@@ -83,7 +83,7 @@ ARCHETYPE_REF       : ARCHETYPE_HRID_ROOT '.v' INTEGER ( '.' DIGIT+ )* ;
 fragment ARCHETYPE_HRID_ROOT : (NAMESPACE '::')? IDENTIFIER '-' IDENTIFIER '-' IDENTIFIER '.' ARCHETYPE_CONCEPT_ID ;
 VERSION_ID          : DIGIT+ '.' DIGIT+ '.' DIGIT+ ( ( '-rc' | '-alpha' ) ( '.' DIGIT+ )? )? ;
 fragment IDENTIFIER : ALPHA_CHAR WORD_CHAR* ;
-fragment ARCHETYPE_CONCEPT_ID : ALPHA_CHAR ( NAME_CHAR* ALPHANUM_CHAR )? ;
+fragment ARCHETYPE_CONCEPT_ID : ALPHA_CHAR NAME_CHAR* ;
 
 
 // --------------------- composed primitive types -------------------

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -41,6 +41,14 @@ public class ArchetypeValidatorTest {
     }
 
     @Test
+    public void validArchetypeConceptWithUnderscore() throws Exception {
+        archetype = parse("basic_with_concept_underscore.adls");
+        ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);
+        List<ValidationMessage> messages = validationResult.getErrors();
+        assertEquals(0, messages.size());
+    }
+
+    @Test
     public void VCARMNonExistantType() throws Exception {
         archetype = parse("/adl2-tests/validity/rm_checking/openEHR-EHR-EVALUATION.VCARM_rm_non_existent_attribute.v1.0.0.adls");
         ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);

--- a/tools/src/test/resources/com/nedap/archie/archetypevalidator/basic_with_concept_underscore.adls
+++ b/tools/src/test/resources/com/nedap/archie/archetypevalidator/basic_with_concept_underscore.adls
@@ -1,0 +1,58 @@
+archetype (adl_version=2.0.5; rm_release=1.0.4)
+    openEHR-EHR-OBSERVATION.basic_.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"MK">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["en"] = <
+            language = <[ISO-639_1::en]>
+            purpose = <"Testing">
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- Basic
+        data matches {
+            HISTORY[id2] matches {
+                events matches {
+                    POINT_EVENT[id3] matches {    -- Point event
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items matches {
+                                    ELEMENT[id5] occurrences matches {1} matches {    -- Text
+                                        value matches {
+                                            DV_TEXT[id6]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"Basic">
+                description = <"Basic test observation">
+            >
+            ["id3"] = <
+                text = <"Point event">
+                description = <"Point event">
+            >
+            ["id5"] = <
+                text = <"Text">
+                description = <"text">
+            >
+        >
+    >


### PR DESCRIPTION
- Update BaseLexer to allow underscores and hyphens at the end of archetype concept id's again.
- Add a null check in the ArchieErrorListener.syntaxError() for the offendingSymbol