### PR TITLE
Remove unused value codes during ADL 1.4 conversion

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/PreviousConversionApplier.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/PreviousConversionApplier.java
@@ -184,11 +184,14 @@ public class PreviousConversionApplier {
     }
 
     private void removeTerminologyEntry(String code) {
-        for(String language:archetype.getTerminology().getTermDefinitions().keySet()) {
-            archetype.getTerminology().getTermDefinitions().get(language).remove(code);
-        }
-        List<String> termCodeBindingsToRemove = new ArrayList<>();
+        archetype.getTerminology().getTermDefinitions().values().forEach(
+                map -> map.remove(code)
+        );
+
         if(archetype.getTerminology().getTermBindings() != null) {
+
+            List<String> termCodeBindingsToRemove = new ArrayList<>();
+
             for (String terminologyId: archetype.getTerminology().getTermBindings().keySet()) {
                 Map<String, URI> termBindings = archetype.getTerminology().getTermBindings().get(terminologyId);
                 termBindings.remove(code);
@@ -196,10 +199,12 @@ public class PreviousConversionApplier {
                     termCodeBindingsToRemove.add(terminologyId);
                 }
             }
+
+            for(String terminologyId:termCodeBindingsToRemove) {
+                archetype.getTerminology().getTermBindings().remove(terminologyId);
+            }
         }
-        for(String terminologyId:termCodeBindingsToRemove) {
-            archetype.getTerminology().getTermBindings().remove(terminologyId);
-        }
+
     }
 
     private Set<String> gatherUsedValueSets(CObject cObject) {

--- a/aom/src/main/java/com/nedap/archie/adl14/PreviousConversionApplier.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/PreviousConversionApplier.java
@@ -13,7 +13,10 @@ import com.nedap.archie.aom.CObject;
 import com.nedap.archie.aom.CPrimitiveTuple;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
+import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.aom.terminology.ValueSet;
+import com.nedap.archie.aom.utils.AOMUtils;
+import org.openehr.utils.message.I18n;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -154,17 +157,49 @@ public class PreviousConversionApplier {
         if(this.conversionLog == null) {
             return;
         }
+        removeUnusedValuesets();
+        removeUnusedValues();
+    }
+
+    private void removeUnusedValuesets() {
         Set<String> usedValueSets = gatherUsedValueSets(archetype.getDefinition());
         for(Map.Entry<String, ValueSet> valueSetEntry:this.conversionLog.getCreatedValueSets().entrySet()) {
             if(!usedValueSets.contains(valueSetEntry.getKey())) {
                 //ok, unused, remove it
                 archetype.getTerminology().getValueSets().remove(valueSetEntry.getKey());
-                for(String language:archetype.getTerminology().getTermDefinitions().keySet()) {
-                    archetype.getTerminology().getTermDefinitions().get(language).remove(valueSetEntry.getKey());
+                removeTerminologyEntry(valueSetEntry.getKey());
+            }
+        }
+    }
+
+    private void removeUnusedValues() {
+        Set<String> usedCodes = archetype.getAllUsedCodes();
+        for(Map.Entry<String, CreatedCode> valueEntry:this.conversionLog.getCreatedCodes().entrySet()) {
+            if(valueEntry.getValue().getReasonForCreation() == ReasonForCodeCreation.CREATED_VALUE_FOR_EXTERNAL_TERM
+                    && !usedCodes.contains(valueEntry.getValue().getGeneratedCode())) {
+                //unused code found. Remove!
+                removeTerminologyEntry(valueEntry.getValue().getGeneratedCode());
+            }
+        }
+    }
+
+    private void removeTerminologyEntry(String code) {
+        for(String language:archetype.getTerminology().getTermDefinitions().keySet()) {
+            archetype.getTerminology().getTermDefinitions().get(language).remove(code);
+        }
+        List<String> termCodeBindingsToRemove = new ArrayList<>();
+        if(archetype.getTerminology().getTermBindings() != null) {
+            for (String terminologyId: archetype.getTerminology().getTermBindings().keySet()) {
+                Map<String, URI> termBindings = archetype.getTerminology().getTermBindings().get(terminologyId);
+                termBindings.remove(code);
+                if(termBindings.isEmpty()) {
+                    termCodeBindingsToRemove.add(terminologyId);
                 }
             }
         }
-        //TODO: Gather all unused term bindings and remove from archetype as well
+        for(String terminologyId:termCodeBindingsToRemove) {
+            archetype.getTerminology().getTermBindings().remove(terminologyId);
+        }
     }
 
     private Set<String> gatherUsedValueSets(CObject cObject) {

--- a/tools/src/test/java/com/nedap/archie/adl14/LargeSetOfADL14sTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/LargeSetOfADL14sTest.java
@@ -168,10 +168,12 @@ public class LargeSetOfADL14sTest {
         adl2Repository.compile(BuiltinReferenceModels.getMetaModels());
         int passingValidations = 0;
         for(ValidationResult validationResult:adl2Repository.getAllValidationResults()) {
-            if(validationResult.hasWarningsOrErrors()) {
-                logger.error(String.format("archetype %s has warning %s: ", validationResult.getArchetypeId(), validationResult.getErrors()));
-            }
             if(validationResult.passes()) {
+                //may still have warnings, so print if that's the case, so you can at least see in the log
+                //assertions would be even better, but these are actual warnings due to ADL 1.4 archetype content
+                if(validationResult.hasWarningsOrErrors()) {
+                    logger.error(String.format("archetype %s has warning %s: ", validationResult.getArchetypeId(), validationResult.getErrors()));
+                }
                 passingValidations++;
             } else {
                 logger.error("error validating {}: {}", validationResult.getArchetypeId(), validationResult.getErrors());

--- a/tools/src/test/java/com/nedap/archie/adl14/LargeSetOfADL14sTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/LargeSetOfADL14sTest.java
@@ -168,6 +168,9 @@ public class LargeSetOfADL14sTest {
         adl2Repository.compile(BuiltinReferenceModels.getMetaModels());
         int passingValidations = 0;
         for(ValidationResult validationResult:adl2Repository.getAllValidationResults()) {
+            if(validationResult.hasWarningsOrErrors()) {
+                logger.error(String.format("archetype %s has warning %s: ", validationResult.getArchetypeId(), validationResult.getErrors()));
+            }
             if(validationResult.passes()) {
                 passingValidations++;
             } else {

--- a/tools/src/test/java/com/nedap/archie/adl14/PreviousLogConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/PreviousLogConversionTest.java
@@ -5,6 +5,7 @@ import com.nedap.archie.adl14.log.ADL2ConversionRunLog;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.CAttribute;
 import com.nedap.archie.aom.CObject;
+import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.archetypevalidator.ArchetypeValidator;
 import com.nedap.archie.archetypevalidator.ValidationResult;
 import org.junit.Test;
@@ -12,7 +13,7 @@ import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import java.io.InputStream;
 
-import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.*;
 import static org.junit.Assert.assertTrue;
 
 public class PreviousLogConversionTest {
@@ -82,6 +83,46 @@ public class PreviousLogConversionTest {
             assertTrue(converted.getTerminology().getTermDefinitions().get("nl").containsKey("ac9002"));
             assertTrue(converted.getTerminology().getTermDefinitions().get("nl").containsKey("ac9003"));
 
+        }
+    }
+
+    @Test
+    public void unusedValuesAreRemoved() throws Exception {
+        ADL14ConversionConfiguration conversionConfiguration = ConversionConfigForTest.getConfig();
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
+        ADL2ConversionRunLog log = null;
+        String createdAtCode = null;
+        //apply the first conversion and store the log. It has created an at code to bind to [openehr::124], used in a DV_QUANTITY.property
+        try(InputStream stream = getClass().getResourceAsStream("/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.0.adl")) {
+            ADL2ConversionResultList result = converter.convert(
+                    Lists.newArrayList(new ADL14Parser(BuiltinReferenceModels.getMetaModels()).parse(stream, conversionConfiguration)));
+            log = result.getConversionLog();
+            Archetype converted = result.getConversionResults().get(0).getArchetype();
+            ValidationResult validated = new ArchetypeValidator(BuiltinReferenceModels.getMetaModels()).validate(converted);
+            assertTrue(validated.toString(), validated.passes() );
+             createdAtCode = log.getConversionLog("openEHR-EHR-CLUSTER.value_binding.v1").getCreatedCodes().get("[openehr::124]").getGeneratedCode();
+            ArchetypeTerm termDefinition = converted.getTerminology().getTermDefinition("en", createdAtCode);
+            assertNotNull(termDefinition);
+        }
+
+        assertEquals(1, log.getConvertedArchetypes().size());
+
+        //apply the first conversion. The openehr::124 term binding is gone, and should not be present in the result, but should remain in the conversion log for future readdition
+        try(InputStream stream = getClass().getResourceAsStream("/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.1.adl")) {
+            ADL2ConversionResultList result = converter.convert(
+                    Lists.newArrayList(new ADL14Parser(BuiltinReferenceModels.getMetaModels()).parse(stream, conversionConfiguration)),
+                    log);
+            Archetype converted = result.getConversionResults().get(0).getArchetype();
+            ValidationResult validated = new ArchetypeValidator(BuiltinReferenceModels.getMetaModels()).validate(converted);
+            assertTrue(validated.toString(), validated.passes() );
+
+            ArchetypeTerm termDefinition = converted.getTerminology().getTermDefinition("en", "at9000");
+            assertNull(termDefinition);
+            assertFalse(validated.toString(), validated.hasWarningsOrErrors() );
+
+            ADL2ConversionRunLog log2 = result.getConversionLog();
+            //the code should still be present in the conversion log, should it be added later on
+            assertNotNull(log2.getConversionLog("openEHR-EHR-CLUSTER.value_binding.v1").getCreatedCodes().get("[openehr::124]"));
         }
     }
 

--- a/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.0.adl
+++ b/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.0.adl
@@ -1,0 +1,59 @@
+archetype (adl_version=1.4; uid=1.2.36.1.2001.1001.100.137.1.0)
+	openEHR-EHR-CLUSTER.value_binding.v1
+
+concept
+	[at0000]	-- value_binding
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"A test for value binding">
+			use = <"">
+			misuse = <"">
+		>
+	>
+	other_contributors = <>
+	other_details = <
+		["revision"] = <"1.0.0">
+	>
+
+definition
+
+CLUSTER[at0000] matches {
+    items matches {
+        ELEMENT[at0006] occurrences matches {0..1} matches {	-- Total saturated fatty acids
+            value matches {
+                C_DV_QUANTITY <
+                    property = <[openehr::124]>
+                    list = <
+                        ["1"] = <
+                            units = <"g">
+                            magnitude = <|>=0.0|>
+                        >
+                    >
+                >
+            }
+        }
+    }
+}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"root node">
+					description = <"Root node">
+				>
+				["at0006"] = <
+					text = <"element">
+					description = <"Element">
+				>
+            >
+        >
+    >

--- a/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.0.adl
+++ b/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.0.adl
@@ -1,26 +1,26 @@
 archetype (adl_version=1.4; uid=1.2.36.1.2001.1001.100.137.1.0)
-	openEHR-EHR-CLUSTER.value_binding.v1
+    openEHR-EHR-CLUSTER.value_binding.v1
 
 concept
-	[at0000]	-- value_binding
+    [at0000]	-- value_binding
 language
-	original_language = <[ISO_639-1::en]>
+    original_language = <[ISO_639-1::en]>
 description
-	original_author = <
-		["name"] = <"Pieter Bos">
-	>
-	details = <
-		["en"] = <
-			language = <[ISO_639-1::en]>
-			purpose = <"A test for value binding">
-			use = <"">
-			misuse = <"">
-		>
-	>
-	other_contributors = <>
-	other_details = <
-		["revision"] = <"1.0.0">
-	>
+    original_author = <
+        ["name"] = <"Pieter Bos">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"A test for value binding">
+            use = <"">
+            misuse = <"">
+        >
+    >
+    other_contributors = <>
+    other_details = <
+        ["revision"] = <"1.0.0">
+    >
 
 definition
 
@@ -43,17 +43,17 @@ CLUSTER[at0000] matches {
 }
 
 ontology
-	term_definitions = <
-		["en"] = <
-			items = <
-				["at0000"] = <
-					text = <"root node">
-					description = <"Root node">
-				>
-				["at0006"] = <
-					text = <"element">
-					description = <"Element">
-				>
+    term_definitions = <
+        ["en"] = <
+            items = <
+                ["at0000"] = <
+                    text = <"root node">
+                    description = <"Root node">
+                >
+                ["at0006"] = <
+                    text = <"element">
+                    description = <"Element">
+                >
             >
         >
     >

--- a/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.1.adl
+++ b/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.1.adl
@@ -1,0 +1,58 @@
+archetype (adl_version=1.4; uid=1.2.36.1.2001.1001.100.137.1.0)
+	openEHR-EHR-CLUSTER.value_binding.v1
+
+concept
+	[at0000]	-- value_binding
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"A test for value binding">
+			use = <"">
+			misuse = <"">
+		>
+	>
+	other_contributors = <>
+	other_details = <
+		["revision"] = <"1.0.0">
+	>
+
+definition
+
+CLUSTER[at0000] matches {
+    items matches {
+        ELEMENT[at0006] occurrences matches {0..1} matches {	-- Total saturated fatty acids
+            value matches {
+                C_DV_QUANTITY <
+                    list = <
+                        ["1"] = <
+                            units = <"g">
+                            magnitude = <|>=0.0|>
+                        >
+                    >
+                >
+            }
+        }
+    }
+}
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"root node">
+					description = <"Root node">
+				>
+				["at0006"] = <
+					text = <"element">
+					description = <"Element">
+				>
+            >
+        >
+    >

--- a/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.1.adl
+++ b/tools/src/test/resources/adl14/openEHR-EHR-CLUSTER.value_binding.v1.0.1.adl
@@ -1,26 +1,26 @@
 archetype (adl_version=1.4; uid=1.2.36.1.2001.1001.100.137.1.0)
-	openEHR-EHR-CLUSTER.value_binding.v1
+    openEHR-EHR-CLUSTER.value_binding.v1
 
 concept
-	[at0000]	-- value_binding
+    [at0000]	-- value_binding
 language
-	original_language = <[ISO_639-1::en]>
+    original_language = <[ISO_639-1::en]>
 description
-	original_author = <
-		["name"] = <"Pieter Bos">
-	>
-	details = <
-		["en"] = <
-			language = <[ISO_639-1::en]>
-			purpose = <"A test for value binding">
-			use = <"">
-			misuse = <"">
-		>
-	>
-	other_contributors = <>
-	other_details = <
-		["revision"] = <"1.0.0">
-	>
+    original_author = <
+        ["name"] = <"Pieter Bos">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"A test for value binding">
+            use = <"">
+            misuse = <"">
+        >
+    >
+    other_contributors = <>
+    other_details = <
+        ["revision"] = <"1.0.0">
+    >
 
 definition
 
@@ -42,17 +42,17 @@ CLUSTER[at0000] matches {
 }
 
 ontology
-	term_definitions = <
-		["en"] = <
-			items = <
-				["at0000"] = <
-					text = <"root node">
-					description = <"Root node">
-				>
-				["at0006"] = <
-					text = <"element">
-					description = <"Element">
-				>
+    term_definitions = <
+        ["en"] = <
+            items = <
+                ["at0000"] = <
+                    text = <"root node">
+                    description = <"Root node">
+                >
+                ["at0006"] = <
+                    text = <"element">
+                    description = <"Element">
+                >
             >
         >
     >


### PR DESCRIPTION
If a value code with term binding was added in ADL 1.4 conversion, and stored in the conversion log, it was subsequently present in all future versions of that archetype, whether it was used in that archetype or not. This led to some annoying warnings.

This removes it from the archetype, but keeps it in the conversion log, in case the same binding will be reintroduced in a later version, for some extra backwards compatibility.