### PR TITLE
Fix adding attributes to specialized archetypes in the differentiator

### DIFF
--- a/tools/src/main/java/com/nedap/archie/diff/Differentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/Differentiator.java
@@ -39,7 +39,7 @@ public class Differentiator {
         new DifferentialPathGenerator().replace(result);
         new TerminologyDifferentiator().differentiate(result);
 
-        new DefaultRmStructureRemover(metaModels, true).removeRMDefaults(result);
+        new DefaultRmStructureRemover(metaModels, false).removeRMDefaults(result);
         result.setDifferential(true);
 
         return result;


### PR DESCRIPTION
Adding attributes in a specialized archetype should be possible. Especially if those attributes are not present in the parent archetype.

However, the Differentiator just removed all empty attributes, without looking at the parent, due to a bug introduced recently due to changes in the ADL 1.4 converter. This fixes that - you can again add attributes not present in the parent archetype. 
