### PR TITLE
Add option to OPT generation to not fail on missing archetypes

### DIFF
--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -52,6 +52,15 @@ public class FlattenerConfiguration {
      */
     private boolean fillEmptyOccurrences = true;
 
+    /**
+     * Only for Operational templates: in case a used archetype in a slot is missing, switches the following behaviour:
+     * true: throw an exception
+     * false: skip replacing the archetype root with the archetype contents, and continue creating the operational tempalte
+     *
+     * Can be useful for archetype modeling purposes.
+     */
+    private boolean failOnMissingUsedArchetype = true;
+
     private FlattenerConfiguration() {
 
     }
@@ -157,5 +166,13 @@ public class FlattenerConfiguration {
 
     public void setFillEmptyOccurrences(boolean fillEmptyOccurrences) {
         this.fillEmptyOccurrences = fillEmptyOccurrences;
+    }
+
+    public boolean isFailOnMissingUsedArchetype() {
+        return failOnMissingUsedArchetype;
+    }
+
+    public void setFailOnMissingUsedArchetype(boolean failOnMissingUsedArchetype) {
+        this.failOnMissingUsedArchetype = failOnMissingUsedArchetype;
     }
 }

--- a/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
@@ -186,7 +186,12 @@ class OperationalTemplateCreator {
                 newArchetypeRef = archetype.getParentArchetypeId();
             }
             if (archetype == null) {
-                throw new IllegalArgumentException("Archetype with reference :" + archetypeRef + " not found.");
+                if(getConfig().isFailOnMissingUsedArchetype()) {
+                    throw new IllegalArgumentException("Archetype with reference :" + archetypeRef + " not found.");
+                } else {
+                    //just skip, as a form of graceful degradation.
+                    return;
+                }
             }
 
             archetype = flattener.getNewFlattener().flatten(archetype);

--- a/tools/src/test/java/com/nedap/archie/flattener/OperationalTemplateCreatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/OperationalTemplateCreatorTest.java
@@ -3,6 +3,7 @@ package com.nedap.archie.flattener;
 import com.google.common.collect.Lists;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CArchetypeRoot;
 import com.nedap.archie.aom.CAttribute;
 import com.nedap.archie.aom.CComplexObject;
 import com.nedap.archie.aom.CObject;
@@ -16,9 +17,9 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Stack;
 
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class OperationalTemplateCreatorTest {
 
@@ -68,4 +69,33 @@ public class OperationalTemplateCreatorTest {
             }
         }
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failOnMissingArchetypeEnabled() throws Exception {
+        SimpleArchetypeRepository repository = new SimpleArchetypeRepository();
+        try(InputStream stream = getClass().getResourceAsStream("openEHR-EHR-OBSERVATION.with_used_archetype.v1.adls")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModels()).parse(stream);
+            FlattenerConfiguration flattenerConfiguration = FlattenerConfiguration.forOperationalTemplate();
+            Flattener flattener = new Flattener(repository, BuiltinReferenceModels.getMetaModels(), flattenerConfiguration);
+            OperationalTemplate template = (OperationalTemplate) flattener.flatten(archetype);
+            fail();
+        }
+    }
+
+    @Test
+    public void failOnMissingArchetypeDisabled() throws Exception {
+        try(InputStream stream = getClass().getResourceAsStream("openEHR-EHR-OBSERVATION.with_used_archetype.v1.adls")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModels()).parse(stream);
+            FlattenerConfiguration flattenerConfiguration = FlattenerConfiguration.forOperationalTemplate();
+            flattenerConfiguration.setFailOnMissingUsedArchetype(false);
+            Flattener flattener = new Flattener(new SimpleArchetypeRepository(), BuiltinReferenceModels.getMetaModels(), flattenerConfiguration);
+            OperationalTemplate template = (OperationalTemplate) flattener.flatten(archetype);
+
+            CArchetypeRoot archetypeRoot = template.getDefinition().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]");
+            assertEquals("openEHR-EHR-CLUSTER.cluster_with_annotations.v1", archetypeRoot.getArchetypeRef());
+            assertTrue(archetypeRoot.getAttributes().isEmpty());
+        }
+    }
+
+
 }


### PR DESCRIPTION
Useful for modelling purposes, where you may still want to see most of the archetype, even if an included archetype is missing.