### PR TITLE
Make matches {CTerminologyCode} work in rules

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -49,7 +49,6 @@ public class ADLListener extends AdlBaseListener {
 
     private void setArchetype(Archetype archetype) {
         this.archetype = archetype;
-        this.cComplexObjectParser.setArchetype(archetype);
     }
 
     @Override

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -43,8 +43,13 @@ public class ADLListener extends AdlBaseListener {
     @Override
     public void enterArchetype(ArchetypeContext ctx) {
         rootArchetype = new AuthoredArchetype();
-        archetype = rootArchetype;
+        setArchetype(rootArchetype);
         parseArchetypeHRID(ctx.ARCHETYPE_HRID());
+    }
+
+    private void setArchetype(Archetype archetype) {
+        this.archetype = archetype;
+        this.cComplexObjectParser.setArchetype(archetype);
     }
 
     @Override
@@ -55,7 +60,7 @@ public class ADLListener extends AdlBaseListener {
     @Override
     public void enterTemplate(TemplateContext ctx) {
         rootArchetype = new Template();
-        archetype = rootArchetype;
+        setArchetype(rootArchetype);
         parseArchetypeHRID(ctx.ARCHETYPE_HRID());
     }
 
@@ -79,7 +84,7 @@ public class ADLListener extends AdlBaseListener {
         } else {
             rootArchetype = overlay;
         }
-        archetype = overlay;
+        setArchetype(overlay);
         parseArchetypeHRID(ctx.ARCHETYPE_HRID());
     }
 
@@ -87,7 +92,7 @@ public class ADLListener extends AdlBaseListener {
     public void enterOperational_template(Operational_templateContext ctx) {
         rootArchetype = new OperationalTemplate();
         rootArchetype.setDifferential(false);//operational templates are flat by definition
-        archetype = rootArchetype;
+        setArchetype(rootArchetype);
         parseArchetypeHRID(ctx.ARCHETYPE_HRID());
     }
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -26,6 +26,7 @@ public class CComplexObjectParser extends BaseTreeWalker {
 
     private final PrimitivesConstraintParser primitivesConstraintParser;
     private final MetaModels metaModels;
+    private Archetype archetype;
 
     public CComplexObjectParser(ANTLRParserErrors errors, MetaModels metaModels) {
         super(errors);
@@ -37,7 +38,7 @@ public class CComplexObjectParser extends BaseTreeWalker {
         RulesSection result = new RulesSection();
 
         result.setContent(context.getText());
-        RulesParser rulesParser = new RulesParser(getErrors());
+        RulesParser rulesParser = new RulesParser(getErrors(), getArchetype());
         for(AssertionContext assertion:context.assertion_list().assertion()) {
             result.addRule(rulesParser.parse(assertion));
         }
@@ -400,5 +401,11 @@ public class CComplexObjectParser extends BaseTreeWalker {
         return interval;
     }
 
+    public Archetype getArchetype() {
+        return archetype;
+    }
 
+    public void setArchetype(Archetype archetype) {
+        this.archetype = archetype;
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -1,7 +1,7 @@
 package com.nedap.archie.adlparser.treewalkers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nedap.archie.adlparser.antlr.AdlParser;
+
 import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
 import com.nedap.archie.aom.*;
@@ -26,7 +26,6 @@ public class CComplexObjectParser extends BaseTreeWalker {
 
     private final PrimitivesConstraintParser primitivesConstraintParser;
     private final MetaModels metaModels;
-    private Archetype archetype;
 
     public CComplexObjectParser(ANTLRParserErrors errors, MetaModels metaModels) {
         super(errors);
@@ -38,7 +37,7 @@ public class CComplexObjectParser extends BaseTreeWalker {
         RulesSection result = new RulesSection();
 
         result.setContent(context.getText());
-        RulesParser rulesParser = new RulesParser(getErrors(), getArchetype());
+        RulesParser rulesParser = new RulesParser(getErrors());
         for(AssertionContext assertion:context.assertion_list().assertion()) {
             result.addRule(rulesParser.parse(assertion));
         }
@@ -401,11 +400,4 @@ public class CComplexObjectParser extends BaseTreeWalker {
         return interval;
     }
 
-    public Archetype getArchetype() {
-        return archetype;
-    }
-
-    public void setArchetype(Archetype archetype) {
-        this.archetype = archetype;
-    }
 }

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DummyRulesPrimitiveObjectParent extends CAttribute {
-    private final Archetype archetype;
+    private final transient Archetype archetype;
 
     public DummyRulesPrimitiveObjectParent() {
         super();

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
@@ -1,0 +1,43 @@
+package com.nedap.archie.adlparser.treewalkers;
+
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.ArchetypeConstraint;
+import com.nedap.archie.aom.CAttribute;
+import com.nedap.archie.paths.PathSegment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DummyRulesPrimitiveObjectParent extends CAttribute {
+    private final Archetype archetype;
+
+    public DummyRulesPrimitiveObjectParent() {
+        super();
+        this.archetype = null;
+    }
+
+    public DummyRulesPrimitiveObjectParent(Archetype archetype) {
+        super();
+        this.archetype = archetype;
+    }
+
+    @Override
+    public List<PathSegment> getPathSegments() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String getLogicalPath() {
+        return "/";
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return false;
+    }
+
+    @Override
+    public Archetype getArchetype() {
+        return archetype;
+    }
+}

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
@@ -4,31 +4,45 @@ import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeConstraint;
 import com.nedap.archie.aom.CAttribute;
 import com.nedap.archie.paths.PathSegment;
+import com.nedap.archie.query.APathQuery;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class DummyRulesPrimitiveObjectParent extends CAttribute {
     private final transient Archetype archetype;
+    private String path;
 
     public DummyRulesPrimitiveObjectParent() {
         super();
         this.archetype = null;
+        this.path = "/";
     }
 
     public DummyRulesPrimitiveObjectParent(Archetype archetype) {
         super();
         this.archetype = archetype;
+        this.path = "/";
+    }
+
+    public DummyRulesPrimitiveObjectParent(Archetype archetype, String path) {
+        super();
+        this.archetype = archetype;
+        this.path = path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
     }
 
     @Override
     public List<PathSegment> getPathSegments() {
-        return new ArrayList<>();
+        return new APathQuery(path).getPathSegments();
     }
 
     @Override
     public String getLogicalPath() {
-        return "/";
+        return path;
     }
 
     @Override

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/DummyRulesPrimitiveObjectParent.java
@@ -11,38 +11,26 @@ import java.util.List;
 
 public class DummyRulesPrimitiveObjectParent extends CAttribute {
     private final transient Archetype archetype;
-    private String path;
-
-    public DummyRulesPrimitiveObjectParent() {
-        super();
-        this.archetype = null;
-        this.path = "/";
-    }
+    private List<PathSegment> pathSegments;
 
     public DummyRulesPrimitiveObjectParent(Archetype archetype) {
         super();
         this.archetype = archetype;
-        this.path = "/";
+        this.pathSegments = new ArrayList<>();
     }
 
-    public DummyRulesPrimitiveObjectParent(Archetype archetype, String path) {
-        super();
-        this.archetype = archetype;
-        this.path = path;
-    }
-
-    public void setPath(String path) {
-        this.path = path;
+    public void setPathSegments(List<PathSegment> pathSegments) {
+        this.pathSegments = pathSegments;
     }
 
     @Override
     public List<PathSegment> getPathSegments() {
-        return new APathQuery(path).getPathSegments();
+       return pathSegments;
     }
 
     @Override
     public String getLogicalPath() {
-        return path;
+        return getPath();
     }
 
     @Override
@@ -54,4 +42,6 @@ public class DummyRulesPrimitiveObjectParent extends CAttribute {
     public Archetype getArchetype() {
         return archetype;
     }
+
+
 }

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -21,7 +21,6 @@ import java.util.regex.Pattern;
  */
 public class RulesParser extends BaseTreeWalker {
 
-    private final Archetype archetype;
     private PrimitivesConstraintParser primitivesConstraintParser;
     public static final Pattern VARIABLE_ASSIGNMENT_PATTERN = Pattern.compile("\\$(?<name>.*)\\:(?<type>.*)");
 
@@ -31,7 +30,6 @@ public class RulesParser extends BaseTreeWalker {
 
     public RulesParser(ANTLRParserErrors errors, Archetype archetype) {
         super(errors);
-        this.archetype = archetype;
         primitivesConstraintParser = new PrimitivesConstraintParser(errors);
     }
 
@@ -190,7 +188,7 @@ public class RulesParser extends BaseTreeWalker {
         } else {
             cPrimitiveObject = primitivesConstraintParser.parseRegex(context.CONTAINED_REGEXP());
         }
-        cPrimitiveObject.setParent(new DummyRulesPrimitiveObjectParent(archetype)); //rules do not yet have a parent, but we'd like to add the archetype
+        //cPrimitiveObject.setParent(dummyRule); //rules do not yet have a parent, but we'd like to add the archetype
         return new BinaryOperator(ExpressionType.BOOLEAN, OperatorKind.matches, leftOperand, new Constraint(cPrimitiveObject));
     }
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -1,17 +1,13 @@
 package com.nedap.archie.adlparser.treewalkers;
 
-import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
-import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.ArchetypeConstraint;
-import com.nedap.archie.paths.PathSegment;
-import com.nedap.archie.serializer.odin.OdinValueParser;
+import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.aom.CPrimitiveObject;
 import com.nedap.archie.rules.*;
+import com.nedap.archie.serializer.odin.OdinValueParser;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -25,10 +21,6 @@ public class RulesParser extends BaseTreeWalker {
     public static final Pattern VARIABLE_ASSIGNMENT_PATTERN = Pattern.compile("\\$(?<name>.*)\\:(?<type>.*)");
 
     public RulesParser(ANTLRParserErrors errors) {
-        this(errors, null);
-    }
-
-    public RulesParser(ANTLRParserErrors errors, Archetype archetype) {
         super(errors);
         primitivesConstraintParser = new PrimitivesConstraintParser(errors);
     }
@@ -188,7 +180,7 @@ public class RulesParser extends BaseTreeWalker {
         } else {
             cPrimitiveObject = primitivesConstraintParser.parseRegex(context.CONTAINED_REGEXP());
         }
-        //cPrimitiveObject.setParent(dummyRule); //rules do not yet have a parent, but we'd like to add the archetype
+
         return new BinaryOperator(ExpressionType.BOOLEAN, OperatorKind.matches, leftOperand, new Constraint(cPrimitiveObject));
     }
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -2,6 +2,9 @@ package com.nedap.archie.adlparser.treewalkers;
 
 import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.ArchetypeConstraint;
+import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.serializer.odin.OdinValueParser;
 import com.nedap.archie.aom.CPrimitiveObject;
 import com.nedap.archie.rules.*;
@@ -18,11 +21,17 @@ import java.util.regex.Pattern;
  */
 public class RulesParser extends BaseTreeWalker {
 
+    private final Archetype archetype;
     private PrimitivesConstraintParser primitivesConstraintParser;
     public static final Pattern VARIABLE_ASSIGNMENT_PATTERN = Pattern.compile("\\$(?<name>.*)\\:(?<type>.*)");
 
     public RulesParser(ANTLRParserErrors errors) {
+        this(errors, null);
+    }
+
+    public RulesParser(ANTLRParserErrors errors, Archetype archetype) {
         super(errors);
+        this.archetype = archetype;
         primitivesConstraintParser = new PrimitivesConstraintParser(errors);
     }
 
@@ -170,9 +179,11 @@ public class RulesParser extends BaseTreeWalker {
 
 
     private Expression parseBooleanConstraint(BooleanConstraintContext context) {
-        ModelReference modelReference = null;
+        Expression leftOperand = null;
         if(context.adlRulesPath() != null) {
-            modelReference = parseModelReference(context.adlRulesPath());
+            leftOperand = parseModelReference(context.adlRulesPath());
+        } else if (context.variableReference() != null) {
+            leftOperand = parseVariableReference(context.variableReference());
         }
 
         CPrimitiveObject cPrimitiveObject = null;
@@ -181,7 +192,8 @@ public class RulesParser extends BaseTreeWalker {
         } else {
             cPrimitiveObject = primitivesConstraintParser.parseRegex(context.CONTAINED_REGEXP());
         }
-        return new BinaryOperator(ExpressionType.BOOLEAN, OperatorKind.matches, modelReference, new Constraint(cPrimitiveObject));
+        cPrimitiveObject.setParent(new DummyRulesPrimitiveObjectParent(archetype)); //rules do not yet have a parent, but we'd like to add the archetype
+        return new BinaryOperator(ExpressionType.BOOLEAN, OperatorKind.matches, leftOperand, new Constraint(cPrimitiveObject));
     }
 
     private Expression parseEqualityExpression(EqualityExpressionContext context) {

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/RulesParser.java
@@ -180,10 +180,8 @@ public class RulesParser extends BaseTreeWalker {
 
     private Expression parseBooleanConstraint(BooleanConstraintContext context) {
         Expression leftOperand = null;
-        if(context.adlRulesPath() != null) {
-            leftOperand = parseModelReference(context.adlRulesPath());
-        } else if (context.variableReference() != null) {
-            leftOperand = parseVariableReference(context.variableReference());
+        if(context.equalityExpression() != null) {
+            leftOperand = parseEqualityExpression(context.equalityExpression());
         }
 
         CPrimitiveObject cPrimitiveObject = null;

--- a/aom/src/main/java/com/nedap/archie/aom/Archetype.java
+++ b/aom/src/main/java/com/nedap/archie/aom/Archetype.java
@@ -1,8 +1,6 @@
 package com.nedap.archie.aom;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Strings;
-import com.nedap.archie.adlparser.treewalkers.DummyRulesPrimitiveObjectParent;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;

--- a/aom/src/main/java/com/nedap/archie/aom/Archetype.java
+++ b/aom/src/main/java/com/nedap/archie/aom/Archetype.java
@@ -2,6 +2,7 @@ package com.nedap.archie.aom;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Strings;
+import com.nedap.archie.adlparser.treewalkers.DummyRulesPrimitiveObjectParent;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;

--- a/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
@@ -72,7 +72,6 @@ public abstract class ArchetypeConstraint extends ArchetypeModelObject {
     @JsonIgnore
     public abstract boolean isLeaf();
 
-
     @JsonIgnore
     @XmlTransient
     public Archetype getArchetype() {

--- a/aom/src/main/java/com/nedap/archie/aom/ArchetypeModelObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ArchetypeModelObject.java
@@ -1,6 +1,6 @@
 package com.nedap.archie.aom;
 
-import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.kryo5.Kryo;
 import com.nedap.archie.base.OpenEHRBase;
 import com.nedap.archie.util.KryoUtil;
 
@@ -16,10 +16,10 @@ public abstract class ArchetypeModelObject extends OpenEHRBase implements Serial
     public ArchetypeModelObject clone() {
         Kryo kryo = null;
         try {
-            kryo = KryoUtil.getPool().borrow();
+            kryo = KryoUtil.getPool().obtain();
             return kryo.copy(this);
         } finally {
-            KryoUtil.getPool().release(kryo);
+            KryoUtil.getPool().free(kryo);
         }
     }
 

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -2,6 +2,7 @@ package com.nedap.archie.aom.primitives;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nedap.archie.ArchieLanguageConfiguration;
+import com.nedap.archie.ValidationConfiguration;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.aom.CPrimitiveObject;
@@ -68,9 +69,10 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
         }
         if(value != null && value.getTerminologyId() != null && !value.getTerminologyId().equalsIgnoreCase("local") && !AOMUtils.isValueSetCode(value.getTerminologyId())) {
             //this is a non-local terminology. If a term binding is there, we may be able to validate, if external, we wil not be able to
-            //TODO: check term bindings as well! However, no idea how to handle the URIs, as the value will not be URI. I think?
             //so return true for now for non-local terminology values
-            return true;
+            //TODO: implement checking for direct term bindings later
+            //TODO: implement checking for include openehr-terminology
+            return !ValidationConfiguration.isFailOnUnknownTerminologyId();
         }
         List<String> values = this.getValueSetExpanded();
         if(values != null && !values.isEmpty()) {

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -63,17 +63,11 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
         if(getConstraint().isEmpty()) {
             return true;
         }
-        for(String constraint:getConstraint()) {
-            if(constraint.startsWith("at")) {
-                if(value.getCodeString() != null && value.getCodeString().equals(constraint)) {
-                    return true;
-                }
-            } else if (constraint.startsWith("ac")) {
-                if(value.getTerminologyId() != null && value.getTerminologyId().equals(constraint)) {
-                    return true;
-                }
-            }
+        List<String> values = this.getValueSetExpanded();
+        if(values != null && !values.isEmpty()) {
+            return value.getCodeString() != null && values.contains(value.getCodeString());
         }
+        //TODO: check term bindings as well!
         return false;
     }
 

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -17,9 +17,12 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -63,11 +66,17 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
         if(getConstraint().isEmpty()) {
             return true;
         }
+        if(value != null && value.getTerminologyId() != null && !value.getTerminologyId().equalsIgnoreCase("local") && !AOMUtils.isValueSetCode(value.getTerminologyId())) {
+            //this is a non-local terminology. If a term binding is there, we may be able to validate, if external, we wil not be able to
+            //TODO: check term bindings as well! However, no idea how to handle the URIs, as the value will not be URI. I think?
+            //so return true for now for non-local terminology values
+            return true;
+        }
         List<String> values = this.getValueSetExpanded();
         if(values != null && !values.isEmpty()) {
             return value.getCodeString() != null && values.contains(value.getCodeString());
         }
-        //TODO: check term bindings as well!
+
         return false;
     }
 

--- a/aom/src/main/java/com/nedap/archie/query/AOMPathQuery.java
+++ b/aom/src/main/java/com/nedap/archie/query/AOMPathQuery.java
@@ -233,7 +233,7 @@ public class AOMPathQuery {
      * Find anything matching a specific predicate anywhere inside the APath query. Can be at the end of the full query, at the first matching CComplexObjectProxy or anywhere in between
      * Useful mainly when flattening, probably does not have many other uses
      */
-    public ArchetypeModelObject findMatchingPredicate(CComplexObject root, Predicate predicate) {
+    public ArchetypeModelObject findMatchingPredicate(CComplexObject root, Predicate<ArchetypeModelObject> predicate) {
         List<ArchetypeModelObject> result = new ArrayList<>();
         result.add(root);
         for(PathSegment segment:this.pathSegments) {
@@ -253,7 +253,7 @@ public class AOMPathQuery {
      * Find all path segments matching a specific predicate anywhere inside the APath query. Can be at the end of the full query, at the first matching CComplexObjectProxy or anywhere in between
      * Useful mainly when flattening, probably does not have many other uses
      */
-    public List<ArchetypeModelObject> findAllMatchingPredicate(CComplexObject root, Predicate predicate) {
+    public List<ArchetypeModelObject> findAllMatchingPredicate(CComplexObject root, Predicate<ArchetypeModelObject> predicate) {
         List<ArchetypeModelObject> currentObjects = new ArrayList<>();
         currentObjects.add(root);
         List<ArchetypeModelObject> results = new ArrayList<>();

--- a/base/src/main/java/com/nedap/archie/ValidationConfiguration.java
+++ b/base/src/main/java/com/nedap/archie/ValidationConfiguration.java
@@ -1,0 +1,33 @@
+package com.nedap.archie;
+
+/**
+ * This controls static configuration, applied to all Validation runs, that cannot be applied on the validator itself
+ * due to technical reasons
+ */
+public class ValidationConfiguration {
+
+    private static boolean failOnUnknownTerminologyId = false;
+
+    /**
+     * Set whether to fail validation or not if in CTerminologyCode.isValidValue(), an uknown terminology is encountered
+     * Since Archie does not validate external terminologies at all, this currently means all terminologies with id "local",
+     * including "openehr" until that is implemented.
+     * Sets this globally for the entire JVM!
+     * @param failOnUnknownTerminologyId whether to fail or not
+     */
+    public static void setFailOnUnknownTerminologyId(boolean failOnUnknownTerminologyId) {
+        ValidationConfiguration.failOnUnknownTerminologyId = failOnUnknownTerminologyId;
+    }
+
+
+    /**
+    * Get whether to fail validation or not if in CTerminologyCode.isValidValue(), an uknown terminology is encountered
+    * Since Archie does not validate external terminologies at all, this currently means all terminologies with id "local",
+    * including "openehr" until that is implemented.
+    * This configuration is applied globally to the entire JVM!
+    * @return whether to fail or not
+    **/
+    public static boolean isFailOnUnknownTerminologyId() {
+        return failOnUnknownTerminologyId;
+    }
+}

--- a/bmm/src/main/java/org/openehr/bmm/v2/persistence/PBmmBase.java
+++ b/bmm/src/main/java/org/openehr/bmm/v2/persistence/PBmmBase.java
@@ -1,6 +1,6 @@
 package org.openehr.bmm.v2.persistence;
 
-import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.kryo5.Kryo;
 import com.nedap.archie.base.OpenEHRBase;
 import com.nedap.archie.util.KryoUtil;
 
@@ -9,11 +9,11 @@ public class PBmmBase extends OpenEHRBase {
     public PBmmBase clone() {
         Kryo kryo = null;
         try {
-            kryo = KryoUtil.getPool().borrow();
+            kryo = KryoUtil.getPool().obtain();
             return kryo.copy(this);
         }
         finally {
-            KryoUtil.getPool().release(kryo);
+            KryoUtil.getPool().free(kryo);
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ subprojects {
     compile 'com.google.guava:guava:29.0-jre'
 
     compile "org.reflections:reflections:${reflectionsVersion}"
-    compile 'com.esotericsoftware:kryo-shaded:4.0.2' //for easy and relatively fast object cloning
+    compile 'com.esotericsoftware.kryo:kryo5:5.0.3'
 
     compile('commons-io:commons-io:2.7'){
       exclude group: 'commons-logging', module: 'commons-logging'

--- a/grammars/src/main/antlr/adl_rules.g4
+++ b/grammars/src/main/antlr/adl_rules.g4
@@ -63,7 +63,7 @@ booleanConstraintExpression
     | equalityExpression;
 
 
-booleanConstraint: adlRulesPath SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
+booleanConstraint: (adlRulesPath | variableReference) SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
 
 equalityExpression:
     relOpExpression

--- a/grammars/src/main/antlr/adl_rules.g4
+++ b/grammars/src/main/antlr/adl_rules.g4
@@ -63,7 +63,7 @@ booleanConstraintExpression
     | equalityExpression;
 
 
-booleanConstraint: (adlRulesPath | variableReference) SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
+booleanConstraint: equalityExpression SYM_MATCHES ('{' c_primitive_object '}' | CONTAINED_REGEXP );
 
 equalityExpression:
     relOpExpression

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/RMObject.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/RMObject.java
@@ -1,6 +1,6 @@
 package com.nedap.archie.rm;
 
-import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.kryo5.Kryo;
 import com.nedap.archie.base.OpenEHRBase;
 import com.nedap.archie.util.KryoUtil;
 
@@ -16,10 +16,10 @@ public abstract class RMObject extends OpenEHRBase implements Serializable, Clon
     public RMObject clone() {
         Kryo kryo = null;
         try {
-            kryo = KryoUtil.getPool().borrow();
+            kryo = KryoUtil.getPool().obtain();
             return kryo.copy(this);
         } finally {
-            KryoUtil.getPool().release(kryo);
+            KryoUtil.getPool().free(kryo);
         }
     }
 

--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -1,6 +1,6 @@
 package com.nedap.archie.flattener;
 
-import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.kryo5.Kryo;
 import com.nedap.archie.util.KryoUtil;
 
 public class FlattenerConfiguration {
@@ -112,10 +112,10 @@ public class FlattenerConfiguration {
     public FlattenerConfiguration clone() {
         Kryo kryo = null;
         try {
-            kryo = KryoUtil.getPool().borrow();
+            kryo = KryoUtil.getPool().obtain();
             return kryo.copy(this);
         } finally {
-            KryoUtil.getPool().release(kryo);
+            KryoUtil.getPool().free(kryo);
         }
     }
 

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
@@ -38,6 +38,12 @@ public class AssertionResult {
      */
     private List<String> pathsThatMustNotExist = new ArrayList<>();
 
+    /**
+     * Paths where a term code must now be constrained to a value set. Use for example to change a drop down list, to a subselection of
+     * the original full list of values
+     */
+    private Map<String, String> pathsConstrainedToValueSets = new LinkedHashMap<>();
+
     public String getTag() {
         return tag;
     }
@@ -90,6 +96,14 @@ public class AssertionResult {
         return pathsThatMustNotExist;
     }
 
+    public Map<String, String> getPathsConstrainedToValueSets() {
+        return pathsConstrainedToValueSets;
+    }
+
+    public void setPathsConstrainedToValueSets(Map<String, String> pathsConstrainedToValueSets) {
+        this.pathsConstrainedToValueSets = pathsConstrainedToValueSets;
+    }
+
     public void setPathsThatMustNotExist(List<String> pathsThatMustNotExist) {
         this.pathsThatMustNotExist = pathsThatMustNotExist;
     }
@@ -129,5 +143,9 @@ public class AssertionResult {
             setPathValues.put(path, value);
         }
 
+    }
+
+    public void constrainPathToValueSet(String path, String valueSetId) {
+        pathsConstrainedToValueSets.put(path, valueSetId);
     }
 }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/DummyRulesPrimitiveObjectParent.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/DummyRulesPrimitiveObjectParent.java
@@ -1,4 +1,4 @@
-package com.nedap.archie.adlparser.treewalkers;
+package com.nedap.archie.rules.evaluation;
 
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeConstraint;

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
@@ -2,6 +2,7 @@ package com.nedap.archie.rules.evaluation;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.nedap.archie.aom.CPrimitiveObject;
+import com.nedap.archie.aom.utils.AOMUtils;
 import com.nedap.archie.query.RMObjectWithPath;
 import com.nedap.archie.rules.BinaryOperator;
 import com.nedap.archie.rules.Constraint;
@@ -140,20 +141,22 @@ class FixableAssertionsChecker {
             }
             ValueList valueList = new ValueList();
             switch(object.getClass().getSimpleName()) {
-                case "CTerminologyCode":  {
-                        String constraint = (String) constraints.get(0);
+                case "CTerminologyCode": {
+                    String constraint = (String) constraints.get(0);
+                    if (AOMUtils.isValueCode(constraint)) {
                         valueList.addValue(constraint, Collections.emptyList());
                         String path = resolveModelReference(pathToSet);
-                        if(path.endsWith("symbol")) { // different for DV_CODED_TEXT and DV_CODEPHRASE
+                        if (path.endsWith("symbol")) { // different for DV_CODED_TEXT and DV_CODEPHRASE
                             /// it would be better to check the actual type, but hasn't been done now
                             //this limits this to the OpenEHR RM
                             path = path + "/defining_code/code_string";
-                        } else if(path.endsWith("defining_code")) {
+                        } else if (path.endsWith("defining_code")) {
                             path = path + "/code_string";
                         }
                         setPathsToValues(assertionResult, path, valueList);
                     }
                     break;
+                }
                 case "CString": {
                         String constraint = (String) constraints.get(0);
                         valueList.addValue(constraint, Collections.emptyList());

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
@@ -154,6 +154,9 @@ class FixableAssertionsChecker {
                             path = path + "/code_string";
                         }
                         setPathsToValues(assertionResult, path, valueList);
+                    } else if (AOMUtils.isValueSetCode(constraint)) {
+                        String path = resolveModelReference(pathToSet);
+                        assertionResult.constrainPathToValueSet(path, constraint);
                     }
                     break;
                 }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 /**
  * Created by pieter.bos on 31/03/16.
@@ -34,6 +35,7 @@ public class RuleEvaluation<T> {
     //evaluation state
     private T root;
     private VariableMap variables;
+    private Stack<String> forAllStack;
     EvaluationResult evaluationResult;
     private List<AssertionResult> assertionResults;
 
@@ -78,6 +80,7 @@ public class RuleEvaluation<T> {
 
         ruleElementValues = ArrayListMultimap.create();
         variables = new VariableMap();
+        forAllStack = new Stack<>();
         assertionResults = new ArrayList<>();
         evaluationResult = new EvaluationResult();
         queryContext = new RMQueryContext(modelInfoLookup, this.root, jaxbContext);
@@ -163,5 +166,20 @@ public class RuleEvaluation<T> {
 
     public ModelInfoLookup getModelInfoLookup() {
         return modelInfoLookup;
+    }
+
+    public void enterForAllScope(String path) {
+        forAllStack.push(path);
+    }
+
+    public void exitForAllScope() {
+        forAllStack.pop();
+    }
+
+    public String getForAllScope() {
+        if(forAllStack.isEmpty()) {
+            return "/";
+        }
+        return forAllStack.peek();
     }
 }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -58,7 +58,7 @@ public class RuleEvaluation<T> {
         add(new VariableDeclarationEvaluator());
         add(new ConstantEvaluator());
         add(new AssertionEvaluator());
-        add(new BinaryOperatorEvaluator(modelInfoLookup));
+        add(new BinaryOperatorEvaluator(modelInfoLookup, archetype));
         add(new UnaryOperatorEvaluator());
         add(new VariableReferenceEvaluator());
         add(new ModelReferenceEvaluator());

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/RuleEvaluation.java
@@ -35,7 +35,6 @@ public class RuleEvaluation<T> {
     //evaluation state
     private T root;
     private VariableMap variables;
-    private Stack<String> forAllStack;
     EvaluationResult evaluationResult;
     private List<AssertionResult> assertionResults;
 
@@ -80,7 +79,6 @@ public class RuleEvaluation<T> {
 
         ruleElementValues = ArrayListMultimap.create();
         variables = new VariableMap();
-        forAllStack = new Stack<>();
         assertionResults = new ArrayList<>();
         evaluationResult = new EvaluationResult();
         queryContext = new RMQueryContext(modelInfoLookup, this.root, jaxbContext);
@@ -168,18 +166,4 @@ public class RuleEvaluation<T> {
         return modelInfoLookup;
     }
 
-    public void enterForAllScope(String path) {
-        forAllStack.push(path);
-    }
-
-    public void exitForAllScope() {
-        forAllStack.pop();
-    }
-
-    public String getForAllScope() {
-        if(forAllStack.isEmpty()) {
-            return "/";
-        }
-        return forAllStack.peek();
-    }
 }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -2,13 +2,10 @@ package com.nedap.archie.rules.evaluation.evaluators;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import com.nedap.archie.adlparser.treewalkers.DummyRulesPrimitiveObjectParent;
+import com.nedap.archie.rules.evaluation.DummyRulesPrimitiveObjectParent;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeConstraint;
 import com.nedap.archie.aom.ArchetypeModelObject;
-import com.nedap.archie.aom.ArchetypeSlot;
-import com.nedap.archie.aom.CArchetypeRoot;
-import com.nedap.archie.aom.CComplexObject;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.query.AOMPathQuery;
@@ -23,11 +20,9 @@ import com.nedap.archie.rules.evaluation.RuleEvaluation;
 import com.nedap.archie.rules.evaluation.Value;
 import com.nedap.archie.rules.evaluation.ValueList;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.function.Predicate;
 
 import static com.nedap.archie.rules.evaluation.evaluators.FunctionUtil.checkAndHandleNull;
 

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -112,7 +112,7 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
                 //against the correct part of the archetype. This is a bit of a hack
                 //better would be to flatten rules in a separate structure for each included archetype, similar to componentTerminologies.
                 //and to evaluate those. That is a later improvement than this fix
-                dummyParent.setPath(convertToArchetypePath((String) value.getPaths().get(0)));
+                dummyParent.setPathSegments(convertToArchetypePath((String) value.getPaths().get(0)));
             }
             result.addValue(constraint.getItem().isValidValue(lookup, value.getValue()), value.getPaths());
         }
@@ -120,7 +120,7 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
 
     }
 
-    private String convertToArchetypePath(String path) {
+    private List<PathSegment> convertToArchetypePath(String path) {
         List<PathSegment> segments = new APathQuery(path).getPathSegments();
         for(PathSegment segment:segments) {
             if(segment.getIndex() != null) {
@@ -128,15 +128,15 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
             }
         }
         String archetypePath = segments.isEmpty() ? "/" : Joiner.on("").join(segments);
-        List<ArchetypeModelObject> allMatchingPredicate = new AOMPathQuery(archetypePath).findAllMatchingPredicate(archetype.getDefinition(), o -> o instanceof CArchetypeRoot || o instanceof ArchetypeSlot);
+        List<ArchetypeModelObject> allMatchingPredicate = new AOMPathQuery(archetypePath).findAllMatchingPredicate(archetype.getDefinition(), o -> true);
         if(allMatchingPredicate.isEmpty()) {
-            return archetypePath;
+            return segments;
         } else {
             ArchetypeModelObject archetypeModelObject = allMatchingPredicate.get(allMatchingPredicate.size() - 1);
             if(archetypeModelObject instanceof ArchetypeConstraint) {
-                return ((ArchetypeConstraint) archetypeModelObject).getPath();
+                return ((ArchetypeConstraint) archetypeModelObject).getPathSegments();
             }
-            return archetypePath;
+            return segments;
         }
     }
 

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ForAllEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ForAllEvaluator.java
@@ -43,7 +43,9 @@ public class ForAllEvaluator implements Evaluator<ForAllStatement> {
             valueList.setType(PrimitiveType.ObjectReference);
 
             //set the variable
+            evaluation.enterForAllScope(path);
             evaluation.getVariableMap().put(variableName, valueList);
+
             //evaluate
             ValueList evaluated = evaluation.evaluate(toEvaluate);
             allPaths.addAll(evaluated.getAllPaths());
@@ -58,8 +60,10 @@ public class ForAllEvaluator implements Evaluator<ForAllStatement> {
             } else if(evaluated.getType() == PrimitiveType.Integer || evaluated.getType() == PrimitiveType.Real) {
                 throw new UnsupportedOperationException("cannot convert type to boolean yet: " + evaluated.getType());
             }
+            evaluation.exitForAllScope();
         }
         evaluation.getVariableMap().put(variableName, null);
+
         return new ValueList(Lists.newArrayList(new Value(resultingCheck, allPaths)));
     }
 

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ForAllEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ForAllEvaluator.java
@@ -43,7 +43,6 @@ public class ForAllEvaluator implements Evaluator<ForAllStatement> {
             valueList.setType(PrimitiveType.ObjectReference);
 
             //set the variable
-            evaluation.enterForAllScope(path);
             evaluation.getVariableMap().put(variableName, valueList);
 
             //evaluate
@@ -60,7 +59,6 @@ public class ForAllEvaluator implements Evaluator<ForAllStatement> {
             } else if(evaluated.getType() == PrimitiveType.Integer || evaluated.getType() == PrimitiveType.Real) {
                 throw new UnsupportedOperationException("cannot convert type to boolean yet: " + evaluated.getType());
             }
-            evaluation.exitForAllScope();
         }
         evaluation.getVariableMap().put(variableName, null);
 

--- a/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -60,6 +60,17 @@ public class TerminologyCodeConstraintsTest {
     }
 
     @Test
+    public void externalTerminology() {
+        CTerminologyCode code = new CTerminologyCode();
+        code.setParent(new DummyRulesPrimitiveObjectParent(archetype));
+        code.addConstraint("ac12");
+        //this is valid, because we have no idea about the binding currently. Could be invalid later, when we have proper
+        //external terminology support
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[snomedct::72489423]")));
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[anything::atall]")));
+    }
+
+    @Test
     public void terminologyCodeConstraint() {
         CTerminologyCode code = new CTerminologyCode();
         code.setParent(new DummyRulesPrimitiveObjectParent(archetype));

--- a/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -2,6 +2,7 @@ package com.nedap.archie.aom;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.nedap.archie.ValidationConfiguration;
 import com.nedap.archie.rules.evaluation.DummyRulesPrimitiveObjectParent;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;

--- a/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -2,7 +2,7 @@ package com.nedap.archie.aom;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.nedap.archie.adlparser.treewalkers.DummyRulesPrimitiveObjectParent;
+import com.nedap.archie.rules.evaluation.DummyRulesPrimitiveObjectParent;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.aom.terminology.ValueSet;

--- a/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -1,20 +1,27 @@
 package com.nedap.archie.aom;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.nedap.archie.adlparser.treewalkers.DummyRulesPrimitiveObjectParent;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.aom.terminology.ValueSet;
 import com.nedap.archie.base.terminology.TerminologyCode;
+import com.nedap.archie.flattener.Flattener;
+import com.nedap.archie.flattener.FlattenerConfiguration;
+import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
+import com.nedap.archie.flattener.specexamples.FlattenerTestUtil;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import org.junit.Before;
 import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -97,5 +104,20 @@ public class TerminologyCodeConstraintsTest {
         text.setDefiningCode(null);
         assertFalse(code.isValidValue(ArchieRMInfoLookup.getInstance(), text));
         assertFalse(code.isValidValue(ArchieRMInfoLookup.getInstance(), null));
+    }
+
+    @Test
+    public void validationInOptTest() throws Exception {
+        //getting the term for a use archetype is a bit of a tricky situation - it's not for the 'id1' code,
+        //it's for the code in the parent. So do some specific test here
+        InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
+        repository.addArchetype(FlattenerTestUtil.parse("/com/nedap/archie/aom/openEHR-EHR-COMPOSITION.parent.v1.0.0.adls"));
+        repository.addArchetype(FlattenerTestUtil.parse("/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls"));
+
+        //create operational template
+        Flattener flattener = new Flattener(repository, BuiltinReferenceModels.getMetaModels(), FlattenerConfiguration.forOperationalTemplate());
+        OperationalTemplate opt = (OperationalTemplate) flattener.flatten(repository.getArchetype("openEHR-EHR-COMPOSITION.parent.v1.0.0"));
+        CTerminologyCode code = opt.itemAtPath("/content/data/items/value/defining_code[1]");
+        assertEquals(Lists.newArrayList("at4", "at5", "at6"), code.getValueSetExpanded());
     }
 }

--- a/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -1,11 +1,19 @@
 package com.nedap.archie.aom;
 
+import com.google.common.collect.Sets;
+import com.nedap.archie.adlparser.treewalkers.DummyRulesPrimitiveObjectParent;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
+import com.nedap.archie.aom.terminology.ArchetypeTerminology;
+import com.nedap.archie.aom.terminology.ValueSet;
 import com.nedap.archie.base.terminology.TerminologyCode;
 import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -14,6 +22,25 @@ import static org.junit.Assert.assertTrue;
  * Created by pieter.bos on 23/02/16.
  */
 public class TerminologyCodeConstraintsTest {
+
+    private Archetype archetype;
+
+    @Before
+    public void setupArchetype() {
+        archetype = new AuthoredArchetype();
+        ArchetypeTerminology terminology = new ArchetypeTerminology();
+        archetype.setTerminology(terminology);
+        Map<String, ValueSet> valueSets = new LinkedHashMap<>();
+        terminology.setValueSets(valueSets);
+        ValueSet ac12 = new ValueSet();
+        ac12.setId("ac12");
+        ac12.setMembers(Sets.newHashSet("at23", "at24"));
+        ValueSet ac13 = new ValueSet();
+        ac13.setId("ac13");
+        ac13.setMembers(Sets.newHashSet("at24"));
+        valueSets.put("ac12", ac12 );
+        valueSets.put("ac13", ac13 );
+    }
 
     @Test
     public void noConstraint() {
@@ -24,15 +51,18 @@ public class TerminologyCodeConstraintsTest {
     @Test
     public void terminologyIdConstraint() {
         CTerminologyCode code = new CTerminologyCode();
+        code.setParent(new DummyRulesPrimitiveObjectParent(archetype));
         code.addConstraint("ac12");
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at23]")));
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at24]")));
-        assertFalse(code.isValidValue(TerminologyCode.createFromString("[ac13::at23]")));
+        assertFalse(code.isValidValue(TerminologyCode.createFromString("[ac12::at25]")));
+        assertTrue(code.isValidValue(TerminologyCode.createFromString("[local::at23]")));
     }
 
     @Test
     public void terminologyCodeConstraint() {
         CTerminologyCode code = new CTerminologyCode();
+        code.setParent(new DummyRulesPrimitiveObjectParent(archetype));
         code.addConstraint("at23");
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac12::at23]")));
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[ac13::at23]")));
@@ -43,6 +73,7 @@ public class TerminologyCodeConstraintsTest {
     public void dvCodedText() {
         //DV_CODED_TEXT can be constrained by a C_TERMINOLOGY_CONSTRAINT, according to lots of DV_ORDINAL usage in the CKM
         CTerminologyCode code = new CTerminologyCode();
+        code.setParent(new DummyRulesPrimitiveObjectParent(archetype));
         code.addConstraint("at23");
         DvCodedText text = new DvCodedText();
         text.setValue("does not matter for this validation");

--- a/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/TerminologyCodeConstraintsTest.java
@@ -71,10 +71,14 @@ public class TerminologyCodeConstraintsTest {
         CTerminologyCode code = new CTerminologyCode();
         code.setParent(new DummyRulesPrimitiveObjectParent(archetype));
         code.addConstraint("ac12");
-        //this is valid, because we have no idea about the binding currently. Could be invalid later, when we have proper
-        //external terminology support
+
+        ValidationConfiguration.setFailOnUnknownTerminologyId(false);
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[snomedct::72489423]")));
         assertTrue(code.isValidValue(TerminologyCode.createFromString("[anything::atall]")));
+
+        ValidationConfiguration.setFailOnUnknownTerminologyId(true);
+        assertFalse(code.isValidValue(TerminologyCode.createFromString("[snomedct::72489423]")));
+        assertFalse(code.isValidValue(TerminologyCode.createFromString("[anything::atall]")));
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -672,6 +672,7 @@ public class ParsedRulesEvaluationTest {
         codedText.setValue("value 1");
         EvaluationResult result = ruleEvaluation.evaluate(cluster, opt.getRules().getRules());
         AssertionResult assertionResult = result.getAssertionResults().get(0);
+        assertEquals("ac3", assertionResult.getPathsConstrainedToValueSets().get("/items[id2]/items[id2]/value/defining_code"));
 
         //incorrect case next
         codedText.setDefiningCode(new CodePhrase(new TerminologyId("local"), "at26"));//wrong code!
@@ -679,6 +680,7 @@ public class ParsedRulesEvaluationTest {
         EvaluationResult falseResult = ruleEvaluation.evaluate(cluster, opt.getRules().getRules());
         AssertionResult  falseAssertionResult = falseResult.getAssertionResults().get(0);
         assertFalse(falseAssertionResult.getResult());
+        assertEquals("ac3", assertionResult.getPathsConstrainedToValueSets().get("/items[id2]/items[id2]/value/defining_code"));
 
 
     }

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -672,6 +672,7 @@ public class ParsedRulesEvaluationTest {
         codedText.setValue("value 1");
         EvaluationResult result = ruleEvaluation.evaluate(cluster, opt.getRules().getRules());
         AssertionResult assertionResult = result.getAssertionResults().get(0);
+        assertTrue("The given validation rule should pass", assertionResult.getResult());
         assertEquals("ac3", assertionResult.getPathsConstrainedToValueSets().get("/items[id2]/items[id2]/value/defining_code"));
 
         //incorrect case next

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -3,10 +3,20 @@ package com.nedap.archie.rules.evaluation;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.adlparser.modelconstraints.RMConstraintImposer;
 import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.OperationalTemplate;
+import com.nedap.archie.creation.ExampleJsonInstanceGenerator;
+import com.nedap.archie.flattener.Flattener;
+import com.nedap.archie.flattener.FlattenerConfiguration;
+import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
+import com.nedap.archie.json.JacksonUtil;
 import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.composition.Observation;
+import com.nedap.archie.rm.datastructures.Cluster;
 import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datatypes.CodePhrase;
+import com.nedap.archie.rm.datavalues.DvCodedText;
 import com.nedap.archie.rm.datavalues.quantity.DvQuantity;
+import com.nedap.archie.rm.support.identification.TerminologyId;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rules.Assertion;
 import com.nedap.archie.rules.BinaryOperator;
@@ -17,10 +27,12 @@ import com.nedap.archie.testutil.TestUtil;
 import com.nedap.archie.xml.JAXBUtil;
 import org.junit.Before;
 import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 
@@ -60,9 +72,10 @@ public class ParsedRulesEvaluationTest {
 
     }
 
-    private void parse(String filename) throws IOException {
+    private Archetype parse(String filename) throws IOException {
         archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream(filename));
         assertTrue(parser.getErrors().toString(), parser.getErrors().hasNoErrors());
+        return archetype;
     }
 
     @Test
@@ -637,6 +650,36 @@ public class ParsedRulesEvaluationTest {
         assertEquals(false, variables.get("test_neq_test").getObject(0));
         assertEquals(true, variables.get("test_eq_test").getObject(0));
         assertEquals("string contents", variables.get("string_variable").getObject(0));
+
+    }
+
+    @Test
+    public void flattenedRules() throws IOException {
+        Archetype valueSet = parse("matches_valueset.adls");
+        Archetype parent = parse("termcodeparent.adls");
+        InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
+        repository.addArchetype(parent);
+        repository.addArchetype(valueSet);
+        Flattener flattener = new Flattener(repository, BuiltinReferenceModels.getMetaModels(), FlattenerConfiguration.forOperationalTemplate());
+        OperationalTemplate opt = (OperationalTemplate) flattener.flatten(parent);
+        ExampleJsonInstanceGenerator generator = new ExampleJsonInstanceGenerator(BuiltinReferenceModels.getMetaModels(), "en");
+        Map<String, Object> exampleInstance = generator.generate(opt);
+        Cluster cluster = JacksonUtil.getObjectMapper().readValue(JacksonUtil.getObjectMapper().writeValueAsString(exampleInstance), Cluster.class);
+        //correct case first
+        RuleEvaluation ruleEvaluation = new RuleEvaluation(ArchieRMInfoLookup.getInstance(), JAXBUtil.getArchieJAXBContext(), opt);
+        DvCodedText codedText = (DvCodedText) cluster.itemAtPath("/items[1]/items[1]/value[1]");
+        codedText.setDefiningCode(new CodePhrase(new TerminologyId("local"), "at4"));
+        codedText.setValue("value 1");
+        EvaluationResult result = ruleEvaluation.evaluate(cluster, opt.getRules().getRules());
+        AssertionResult assertionResult = result.getAssertionResults().get(0);
+
+        //incorrect case next
+        codedText.setDefiningCode(new CodePhrase(new TerminologyId("local"), "at26"));//wrong code!
+        codedText.setValue("value 26");
+        EvaluationResult falseResult = ruleEvaluation.evaluate(cluster, opt.getRules().getRules());
+        AssertionResult  falseAssertionResult = falseResult.getAssertionResults().get(0);
+        assertFalse(falseAssertionResult.getResult());
+
 
     }
 

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -104,21 +104,7 @@ public class ParsedRulesEvaluationTest {
         return null;
     }
 
-    private Assertion getAssertionByTag(Archetype archetype, String tag) {
-        for(RuleStatement statement:archetype.getRules().getRules()) {
-            if(statement instanceof Assertion) {
-                Assertion assertion = (Assertion) statement;
-                if(Objects.equals(assertion.getTag(), tag)) {
-                    return assertion;
-                }
-            }
-        }
-        return null;
-    }
-
-
-
-    @Test
+      @Test
     public void modelReferences() throws Exception {
         parse("modelreferences.adls");
         RuleEvaluation ruleEvaluation = getRuleEvaluation();
@@ -156,14 +142,46 @@ public class ParsedRulesEvaluationTest {
 
         ruleEvaluation.evaluate(root, archetype.getRules().getRules());
         assertEquals(false, ruleEvaluation.getVariableMap().get("extended_validity").getObject(0));
+        assertEquals(false, ruleEvaluation.getVariableMap().get("extended_validity_2").getObject(0));
+
         ValueList extendedValidity = ruleEvaluation.getVariableMap().get("extended_validity");
+        ValueList extendedValidity2 = ruleEvaluation.getVariableMap().get("extended_validity_2");
+        ValueList variableMatches = ruleEvaluation.getVariableMap().get("variable_matches");
+        assertEquals(false, extendedValidity.getObject(0));
+        assertEquals(false, extendedValidity2.getObject(0));
+        assertEquals(false, variableMatches.getObject(0));
         assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", extendedValidity.getPaths(0).get(0));
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", extendedValidity2.getPaths(0).get(0));
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", variableMatches.getPaths(0).get(0));
         quantity.setMagnitude(20d);
 
         ruleEvaluation.evaluate(root, archetype.getRules().getRules());
         extendedValidity = ruleEvaluation.getVariableMap().get("extended_validity");
         assertEquals(true, extendedValidity.getObject(0));
         assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", extendedValidity.getPaths(0).get(0));
+
+        extendedValidity2 = ruleEvaluation.getVariableMap().get("extended_validity_2");
+        assertEquals(true, extendedValidity2.getObject(0));
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", extendedValidity2.getPaths(0).get(0));
+
+        variableMatches = ruleEvaluation.getVariableMap().get("variable_matches");
+        assertEquals(true, variableMatches.getObject(0));
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", variableMatches.getPaths(0).get(0));
+
+        quantity.setMagnitude(0d);
+
+        ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+        extendedValidity = ruleEvaluation.getVariableMap().get("extended_validity");
+        assertEquals(true, extendedValidity.getObject(0));
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", extendedValidity.getPaths(0).get(0));
+
+        extendedValidity2 = ruleEvaluation.getVariableMap().get("extended_validity_2");
+        assertEquals(false, extendedValidity2.getObject(0));
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", extendedValidity2.getPaths(0).get(0));
+
+        variableMatches = ruleEvaluation.getVariableMap().get("variable_matches");
+        assertEquals(true, variableMatches.getObject(0));
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude", variableMatches.getPaths(0).get(0));
 
     }
 

--- a/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls
@@ -23,7 +23,13 @@ definition
 	    data matches {
 	        ITEM_TREE[id3] matches {
 	            items matches {
-	                ELEMENT[id2]
+	                ELEMENT[id2] matches {
+	                    value matches {
+	                        DV_CODED_TEXT[id26] matches {
+	                            defining_code matches {[ac3]}
+                            }
+                        }
+	                }
 	            }
 	        }
 	    }
@@ -40,5 +46,27 @@ terminology
                 text = <"an element">
                 description = <"an element described">
             >
+            ["ac3"] = <
+                text = <"a value set">
+                description = <"a value set">
+            >
+            ["at4"] = <
+                text = <"Value 1">
+                description = <"Value 1">
+            >
+            ["at5"] = <
+                text = <"Value 2">
+                description = <"Value 2">
+            >
+            ["at6"] = <
+                text = <"Value 3">
+                description = <"Value 3">
+            >
+        >
+    >
+    value_sets = <
+        ["ac3"] = <
+            id = <"ac3">
+            members=<"at4", "at5", "at6">
         >
     >

--- a/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/aom/openEHR-EHR-GENERIC_ENTRY.included.v1.0.0.adls
@@ -2,38 +2,38 @@ archetype (adl_version=2.0.6; rm_release=1.0.4)
     openEHR-EHR-GENERIC_ENTRY.included.v1.0.0
 
 language
-	original_language = <[ISO_639-1::en]>
+    original_language = <[ISO_639-1::en]>
 
 description
-	original_author = <
-		["name"] = <"Pieter Bos">
-	>
-	details = <
-		["en"] = <
-			language = <[ISO_639-1::en]>
-			purpose = <"pto be included generic entry archetype for test">
-			keywords = <"ADL", "test">
-		>
-	>
-	lifecycle_state = <"draft">
+    original_author = <
+        ["name"] = <"Pieter Bos">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"pto be included generic entry archetype for test">
+            keywords = <"ADL", "test">
+        >
+    >
+    lifecycle_state = <"draft">
 
 
 definition
-	GENERIC_ENTRY[id1] matches {
-	    data matches {
-	        ITEM_TREE[id3] matches {
-	            items matches {
-	                ELEMENT[id2] matches {
-	                    value matches {
-	                        DV_CODED_TEXT[id26] matches {
-	                            defining_code matches {[ac3]}
+    GENERIC_ENTRY[id1] matches {
+        data matches {
+            ITEM_TREE[id3] matches {
+                items matches {
+                    ELEMENT[id2] matches {
+                        value matches {
+                            DV_CODED_TEXT[id26] matches {
+                                defining_code matches {[ac3]}
                             }
                         }
-	                }
-	            }
-	        }
-	    }
-	}
+                    }
+                }
+            }
+        }
+    }
 
 terminology
     term_definitions = <

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches.adls
@@ -52,6 +52,9 @@ definition
 
 rules
 	$extended_validity:Boolean ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude matches {|0.0..30.0|}
+	$extended_validity_2:Boolean ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude - 3 matches {|0.0..30.0|}
+	$variable:Real ::= /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude
+	$variable_matches:Boolean ::= $variable matches {|0.0..30.0|}
 
 terminology
 	term_definitions = <

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_valueset.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_valueset.adls
@@ -1,0 +1,70 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-CLUSTER.matches_valueset.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Test for rules, simple constant arithmetics">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	CLUSTER[id1] matches {
+	    items matches {
+	        ELEMENT[id2] occurrences matches {1} matches {
+	            value matches {
+	                DV_CODED_TEXT[id3]
+	            }
+	        }
+        }
+	}
+
+rules
+    /items[id2]/value/defining_code matches {[ac3]}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Cluster">
+				description = <"Cluster">
+			>
+			["id2"] = <
+                text = <"element">
+                description = <"element">
+            >
+            ["ac3"] = <
+                text = <"value set">
+                description = <"value set">
+            >
+            ["at4"] = <
+                 text = <"value 1">
+                 description = <"value 1">
+            >
+            ["at5"] = <
+                 text = <"value 2">
+                 description = <"value 2">
+            >
+
+		>
+    >
+    value_sets = <
+        ["ac3"] = <
+            id = <"ac3">
+            members = <"at4", "at5">
+        >
+    >
+

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_valueset.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_valueset.adls
@@ -1,48 +1,48 @@
 archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
-	openEHR-EHR-CLUSTER.matches_valueset.v1.0.0
+    openEHR-EHR-CLUSTER.matches_valueset.v1.0.0
 
 language
-	original_language = <[ISO_639-1::en]>
+    original_language = <[ISO_639-1::en]>
 
 description
-	original_author = <
-		["name"] = <"Pieter Bos">
-	>
-	details = <
-		["en"] = <
-			language = <[ISO_639-1::en]>
-			purpose = <"Test for rules, simple constant arithmetics">
-			keywords = <"ADL", "test">
-		>
-	>
-	lifecycle_state = <"published">
-	other_details = <
-		["regression"] = <"PASS">
-	>
-	copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+    original_author = <
+        ["name"] = <"Pieter Bos">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"Test for rules, simple constant arithmetics">
+            keywords = <"ADL", "test">
+        >
+    >
+    lifecycle_state = <"published">
+    other_details = <
+        ["regression"] = <"PASS">
+    >
+    copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
 
 definition
-	CLUSTER[id1] matches {
-	    items matches {
-	        ELEMENT[id2] occurrences matches {1} matches {
-	            value matches {
-	                DV_CODED_TEXT[id3]
-	            }
-	        }
+    CLUSTER[id1] matches {
+        items matches {
+            ELEMENT[id2] occurrences matches {1} matches {
+                value matches {
+                    DV_CODED_TEXT[id3]
+                }
+            }
         }
-	}
+    }
 
 rules
     /items[id2]/value/defining_code matches {[ac3]}
 
 terminology
-	term_definitions = <
-		["en"] = <
-			["id1"] = <
-				text = <"Cluster">
-				description = <"Cluster">
-			>
-			["id2"] = <
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"Cluster">
+                description = <"Cluster">
+            >
+            ["id2"] = <
                 text = <"element">
                 description = <"element">
             >
@@ -59,7 +59,7 @@ terminology
                  description = <"value 2">
             >
 
-		>
+        >
     >
     value_sets = <
         ["ac3"] = <

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/termcodeparent.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/termcodeparent.adls
@@ -1,42 +1,42 @@
 archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
-	openEHR-EHR-CLUSTER.matches_valueset.v1.0.0
+    openEHR-EHR-CLUSTER.matches_valueset.v1.0.0
 
 language
-	original_language = <[ISO_639-1::en]>
+    original_language = <[ISO_639-1::en]>
 
 description
-	original_author = <
-		["name"] = <"Pieter Bos">
-	>
-	details = <
-		["en"] = <
-			language = <[ISO_639-1::en]>
-			purpose = <"Test for rules, simple constant arithmetics">
-			keywords = <"ADL", "test">
-		>
-	>
-	lifecycle_state = <"published">
-	other_details = <
-		["regression"] = <"PASS">
-	>
-	copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+    original_author = <
+        ["name"] = <"Pieter Bos">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"Test for rules, simple constant arithmetics">
+            keywords = <"ADL", "test">
+        >
+    >
+    lifecycle_state = <"published">
+    other_details = <
+        ["regression"] = <"PASS">
+    >
+    copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
 
 definition
-	CLUSTER[id1] matches {
-	    items matches {
-	        use_archetype CLUSTER[id2,openEHR-EHR-CLUSTER.matches_valueset.v1] occurrences matches {1}
+    CLUSTER[id1] matches {
+        items matches {
+            use_archetype CLUSTER[id2,openEHR-EHR-CLUSTER.matches_valueset.v1] occurrences matches {1}
         }
-	}
+    }
 terminology
-	term_definitions = <
-		["en"] = <
-			["id1"] = <
-				text = <"Cluster">
-				description = <"Cluster">
-			>
-			["id2"] = <
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"Cluster">
+                description = <"Cluster">
+            >
+            ["id2"] = <
                 text = <"cluster">
                 description = <"cluster">
             >
-		>
+        >
     >

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/termcodeparent.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/termcodeparent.adls
@@ -1,0 +1,42 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+	openEHR-EHR-CLUSTER.matches_valueset.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Pieter Bos">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Test for rules, simple constant arithmetics">
+			keywords = <"ADL", "test">
+		>
+	>
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+	CLUSTER[id1] matches {
+	    items matches {
+	        use_archetype CLUSTER[id2,openEHR-EHR-CLUSTER.matches_valueset.v1] occurrences matches {1}
+        }
+	}
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Cluster">
+				description = <"Cluster">
+			>
+			["id2"] = <
+                text = <"cluster">
+                description = <"cluster">
+            >
+		>
+    >

--- a/utils/src/main/java/com/nedap/archie/util/KryoUtil.java
+++ b/utils/src/main/java/com/nedap/archie/util/KryoUtil.java
@@ -1,8 +1,8 @@
 package com.nedap.archie.util;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.pool.KryoFactory;
-import com.esotericsoftware.kryo.pool.KryoPool;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.util.Pool;
+
 
 /**
  * Created by pieter.bos on 03/11/15.
@@ -10,19 +10,23 @@ import com.esotericsoftware.kryo.pool.KryoPool;
 public class KryoUtil {
 
     // Build pool with SoftReferences enabled (optional)
-    private static KryoPool pool;
+    private static Pool<Kryo> pool;
 
     static {
-        KryoFactory factory = new KryoFactory() {
-            public Kryo create() {
+        // Pool constructor arguments: thread safe, soft references, maximum capacity
+        pool = new Pool<Kryo>(true, false) {
+            protected Kryo create () {
                 Kryo kryo = new Kryo();
+                kryo.setRegistrationRequired(false);
+                kryo.setReferences(true);
+                kryo.setCopyReferences(true);
                 return kryo;
             }
         };
-        pool = new KryoPool.Builder(factory).softReferences().build();
+
     }
 
-    public static KryoPool getPool() {
+    public static Pool<Kryo> getPool() {
         return pool;
     }
 }


### PR DESCRIPTION
the matches operator in the rule was only possible for a single path instead of also a full expression. This adds full `expression matches {something}` support, plus corrects CTerminologyCode validation, plus tests

If the form `/path matches {[ac3]}`, this is added to the assertionResult on the property `pathsConstrainedToValueSets`, so anything rendering a form based on these rules can update selection possibilities for a code for that path, for instance to show a different dropdown-list.
