### PR TITLE
Run the Archetype post-processor on ADL 1.4 archetypes both before an…

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
@@ -9,6 +9,7 @@ import com.nedap.archie.adlparser.modelconstraints.ReflectionConstraintImposer;
 import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.antlr.errors.ArchieErrorListener;
 import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.utils.ArchetypeParsePostProcesser;
 import com.nedap.archie.rminfo.MetaModels;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -70,6 +71,7 @@ public class ADL14Parser {
         walker= new ParseTreeWalker();
         walker.walk(listener, tree);
         Archetype result = listener.getArchetype();
+        ArchetypeParsePostProcesser.fixArchetype(result);
         if (metaModels != null) {
             metaModels.selectModel(result);
             if(metaModels.getSelectedBmmModel() != null) {


### PR DESCRIPTION
The ArchetypePostProcessor was not run during ADL 1.4 parsing. That's ok during conversion, but not so much if you want to use it for anything else. This runs it directly after parsing as well as directly after conversion.