### PR TITLE
Add support for Duration formats such as P10Y10DT12H

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,14 @@ subprojects {
     runtime 'com.sun.xml.bind:jaxb-impl:2.3.0'
     compile 'javax.activation:activation:1.1.1'
 
+    implementation 'org.threeten:threeten-extra:1.5.0'
+
     testCompile 'junit:junit:4.+'
     testCompile 'org.slf4j:slf4j-simple:1.7.30'
 
     compile 'com.github.zafarkhaja:java-semver:0.9.0'
+
+
   }
 
 

--- a/tools/src/test/java/com/nedap/archie/json/AOMJacksonTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/AOMJacksonTest.java
@@ -10,10 +10,12 @@ import com.nedap.archie.base.Interval;
 import com.nedap.archie.rm.datastructures.Cluster;
 import com.nedap.archie.serializer.adl.ADLArchetypeSerializer;
 import org.junit.Test;
+import org.threeten.extra.PeriodDuration;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
+import java.time.Period;
 import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -67,5 +69,20 @@ public class AOMJacksonTest {
 
         CDuration parsedDuration = objectMapper.readValue(cDurationJson, CDuration.class);
         assertEquals(Lists.newArrayList(new Interval<>(Duration.of(-10, ChronoUnit.HOURS), Duration.of(10, ChronoUnit.SECONDS))), parsedDuration.getConstraint());
+    }
+
+    @Test
+    public void cDurationPeriodDuration() throws Exception {
+        CDuration cDuration = new CDuration();
+        PeriodDuration tenYearsTenSeconds = PeriodDuration.of(Period.of(10, 0, 0), Duration.of(10, ChronoUnit.SECONDS));
+        cDuration.addConstraint(new Interval<>(Duration.of(-10, ChronoUnit.HOURS), tenYearsTenSeconds));
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(RMJacksonConfiguration.createStandardsCompliant());
+        String cDurationJson = objectMapper.writeValueAsString(cDuration);
+        assertTrue(cDurationJson.contains("-PT10H"));
+        assertTrue(cDurationJson.contains("P10YT10S"));
+        System.out.println(cDurationJson);
+
+        CDuration parsedDuration = objectMapper.readValue(cDurationJson, CDuration.class);
+        assertEquals(Lists.newArrayList(new Interval<>(Duration.of(-10, ChronoUnit.HOURS), tenYearsTenSeconds)), parsedDuration.getConstraint());
     }
 }

--- a/tools/src/test/java/com/nedap/archie/json/RMJacksonTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/RMJacksonTest.java
@@ -5,6 +5,7 @@ import com.nedap.archie.rm.RMObject;
 import com.nedap.archie.rm.composition.Composition;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDuration;
 import org.junit.Test;
+import org.threeten.extra.PeriodDuration;
 
 import java.io.InputStream;
 import java.time.Duration;
@@ -61,5 +62,19 @@ public class RMJacksonTest {
 
         String s = objectMapper.writeValueAsString(dvDuration);
         assertTrue(s.contains("-PT12H20S"));
+    }
+
+    @Test
+    public void parsePeriodDuration() throws Exception {
+        String json = "{\n" +
+                "  \"_type\": \"DV_DURATION\",\n" +
+                "  \"value\": \"-P10Y10DT12H20S\"\n" +
+                "}";
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(RMJacksonConfiguration.createStandardsCompliant());
+        DvDuration dvDuration = objectMapper.readValue(json, DvDuration.class);
+        assertEquals(PeriodDuration.parse("-P10Y10DT12H20S"), dvDuration.getValue());
+
+        String s = objectMapper.writeValueAsString(dvDuration);
+        assertTrue(s.contains("-P10Y10DT12H20S"));
     }
 }

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBAOMTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBAOMTest.java
@@ -79,7 +79,7 @@ public class JAXBAOMTest {
                 "            <children xsi:type=\"C_DURATION\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
                 "                <constraint lower_unbounded=\"false\" upper_unbounded=\"false\" lower_included=\"true\" upper_included=\"true\">\n" +
                 "                    <lower xsi:type=\"xs:string\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">-P10D</lower>\n" +
-                "                    <upper xsi:type=\"xs:string\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">PT10S</upper>\n" +
+                "                    <upper xsi:type=\"xs:string\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">P10YT10S</upper>\n" +
                 "                </constraint>\n" +
                 "            </children>\n" +
                 "        </attributes>\n" +
@@ -93,7 +93,7 @@ public class JAXBAOMTest {
         Interval<TemporalAmount> constraint = parsedDuration.getConstraint().get(0);
         assertEquals(1, parsedDuration.getConstraint().size());
         assertEquals(
-                new Interval<TemporalAmount>(DateTimeParsers.parseDurationValue("-P10D"), DateTimeParsers.parseDurationValue("PT10S")),
+                new Interval<TemporalAmount>(DateTimeParsers.parseDurationValue("-P10D"), DateTimeParsers.parseDurationValue("P10YT10S")),
                 constraint);
     }
 

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBRMTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBRMTest.java
@@ -4,6 +4,7 @@ import com.nedap.archie.rm.datastructures.Element;
 import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDuration;
 import org.junit.Test;
+import org.threeten.extra.PeriodDuration;
 
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
@@ -72,5 +73,21 @@ public class JAXBRMTest {
         Unmarshaller unmarshaller = JAXBUtil.getArchieJAXBContext().createUnmarshaller();
         Element unmarshalled = (Element) unmarshaller.unmarshal(new StringReader(xml));
         assertEquals(Period.parse("-P10D"), ((DvDuration)unmarshalled.getValue()).getValue());
+    }
+
+    @Test
+    public void parseNegativePeriodDuration() throws Exception {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
+                "<element archetype_node_id=\"id6\" xmlns:ns2=\"http://schemas.openehr.org/v1\">\n" +
+                "    <name>\n" +
+                "        <value>duration</value>\n" +
+                "    </name>\n" +
+                "    <value xsi:type=\"DV_DURATION\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+                "        <value>-P10YT12H</value>\n" +
+                "    </value>\n" +
+                "</element>";
+        Unmarshaller unmarshaller = JAXBUtil.getArchieJAXBContext().createUnmarshaller();
+        Element unmarshalled = (Element) unmarshaller.unmarshal(new StringReader(xml));
+        assertEquals(PeriodDuration.parse("-P10YT12H"), ((DvDuration)unmarshalled.getValue()).getValue());
     }
 }

--- a/utils/src/main/java/com/nedap/archie/datetime/DateTimeParsers.java
+++ b/utils/src/main/java/com/nedap/archie/datetime/DateTimeParsers.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAmount;
+import org.threeten.extra.PeriodDuration;
 
 /**
  * ISO date time parsers
@@ -67,8 +68,10 @@ public class DateTimeParsers {
 
     public static TemporalAmount parseDurationValue(String text) {
         try {
-            if(text.contains("T")) {
+            if(text.startsWith("PT") || text.startsWith("-PT")) {
                 return Duration.parse(text);
+            } else if (text.contains("T")) {
+                return PeriodDuration.parse(text);
             } else {
                 return Period.parse(text);
             }

--- a/utils/src/main/java/com/nedap/archie/datetime/DateTimeSerializerFormatters.java
+++ b/utils/src/main/java/com/nedap/archie/datetime/DateTimeSerializerFormatters.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.datetime;
 
+import org.threeten.extra.PeriodDuration;
+
 import java.time.Duration;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
@@ -56,22 +58,31 @@ public class DateTimeSerializerFormatters {
             return serializeDuration((Duration) amount);
         } else if (amount instanceof Period) {
             return serializeDuration((Period) amount);
+        } else if (amount instanceof PeriodDuration) {
+            return serializePeriodDuration((PeriodDuration) amount);
         }
         return amount.toString();
     }
 
     private static String serializeDuration(Duration duration) {
         if(duration.isNegative()) {
-            return "-" + Duration.ZERO.minus(duration).toString();
+            return "-" + duration.negated();
         }
         return duration.toString();
     }
 
     private static String serializeDuration(Period period) {
         if(period.isNegative()) {
-            return "-" + Period.ZERO.minus(period).toString();
+            return "-" + period.negated();
         }
         return period.toString();
+    }
+
+    private static String serializePeriodDuration(PeriodDuration periodDuration) {
+        if(periodDuration.getPeriod().isNegative() || periodDuration.getDuration().isNegative()) {
+            return "-" + periodDuration.negated();
+        }
+        return periodDuration.toString();
     }
 
 }

--- a/utils/src/test/java/com/nedap/archie/datetime/DateTimeParserTest.java
+++ b/utils/src/test/java/com/nedap/archie/datetime/DateTimeParserTest.java
@@ -1,12 +1,11 @@
-package com.nedap.archie.adlparser;
+package com.nedap.archie.datetime;
 
-import com.nedap.archie.adlparser.treewalkers.TemporalConstraintParser;
-import com.nedap.archie.datetime.DateTimeParsers;
-import com.nedap.archie.datetime.DateTimeSerializerFormatters;
 import org.junit.Test;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 
 import static org.junit.Assert.assertEquals;
@@ -81,9 +80,8 @@ public class DateTimeParserTest {
         TemporalAmount minusTwoYears = DateTimeParsers.parseDurationValue("-P2Y");
         assertEquals(Period.of(-2, 0, 0), minusTwoYears);
 
-        assertEquals("-PT2S", DateTimeSerializerFormatters.serializeDuration(minusTwoSeconds));
-        assertEquals("-P2Y", DateTimeSerializerFormatters.serializeDuration(minusTwoYears));
-        assertEquals("-PT12H2S", DateTimeSerializerFormatters.serializeDuration(minutsTwelHoursTwoSeconds));
+        TemporalAmount minusOneYear2Hours = DateTimeParsers.parseDurationValue("-P1YT2H");
+        assertEquals(PeriodDuration.of(Period.of(-1 ,0, 0), Duration.of(-2, ChronoUnit.HOURS)), minusOneYear2Hours);
     }
 
 }

--- a/utils/src/test/java/com/nedap/archie/datetime/DateTimeSerializerFormattersTest.java
+++ b/utils/src/test/java/com/nedap/archie/datetime/DateTimeSerializerFormattersTest.java
@@ -1,9 +1,12 @@
 package com.nedap.archie.datetime;
 
 import org.junit.Test;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.*;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalAmount;
 
 import static org.junit.Assert.assertEquals;
 
@@ -44,6 +47,24 @@ public class DateTimeSerializerFormattersTest {
     @Test
     public void serializeYearMonth() {
         assertEquals("2015-01", serializeDate(YearMonth.of(2015, 1)));
+    }
+
+    @Test
+    public void serializeNegativeDurations() {
+        TemporalAmount minusTwoSeconds = Duration.of(-2, ChronoUnit.SECONDS);
+        TemporalAmount minutsTwelHoursTwoSeconds = Duration.of(-2 - 12*60*60, ChronoUnit.SECONDS);
+        TemporalAmount minusTwoYears = Period.of(-2, 0, 0);
+        TemporalAmount minusOneYearOneHour = PeriodDuration.of(Period.of(-1 ,0, 0), Duration.of(-2, ChronoUnit.HOURS));
+        TemporalAmount minusTwoHoursPeriodDuration = PeriodDuration.of(Period.ZERO, Duration.of(-2, ChronoUnit.HOURS));
+        TemporalAmount minusOneYearPeriodDuration = PeriodDuration.of(Period.of(-1 ,0, 0), Duration.ZERO);
+
+        assertEquals("-PT2S", DateTimeSerializerFormatters.serializeDuration(minusTwoSeconds));
+        assertEquals("-P2Y", DateTimeSerializerFormatters.serializeDuration(minusTwoYears));
+        assertEquals("-PT12H2S", DateTimeSerializerFormatters.serializeDuration(minutsTwelHoursTwoSeconds));
+        assertEquals("-P1YT2H", DateTimeSerializerFormatters.serializeDuration(minusOneYearOneHour));
+        assertEquals("-PT2H", DateTimeSerializerFormatters.serializeDuration(minusTwoHoursPeriodDuration));
+        assertEquals("-P1Y", DateTimeSerializerFormatters.serializeDuration(minusOneYearPeriodDuration));
+
     }
 
     private String serializeDate(TemporalAccessor value) {


### PR DESCRIPTION
Add the threeten Extras dependency, to be able to support ISO8601 durations that are in java time a combination of a period and a duration.

This still has some problems:
- java Period does have years, months and days, but does not have the notion of weeks. They get converted to days. Is that the same for purposes intended here, as perhaps someone really intended to say '3 weeks' and not '21 days'?
- java Duration is actually a number of seconds+nanoseconds, so if you input PT180M, you will lose that and on serialization get PT3H back.

So we may need a different implementation. That is entirely possible with the java date/time API, just I don't think one is available out of the box, and I have not found any library doing this. Except Joda Time, but I don't think introducing that would be a good idea.

This pull request fixes https://github.com/openEHR/archie/issues/209