### PR TITLE
Adl14 rm1.1.0 conversion

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14ConversionConfiguration.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14ConversionConfiguration.java
@@ -22,6 +22,12 @@ public class ADL14ConversionConfiguration {
     private boolean applyDiff = true;
 
 
+    /**
+     * ADL 1.4 contains no rm release version, 2 does. So one needs to be added. Set to the desired rm_release. Defaults to 1.1.0
+     */
+    private String rmRelease = "1.1.0";
+
+
     public List<TerminologyUriTemplate> getTerminologyConversionTemplates() {
         return terminologyConversionTemplates;
     }
@@ -56,5 +62,13 @@ public class ADL14ConversionConfiguration {
 
     public void setApplyDiff(boolean applyDiff) {
         this.applyDiff = applyDiff;
+    }
+
+    public String getRmRelease() {
+        return rmRelease;
+    }
+
+    public void setRmRelease(String rmRelease) {
+        this.rmRelease = rmRelease;
     }
 }

--- a/aom/src/main/java/com/nedap/archie/adl14/treewalkers/Adl14CComplexObjectParser.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/treewalkers/Adl14CComplexObjectParser.java
@@ -179,19 +179,30 @@ public class Adl14CComplexObjectParser extends BaseTreeWalker {
 
             //TODO: ordinal assumed value is not really possible in ADL 2 thanks to tuples
             CComplexObject ordinal = new CComplexObject(); //create complex object. We'll generate a node id later!
-            ordinal.setRmTypeName("DV_ORDINAL");
+            if(ordinalContainsRealNumber(ordinalContext)) {
+                ordinal.setRmTypeName("DV_SCALE");
+            } else {
+                ordinal.setRmTypeName("DV_ORDINAL");
+            }
             //plus a tuple
             CAttributeTuple tuple = new CAttributeTuple();
             List<CAttribute> members = new ArrayList<>();
             members.add(new CAttribute("value"));
             members.add(new CAttribute("symbol"));
             tuple.setMembers(members);
+            for (Ordinal_termContext ordinal_termContext : ordinalContext.ordinal_term()) {
+                CPrimitiveObject cValue;
+                if(ordinal_termContext.integer_value() != null) {
+                    long value = Integer.parseInt(ordinal_termContext.integer_value().getText());
+                    cValue = new CInteger();
+                    cValue.addConstraint(new Interval<>(value));
+                } else {
+                    double value = Double.parseDouble(ordinal_termContext.real_value().getText());
+                    cValue = new CReal();
+                    cValue.addConstraint(new Interval<>(value));
+                }
 
-            for(Ordinal_termContext ordinal_termContext: ordinalContext.ordinal_term()) {
-                long value = Integer.parseInt(ordinal_termContext.integer_value().getText());
                 CPrimitiveTuple primitiveTuple = new CPrimitiveTuple();
-                CInteger cValue = new CInteger();
-                cValue.addConstraint(new Interval<>(value));
 
                 CTerminologyCode cCode = new CTerminologyCode();
 
@@ -206,6 +217,15 @@ public class Adl14CComplexObjectParser extends BaseTreeWalker {
             return ordinal;
         }
         throw new IllegalArgumentException("unknown non-primitive object: " + objectContext.getText());
+    }
+
+    private boolean ordinalContainsRealNumber(C_ordinalContext ordinalContext) {
+        for (Ordinal_termContext ordinal_termContext : ordinalContext.ordinal_term()) {
+            if(ordinal_termContext.real_value() != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void parseCDVOrdinal(C_non_primitive_objectContext objectContext, CComplexObject result) {

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -183,4 +183,20 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
         }
     }
 
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        result.append("{[");
+        boolean first = true;
+        for(String constraint:getConstraint()) {
+            if(!first) {
+                result.append(", ");
+            }
+            first = false;
+            result.append(constraint.toString());
+        }
+        result.append("]}");
+        return result.toString();
+    }
+
 }

--- a/grammars/src/main/antlr/cadl14.g4
+++ b/grammars/src/main/antlr/cadl14.g4
@@ -39,9 +39,9 @@ c_non_primitive_object:
 
 c_ordinal: ordinal_term  (',' ordinal_term)* (';' assumed_ordinal_value)?;
 
-assumed_ordinal_value: INTEGER;
+assumed_ordinal_value: INTEGER | REAL;
 
-ordinal_term: integer_value '|' c_terminology_code;
+ordinal_term: (integer_value | real_value) '|' c_terminology_code;
 
 c_archetype_root: SYM_USE_ARCHETYPE type_id '[' AT_CODE (SYM_COMMA archetype_ref)? ']' c_occurrences? ( SYM_MATCHES '{' c_attribute_def+ '}' )? ;
 

--- a/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
+++ b/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
@@ -170,7 +170,7 @@ public class ADL14Converter {
 
     private void setCorrectVersions(Archetype result) {
         result.setAdlVersion("2.0.6");
-        result.setRmRelease("1.0.4");
+        result.setRmRelease(conversionConfiguration.getRmRelease());
         if(result.getArchetypeId().getMinorVersion() == null) {
             result.getArchetypeId().setReleaseVersion(result.getArchetypeId().getReleaseVersion() + ".0.0");
         }

--- a/tools/src/test/java/com/nedap/archie/adl14/ConversionConfigurationTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/ConversionConfigurationTest.java
@@ -1,0 +1,35 @@
+package com.nedap.archie.adl14;
+
+import com.google.common.collect.Lists;
+import com.nedap.archie.aom.Archetype;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.io.InputStream;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class ConversionConfigurationTest {
+
+    @Test
+    public void testRmRelease() throws Exception {
+
+        ADL14ConversionConfiguration conversionConfiguration = ConversionConfigForTest.getConfig();
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
+
+
+        try(InputStream stream = getClass().getResourceAsStream("openehr-EHR-COMPOSITION.review.v1.adl")) {
+            Archetype adl14 = new ADL14Parser(BuiltinReferenceModels.getMetaModels()).parse(stream, conversionConfiguration);
+            ADL2ConversionResultList result = converter.convert(Lists.newArrayList(adl14));
+
+            assertEquals("1.1.0", result.getConversionResults().get(0).getArchetype().getRmRelease());
+
+            conversionConfiguration.setRmRelease("1.0.4");
+            converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
+
+            result = converter.convert(Lists.newArrayList(adl14));
+            assertEquals("1.0.4", result.getConversionResults().get(0).getArchetype().getRmRelease());
+        }
+
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/adl14/DvScaleConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/DvScaleConversionTest.java
@@ -2,10 +2,7 @@ package com.nedap.archie.adl14;
 
 import com.google.common.collect.Lists;
 import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.ArchetypeModelObject;
 import com.nedap.archie.aom.CComplexObject;
-import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
-import com.nedap.archie.rm.datavalues.quantity.DvScale;
 import org.junit.Test;
 import org.openehr.referencemodels.BuiltinReferenceModels;
 

--- a/tools/src/test/java/com/nedap/archie/adl14/DvScaleConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/DvScaleConversionTest.java
@@ -15,13 +15,13 @@ import static org.junit.Assert.assertTrue;
 public class DvScaleConversionTest {
 
     @Test
-    public void testRmRelease() throws Exception {
+    public void testDvScale() throws Exception {
 
         ADL14ConversionConfiguration conversionConfiguration = ConversionConfigForTest.getConfig();
         ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
 
 
-        try(InputStream stream = getClass().getResourceAsStream("openehr-EHR-CLUSTER.ordinalandscale.v0.adl")) {
+        try(InputStream stream = getClass().getResourceAsStream("openEHR-EHR-CLUSTER.ordinalandscale.v0.adl")) {
             ADL14Parser adl14Parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
             Archetype adl14 = adl14Parser.parse(stream, conversionConfiguration);
             assertFalse(adl14Parser.getErrors().hasErrors());

--- a/tools/src/test/java/com/nedap/archie/adl14/DvScaleConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/DvScaleConversionTest.java
@@ -1,0 +1,69 @@
+package com.nedap.archie.adl14;
+
+import com.google.common.collect.Lists;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.ArchetypeModelObject;
+import com.nedap.archie.aom.CComplexObject;
+import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
+import com.nedap.archie.rm.datavalues.quantity.DvScale;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.io.InputStream;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DvScaleConversionTest {
+
+    @Test
+    public void testRmRelease() throws Exception {
+
+        ADL14ConversionConfiguration conversionConfiguration = ConversionConfigForTest.getConfig();
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
+
+
+        try(InputStream stream = getClass().getResourceAsStream("openehr-EHR-CLUSTER.ordinalandscale.v0.adl")) {
+            ADL14Parser adl14Parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            Archetype adl14 = adl14Parser.parse(stream, conversionConfiguration);
+            assertFalse(adl14Parser.getErrors().hasErrors());
+            ADL2ConversionResultList result = converter.convert(Lists.newArrayList(adl14));
+            Archetype archetype = result.getConversionResults().get(0).getArchetype();
+            CComplexObject ordinal1 = archetype.itemAtPath("/items[id2]/value[1]");
+            assertEquals("DV_ORDINAL", ordinal1.getRmTypeName());
+            CComplexObject scale1 = archetype.itemAtPath("/items[id6]/value[1]");
+            assertEquals("DV_SCALE", scale1.getRmTypeName());
+            assertEquals(Lists.newArrayList("value", "symbol"), scale1.getAttributeTuples().get(0).getMemberNames());
+            assertEquals(3, scale1.getAttributeTuples().get(0).getTuples().size());
+            assertEquals("{1.0}", scale1.getAttributeTuples().get(0).getTuples().get(0).getMember(0).toString());
+            assertEquals("{[at7]}", scale1.getAttributeTuples().get(0).getTuples().get(0).getMember(1).toString());
+
+            CComplexObject scale2 = archetype.itemAtPath("/items[id10]/value[1]");
+            assertEquals("DV_SCALE", scale2.getRmTypeName());
+
+            assertEquals(Lists.newArrayList("value", "symbol"), scale2.getAttributeTuples().get(0).getMemberNames());
+            assertEquals(4, scale2.getAttributeTuples().get(0).getTuples().size());
+            assertEquals("{1}", scale2.getAttributeTuples().get(0).getTuples().get(0).getMember(0).toString());
+            assertEquals("{[at11]}", scale2.getAttributeTuples().get(0).getTuples().get(0).getMember(1).toString());
+            assertEquals("{2.5}", scale2.getAttributeTuples().get(0).getTuples().get(2).getMember(0).toString());
+            assertEquals("{[at12]}", scale2.getAttributeTuples().get(0).getTuples().get(2).getMember(1).toString());
+
+
+            CComplexObject scale3 = archetype.itemAtPath("/items[id14]/value[1]");
+            assertEquals("DV_SCALE", scale3.getRmTypeName());
+            CComplexObject scale4 = archetype.itemAtPath("/items[id21]/value[1]");
+            assertEquals("DV_SCALE", scale4.getRmTypeName());
+
+            CComplexObject scaleNormal1 = archetype.itemAtPath("/items[id18]/value[id171]");
+            assertEquals("DV_SCALE", scaleNormal1.getRmTypeName());
+            CComplexObject scaleNormal2 = archetype.itemAtPath("/items[id18]/value[id172]");
+            assertEquals("DV_SCALE", scaleNormal2.getRmTypeName());
+
+            CComplexObject scaleUnconstrained = archetype.itemAtPath("/items[id23]/value[1]");
+            assertEquals("DV_SCALE", scaleUnconstrained.getRmTypeName());
+            assertTrue(scaleUnconstrained.getAttributes().isEmpty() && scaleUnconstrained.getAttributeTuples().isEmpty());
+        }
+
+    }
+}

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.ordinalandscale.v0.adl
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.ordinalandscale.v0.adl
@@ -1,0 +1,209 @@
+archetype (adl_version=1.4; uid=64891061-481c-44ce-aa73-1913ef8dc66d)
+    openEHR-EHR-CLUSTER.ordinalandscale.v0
+concept
+    [at0000]    -- Ordinalandscale
+language
+    original_language = <[ISO_639-1::de]>
+description
+    original_author = <
+        ["name"] = <"">
+    >
+    details = <
+        ["de"] = <
+            language = <[ISO_639-1::de]>
+            purpose = <"">
+            use = <"">
+            misuse = <"">
+            copyright = <"© openEHR Foundation">
+        >
+    >
+    lifecycle_state = <"in_development">
+    other_contributors = <>
+    other_details = <
+        ["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.">
+        ["custodian_organisation"] = <"openEHR Foundation">
+        ["original_namespace"] = <"org.openehr">
+        ["original_publisher"] = <"openEHR Foundation">
+        ["custodian_namespace"] = <"org.openehr">
+        ["MD5-CAM-1.0.1"] = <"60400C49A960FAF443B1EC1DB870040B">
+        ["build_uid"] = <"73064b08-4ae3-46c7-941d-b45e5066e7a3">
+        ["revision"] = <"0.0.1-alpha">
+    >
+definition
+    CLUSTER[at0000] matches {   -- Ordinalandscale
+        items cardinality matches {1..*; unordered} matches {
+            ELEMENT[at0001] occurrences matches {0..1} matches {    -- MYOrdinal
+                value matches {
+                    1|[local::at0002],  -- 1ord
+                    2|[local::at0003],  -- 2ord
+                    3|[local::at0004]   -- 3ord
+                }
+            }
+            ELEMENT[at0005] occurrences matches {0..1} matches {    -- MyScale
+                value matches {
+                    1.0|[local::at0006],    -- 1.0scale
+                    2.5|[local::at0007],    -- 25scale
+                    3.0|[local::at0008]     -- 3.0scale
+                }
+            }
+            ELEMENT[at0009] occurrences matches {0..1} matches {    -- MyScale2
+                value matches {
+                    1|[local::at0010],  -- 1scale
+                    2|[local::at0015],  -- 2scale
+                    2.5|[local::at0011],    -- 25scale
+                    3|[local::at0012]   -- 3scale
+                }
+            }
+            ELEMENT[at0013] occurrences matches {0..1} matches {    -- MyScale3
+                value matches {
+                    1.5|[local::at0014],    -- 15scale
+                    2|[local::at0015],  -- 2scale
+                    3|[local::at0016]   -- 3scale
+                }
+            }
+            ELEMENT[at0020] occurrences matches {0..1} matches {    -- MyScale4
+                value matches {
+                    1|[local::at0010],  -- 1scale
+                    2|[local::at0015],  -- 2scale
+                    3|[local::at0006],  -- 3scale
+                    3.5|[local::at0021]     -- 3.5scale
+                }
+            }
+            ELEMENT[at0017] occurrences matches {0..1} matches {    -- MyScale NORMAL
+                value matches {
+                    DV_SCALE[at00170] matches {
+                        value matches {0}
+                        symbol matches {
+                            DV_CODED_TEXT matches {
+                                defining_code matches {
+                                    [local::at0018]
+                                } -- 0scale
+                            }
+                        }
+                    }
+                    DV_SCALE[at00171] matches {
+                        value matches {1.5}
+                        symbol matches {
+                            DV_CODED_TEXT matches {
+                                defining_code matches {
+                                    [local::at0019]
+                                } -- 1.5scale
+                            }
+                        }
+                    }
+                }
+            }
+            ELEMENT[at0022] occurrences matches {0..1} matches {    -- MyScale unconstrained
+                value matches {
+                    DV_SCALE matches { * }
+                }
+            }
+        }
+    }
+ontology
+    term_definitions = <
+        ["de"] = <
+            items = <
+                ["at0000"] = <
+                    text = <"Ordinalandscale">
+                    description = <"unknown">
+                >
+                ["at0001"] = <
+                    text = <"My Ordinal">
+                    description = <"*">
+                >
+                ["at0002"] = <
+                    text = <"1ord">
+                    description = <"*">
+                >
+                ["at0003"] = <
+                    text = <"2ord">
+                    description = <"*">
+                >
+                ["at0004"] = <
+                    text = <"3ord">
+                    description = <"*">
+                >
+                ["at0005"] = <
+                    text = <"MyScale">
+                    description = <"*">
+                >
+                ["at0006"] = <
+                    text = <"1scale">
+                    description = <"*">
+                >
+                ["at0007"] = <
+                    text = <"2.5scale">
+                    description = <"*">
+                >
+                ["at0008"] = <
+                    text = <"3scale">
+                    description = <"*">
+                >
+                ["at0009"] = <
+                    text = <"MyScale2">
+                    description = <"*">
+                >
+                ["at0010"] = <
+                    text = <"1.2scale">
+                    description = <"*">
+                >
+                ["at0011"] = <
+                    text = <"2.5scale">
+                    description = <"*">
+                >
+                ["at0012"] = <
+                    text = <"3scale">
+                    description = <"*">
+                >
+                ["at0013"] = <
+                    text = <"MyScale2">
+                    description = <"*">
+                >
+                ["at0014"] = <
+                    text = <"1.5scale">
+                    description = <"*">
+                >
+                ["at0015"] = <
+                    text = <"2scale">
+                    description = <"*">
+                >
+                ["at0016"] = <
+                    text = <"3scale">
+                    description = <"*">
+                >
+                ["at0017"] = <
+                    text = <"MyScale NORMAL">
+                    description = <"*">
+                >
+                ["at00170"] = <
+                    text = <"First scale dv">
+                    description = <"*">
+                >
+                ["at00171"] = <
+                    text = <"Second scale dv">
+                    description = <"*">
+                >
+                ["at0018"] = <
+                    text = <"0scale">
+                    description = <"*">
+                >
+                ["at0019"] = <
+                    text = <"1.5scale">
+                    description = <"*">
+                >
+                ["at0020"] = <
+                    text = <"MyScale 4">
+                    description = <"*">
+                >
+                ["at0021"] = <
+                    text = <"3.5 scale">
+                    description = <"*">
+                >
+                ["at0022"] = <
+                    text = <"Unconstrained scale">
+                    description = <"*">
+                >
+            >
+        >
+    >


### PR DESCRIPTION
- default the rm_release in the converter to 1.1.0, but make configurable
- Implement the custom DV_ORDINAL/DV_SCALE syntax, and convert to correct type with tuples
- tests for both features