### PR TITLE
Fix flattening specialized rules

### DIFF
--- a/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/RulesFlattener.java
@@ -76,7 +76,7 @@ public class RulesFlattener {
             if(!Strings.isNullOrEmpty(assertion.getTag())) {
                 assertion.setTag(tagPrefix + assertion.getTag());
             }
-            if (!(assertion.getExpression() instanceof ForAllStatement)) {
+            if (!Strings.isNullOrEmpty(pathPrefix) && !(assertion.getExpression() instanceof ForAllStatement)) {
                 //Cast expression to ForAllStatement. The variableReferencePrefix is set for all operands within this
                 //expression so that they are recognized as operands of a ForAllStatement, i.e. the prefix will be used
                 //instead of the full path within the flattened rule section. Note that the prefix "item" is

--- a/tools/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
@@ -12,8 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openehr.referencemodels.BuiltinReferenceModels;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Created by pieter.bos on 15/05/2017.
@@ -60,12 +59,21 @@ public class RulesFlattenerTest {
         assertEquals("diastolic", diastolic.getName());
         assertEquals("blood_pressure", bloodPressure.getTag());
         assertEquals("flattened_path_arguments", flattenedPathArguments.getName());
-        assertEquals(ForAllStatement.class, biggerThan90.getExpression().getClass());
+        assertEquals(BinaryOperator.class, biggerThan90.getExpression().getClass());
+        checkCorrectSyntax(flattened);
+    }
+
+    private void checkCorrectSyntax(Archetype flattened) {
+        String serialized= ADLArchetypeSerializer.serialize(flattened);
+        ADLParser parser = new ADLParser();
+        parser.parse(serialized);
+        assertFalse(parser.getErrors().toString(), parser.getErrors().hasErrors());
     }
 
     @Test
     public void flattenedRules() throws Exception {
         Archetype flattened = flattener.flatten(containingRules);
+
         CObject systolicCObject = flattened.itemAtPath("/content[id5]/data/events/data/items[id5]");
         assertEquals("systolic", systolicCObject.getTerm().getText());
         assertEquals(5, flattened.getRules().getRules().size()); //specialized rules, prefixed with the content[id5] path
@@ -88,6 +96,7 @@ public class RulesFlattenerTest {
         ADLParser parser = new ADLParser();
         parser.parse(ADLArchetypeSerializer.serialize(flattened));
         assertTrue(parser.getErrors().hasNoErrors());
+        checkCorrectSyntax(flattened);
     }
 
 }


### PR DESCRIPTION
When flattening a specialized archetype, the rules flattener incorrectly added a for all statement around every rule. That was useless, and added a syntax error. Bad flattener!

so we prevented that by only adding the for all statement in case of an included archetype, by checking that pathPrefix is not null or empty. Then we added a test checking the syntax error, and confirming the new behaviour.