### PR TITLE
Fix CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ subprojects {
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
-    compile 'com.google.guava:guava:29.0-jre'
+    compile 'com.google.guava:guava:30.1-jre'
 
     compile "org.reflections:reflections:${reflectionsVersion}"
     compile 'com.esotericsoftware:kryo-shaded:4.0.2' //for easy and relatively fast object cloning

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -15,5 +15,5 @@ dependencies {
   testCompile project(':referencemodels')
 
   compile 'org.leadpony.justify:justify:2.1.0'
-  compile 'org.glassfish:jakarta.json:1.1.5:module'
+  compile 'org.glassfish:jakarta.json:1.1.6:module'
 }


### PR DESCRIPTION
Fixes:
```
- guava-29.0-jre.jar (pkg:maven/com.google.guava/guava@29.0-jre, cpe:2.3:a:google:guava:29.0:*:*:*:*:*:*:*) : CVE-2020-8908
- jakarta.json-1.1.5-module.jar (pkg:maven/org.glassfish/jakarta.json@1.1.5, cpe:2.3:a:processing:processing:1.1.5:*:*:*:*:*:*:*) : CVE-2018-1000840
```