### PR TITLE
Fix the javadoc doclint to fail on all errors

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,19 +11,19 @@ blocks:
         - name: Java 8 build
           commands:
             - sem-version java 1.8
-            - ./gradlew build
+            - ./gradlew clean check javadoc build
         - name: Java 9 build
           commands:
             - sem-version java 9
-            - ./gradlew build
+            - ./gradlew clean check javadoc build
         - name: Java 10 build
           commands:
             - sem-version java 10
-            - ./gradlew build
+            - ./gradlew clean check javadoc build
         - name: Java 11 build
           commands:
             - sem-version java 11
-            - ./gradlew build
+            - ./gradlew clean check javadoc build
             - ./gradlew jacocoRootReport
             - >-
               bash <(curl -s https://codecov.io/bash) -f

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,19 +11,19 @@ blocks:
         - name: Java 8 build
           commands:
             - sem-version java 1.8
-            - ./gradlew clean check javadoc build
+            - ./gradlew clean build
         - name: Java 9 build
           commands:
             - sem-version java 9
-            - ./gradlew clean check javadoc build
+            - ./gradlew clean build
         - name: Java 10 build
           commands:
             - sem-version java 10
-            - ./gradlew clean check javadoc build
+            - ./gradlew clean build
         - name: Java 11 build
           commands:
             - sem-version java 11
-            - ./gradlew clean check javadoc build
+            - ./gradlew clean build
             - ./gradlew jacocoRootReport
             - >-
               bash <(curl -s https://codecov.io/bash) -f

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ allprojects {
   //archivesBaseName = 'archie'
 
   tasks.withType(Javadoc) {
-    options.addStringOption('Xdoclint:all')
+    options.addStringOption('Xdoclint:all', '-quiet')
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ allprojects {
   ext.gradleScriptDir = "${rootProject.projectDir}/gradle"
   //archivesBaseName = 'archie'
 
+  tasks.withType(Javadoc) {
+    options.addStringOption('Xdoclint:all')
+  }
 }
 
 gradle.ext.ossrhUsernameSafe = hasProperty('ossrhUsername') ? ossrhUsername : ""


### PR DESCRIPTION
Semaphore defaults to none, my mac to all, so let's fix it to all. 

confirmed, the current master now should be green with this PR applied, while this branch fails - since this PR actually adds the missing check to CI.