### PR TITLE
If a code was synthesized during an earlier conversion, and now expli…

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14ConversionMessageCode.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14ConversionMessageCode.java
@@ -6,7 +6,7 @@ public enum ADL14ConversionMessageCode implements MessageCode {
     WARNING_SPECIALIZED_FIRST_MATCHING_CHILD("Found two matching children. Only picked one"),
     WARNING_UNKNOWN_CODE_TYPE_IN_TERMBINDING("Termbindings contains at code {0}, but this is unused in the archetype. This cannot be automatically converted"),
     INFO_PREVIOUSLY_CONVERTED_CODE_DELETED("A previously converted path no longer exists. This usually means the source ADL 1.4 has been edited, in that case there's no problem."),
-    INFO_PREVIOUSLY_CONVERTED_CODE_RENAMED("A previously synthesized code is now an explicit code int he ADL 1.4 archetype. The explictly set code will be used instead of the synthesized one. This can cause backwards compatibility issues");
+    INFO_PREVIOUSLY_CONVERTED_CODE_RENAMED("A previously synthesized code is now an explicit code in the ADL 1.4 archetype. The explicitly set code will be used instead of the synthesized one. This can cause backwards compatibility issues");
 
     private String template;
 

--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14ConversionMessageCode.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14ConversionMessageCode.java
@@ -5,7 +5,8 @@ import org.openehr.utils.message.MessageCode;
 public enum ADL14ConversionMessageCode implements MessageCode {
     WARNING_SPECIALIZED_FIRST_MATCHING_CHILD("Found two matching children. Only picked one"),
     WARNING_UNKNOWN_CODE_TYPE_IN_TERMBINDING("Termbindings contains at code {0}, but this is unused in the archetype. This cannot be automatically converted"),
-    INFO_PREVIOUSLY_CONVERTED_CODE_DELETED("A previously converted path no longer exists. This usually means the source ADL 1.4 has been edited, in that case there's no problem.");
+    INFO_PREVIOUSLY_CONVERTED_CODE_DELETED("A previously converted path no longer exists. This usually means the source ADL 1.4 has been edited, in that case there's no problem."),
+    INFO_PREVIOUSLY_CONVERTED_CODE_RENAMED("A previously synthesized code is now an explicit code int he ADL 1.4 archetype. The explictly set code will be used instead of the synthesized one. This can cause backwards compatibility issues");
 
     private String template;
 

--- a/aom/src/main/java/com/nedap/archie/adl14/PreviousConversionApplier.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/PreviousConversionApplier.java
@@ -123,9 +123,13 @@ public class PreviousConversionApplier {
             int index = attribute.getIndexOfChildWithMatchingRmTypeName(createdCode.getRmTypeName());
             if(index >= 0) {
                 CObject cObject = attribute.getChildren().get(index);
-                cObject.setNodeId(createdCode.getGeneratedCode());
-                //store the created code so it appears in the new conversion log as well
-                converter.addCreatedCode(createdCode.getGeneratedCode(), createdCode);
+                if(cObject.getNodeId() == null) {
+                    cObject.setNodeId(createdCode.getGeneratedCode());
+                    //store the created code so it appears in the new conversion log as well
+                    converter.addCreatedCode(createdCode.getGeneratedCode(), createdCode);
+                } else {
+                    this.converter.getConversionResult().getLog().addInfoWithLocation(ADL14ConversionMessageCode.INFO_PREVIOUSLY_CONVERTED_CODE_RENAMED, createdCode.getPathCreated());
+                }
 
             } else {
                 this.converter.getConversionResult().getLog().addInfoWithLocation(ADL14ConversionMessageCode.INFO_PREVIOUSLY_CONVERTED_CODE_DELETED, createdCode.getPathCreated());

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-COMPOSITION.review.v1.codeadded.adl
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-COMPOSITION.review.v1.codeadded.adl
@@ -1,0 +1,52 @@
+archetype (adl_version=1.4)
+	openEHR-EHR-COMPOSITION.review.v1
+
+concept
+	[at0000]	-- Review
+language
+	original_language = <[ISO_639-1::en]>
+description
+	original_author = <
+		["name"] = <"Heather Leslie">
+		["organisation"] = <"Ocean Informatics">
+		["email"] = <"heather.leslie@oceaninformatics.com">
+		["date"] = <"2012-12-11">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record the details of a formal review of a subject's clinical situation or any specific aspect of their clinical care.">
+			use = <"Use to record the details of a formal review of a subject's clinical situation or any specific aspect of their clinical care. For example: use to record Medicines reviews; or Case Coordinator reviews.">
+			keywords = <"review", "assessment", "medicine", "clinical", "case", "file">
+			misuse = <"">
+			copyright = <"© openEHR Foundation">
+		>
+	>
+	lifecycle_state = <"CommitteeDraft">
+	other_contributors = <>
+	other_details = <
+		["current_contact"] = <"Heather Leslie, Ocean Informatics, heather.leslie@oceaninformatics.com">
+		["MD5-CAM-1.0.1"] = <"2DC12B7D97D991644135FB1F47C6C102">
+	>
+
+definition
+	COMPOSITION[at0000] matches {	-- Review
+		category matches {
+			DV_CODED_TEXT[at0026] matches { --this used to not have a code
+				defining_code matches {[openehr::433]}
+			}
+		}
+	}
+
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Review">
+					description = <"Composition for the recording of the details of a formal review of a subject's clinical situation or any specific aspect of their clinical care.">
+				>
+			>
+		>
+	>


### PR DESCRIPTION
…ctly set, it was still using the synthesized version

The scenario:
 - a node in an archetype has no node id.
 - it is converted to ADL 2
- the adl 1.4 one is edited, in a newer version, so that node now has an explicity node id
- it is converted to ADL 2 again, with the previous conversion log applied

What happens before this fix:
The old generated code is still used

And after this fix:
The code from the ADL is still used. An info message is added to the conversion log.


This is rather annoying and causes backwards compatibility problems. However, not fixing this causes specializations and template problems, so probably worth it to fix.
