### PR TITLE
Fix C_ATTRIBUTE.isleaf(), fixes #241

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/CAttribute.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CAttribute.java
@@ -372,7 +372,7 @@ public class CAttribute extends ArchetypeConstraint {
     @Override
     @JsonIgnore
     public boolean isLeaf() {
-        return children != null && children.size() > 0;
+        return children == null || children.isEmpty();
     }
 
     /**

--- a/tools/src/test/java/com/nedap/archie/aom/ArchetypeSlotTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/ArchetypeSlotTest.java
@@ -1,0 +1,15 @@
+package com.nedap.archie.aom;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ArchetypeSlotTest {
+
+    @Test
+    public void isLeaf() {
+        ArchetypeSlot archetypeSlot = new ArchetypeSlot();
+
+        assertTrue(archetypeSlot.isLeaf());
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/aom/CAttributeTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/CAttributeTest.java
@@ -86,6 +86,17 @@ public class CAttributeTest {
         assertEquals(child2, attribute.getChild("id3"));
     }
 
+    @Test
+    public void isLeaf() {
+        CAttribute cAttribute = new CAttribute("items");
+
+        assertTrue(cAttribute.isLeaf());
+
+        cAttribute.addChild(createCComplexObject("id2"));
+
+        assertFalse(cAttribute.isLeaf());
+    }
+
     private CComplexObject createCComplexObject(String nodeId) {
         CComplexObject complexObject = new CComplexObject();
         complexObject.setNodeId(nodeId);

--- a/tools/src/test/java/com/nedap/archie/aom/CComplexObjectProxyTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/CComplexObjectProxyTest.java
@@ -1,0 +1,15 @@
+package com.nedap.archie.aom;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CComplexObjectProxyTest {
+
+    @Test
+    public void isLeaf() {
+        CComplexObject cComplexObject = new CComplexObject();
+
+        assertTrue(cComplexObject.isLeaf());
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/aom/CComplexObjectTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/CComplexObjectTest.java
@@ -1,0 +1,30 @@
+package com.nedap.archie.aom;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CComplexObjectTest {
+
+    @Test
+    public void isLeafAttributes() {
+        CComplexObject cComplexObject = new CComplexObject();
+
+        assertTrue(cComplexObject.isLeaf());
+
+        cComplexObject.addAttribute(new CAttribute("items"));
+
+        assertFalse(cComplexObject.isLeaf());
+    }
+
+    @Test
+    public void isLeafAttributeTuples() {
+        CComplexObject cComplexObject = new CComplexObject();
+
+        assertTrue(cComplexObject.isLeaf());
+
+        cComplexObject.addAttributeTuple(new CAttributeTuple());
+
+        assertFalse(cComplexObject.isLeaf());
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/aom/CPrimitiveObjectTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/CPrimitiveObjectTest.java
@@ -1,0 +1,16 @@
+package com.nedap.archie.aom;
+
+import com.nedap.archie.aom.primitives.CBoolean;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CPrimitiveObjectTest {
+
+    @Test
+    public void isLeaf() {
+        CBoolean cBoolean = new CBoolean();
+
+        assertTrue(cBoolean.isLeaf());
+    }
+}


### PR DESCRIPTION
In #241 , Bert Verhees found that CAttribute.isLeaf() did the exact opposite of what it should do. This fixes it.