### PR TITLE
Feature/rm identification methods

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
@@ -22,6 +22,10 @@ public class ObjectVersionId extends UIDBasedId {
         super(value);
     }
 
+    public ObjectVersionId(String objectId, String creatingSystemId, String versionTreeId) {
+        this(objectId + "::" + creatingSystemId + "::" + versionTreeId);
+    }
+
     @JsonIgnore
     @XmlTransient
     public UID getObjectId() {
@@ -31,17 +35,17 @@ public class ObjectVersionId extends UIDBasedId {
     @JsonIgnore
     @XmlTransient
     public UID getCreatingSystemId() {
-        if (getExtension() == null)
-            // TODO: what kind of exception should be thrown here?
-            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have EXTENSION.");
+        if (getExtension() == null) {
+            throw new UnsupportedOperationException("Invalid OBJECT_VERSION_ID. Needs to have EXTENSION.");
+        }
 
         int index = getExtension().indexOf("::");
         String system;
-        if (index != -1)
+        if (index != -1) {
             system = getExtension().substring(0, index);
-        else
-            // TODO: what kind of exception should be thrown here?
-            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have CREATING_SYSTEM_ID.");
+        } else {
+            throw new UnsupportedOperationException("Invalid OBJECT_VERSION_ID. Needs to have CREATING_SYSTEM_ID.");
+        }
 
         return new UUID(system);
     }
@@ -49,17 +53,17 @@ public class ObjectVersionId extends UIDBasedId {
     @JsonIgnore
     @XmlTransient
     public VersionTreeId getVersionTreeId() {
-        if (getExtension() == null)
-            // TODO: what kind of exception should be thrown here?
-            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have EXTENSION.");
+        if (getExtension() == null) {
+            throw new UnsupportedOperationException("Invalid OBJECT_VERSION_ID. Needs to have EXTENSION.");
+        }
 
         int index = getExtension().indexOf("::");
         String version;
-        if (index != -1)
-            version = getExtension().substring(index+2);
-        else
-            // TODO: what kind of exception should be thrown here?
-            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have CREATING_SYSTEM_ID.");
+        if (index != -1) {
+            version = getExtension().substring(index + 2);
+        } else {
+            throw new UnsupportedOperationException("Invalid OBJECT_VERSION_ID. Needs to have CREATING_SYSTEM_ID.");
+        }
 
         return  new VersionTreeId(version);
     }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
@@ -1,7 +1,10 @@
 package com.nedap.archie.rm.support.identification;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 /**
@@ -16,5 +19,53 @@ public class ObjectVersionId extends UIDBasedId {
 
     public ObjectVersionId(String value) {
         super(value);
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public UID getObjectId() {
+        return getRoot();
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public UID getCreatingSystemId() {
+        if (getExtension() == null)
+            // TODO: what kind of exception should be thrown here?
+            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have EXTENSION.");
+
+        int index = getExtension().indexOf("::");
+        String system;
+        if (index != -1)
+            system = getExtension().substring(0, index);
+        else
+            // TODO: what kind of exception should be thrown here?
+            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have CREATING_SYSTEM_ID.");
+
+        return new UUID(system);
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public VersionTreeId getVersionTreeId() {
+        if (getExtension() == null)
+            // TODO: what kind of exception should be thrown here?
+            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have EXTENSION.");
+
+        int index = getExtension().indexOf("::");
+        String version;
+        if (index != -1)
+            version = getExtension().substring(index+2);
+        else
+            // TODO: what kind of exception should be thrown here?
+            throw new IllegalArgumentException("Invalid OBJECT_VERSION_ID. Needs to have CREATING_SYSTEM_ID.");
+
+        return  new VersionTreeId(version);
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public Boolean isBranch() {
+        return getVersionTreeId().isBranch();
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rm.support.identification;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.nedap.archie.rminfo.RMProperty;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -65,6 +66,7 @@ public class ObjectVersionId extends UIDBasedId {
 
     @JsonIgnore
     @XmlTransient
+    @RMProperty("is_branch")
     public Boolean isBranch() {
         return getVersionTreeId().isBranch();
     }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectVersionId.java
@@ -71,7 +71,7 @@ public class ObjectVersionId extends UIDBasedId {
     @JsonIgnore
     @XmlTransient
     @RMProperty("is_branch")
-    public Boolean isBranch() {
+    public boolean isBranch() {
         return getVersionTreeId().isBranch();
     }
 }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
@@ -69,12 +69,11 @@ public abstract class UIDBasedId extends ObjectId {
         }
     }
 
-    @Nullable
     @JsonIgnore
-    public Boolean hasExtension() {
-        if (getExtension() == null)
-            return null;
-        else {
+    public boolean hasExtension() {
+        if (getExtension() == null) {
+            return false;
+        } else {
             return !getExtension().isEmpty();
         }
     }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
@@ -71,7 +71,6 @@ public abstract class UIDBasedId extends ObjectId {
 
     @Nullable
     @JsonIgnore
-    @XmlTransient
     public Boolean hasExtension() {
         if (getExtension() == null)
             return null;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UIDBasedId.java
@@ -36,7 +36,7 @@ public abstract class UIDBasedId extends ObjectId {
         if (index < 0) {
             resultString = value;
         } else {
-            resultString = value.substring(index);
+            resultString = value.substring(0, index);
         }
         if (resultString.matches(UUID_REGEXP)) {
             UID result = new UUID();
@@ -66,6 +66,17 @@ public abstract class UIDBasedId extends ObjectId {
             return "";
         } else {
             return value.substring(index + 2);
+        }
+    }
+
+    @Nullable
+    @JsonIgnore
+    @XmlTransient
+    public Boolean hasExtension() {
+        if (getExtension() == null)
+            return null;
+        else {
+            return !getExtension().isEmpty();
         }
     }
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
@@ -1,13 +1,18 @@
 package com.nedap.archie.rm.support.identification;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nedap.archie.rm.RMObject;
 
+import javax.xml.bind.annotation.XmlTransient;
 import java.util.Objects;
 
 /**
  * Created by pieter.bos on 08/07/16.
  */
 public class VersionTreeId extends RMObject {
+
+    public static final String BRANCH_VERSION = ".*[1-9][0-9]*[.].*[0-9].*[.].*[0-9].*";
+    public static final String SIMPLE_VERSION = "[1-9][0-9]*";
 
     private String value;
 
@@ -24,6 +29,60 @@ public class VersionTreeId extends RMObject {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public Boolean isBranch() {
+        if (value == null) {
+            return null;
+        }
+
+        if (value.matches(BRANCH_VERSION))
+            return true;
+        else {
+            // checking if it is just a 1-part identifier or invalid
+            if (value.matches(SIMPLE_VERSION))
+                return false;
+            else    // TODO: what kind of exception should be thrown here?
+                throw new IllegalArgumentException("Invalid object. Version needs to be 1- or 3-part numeric identifier.");
+        }
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public String getTrunkVersion() {
+        if (value == null) {
+            return null;
+        }
+
+        if (isBranch()) {
+            int dot = value.indexOf(".");
+            return value.substring(0, dot);
+        } else
+            return value;
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public String getBranchNumber() {
+        if (value == null || isBranch().equals(false)) {
+            return null;
+        }
+
+        String branch = value.substring(value.indexOf(".")+1);
+        return branch.substring(0, branch.indexOf("."));
+    }
+
+    @JsonIgnore
+    @XmlTransient
+    public String getBranchVersion() {
+        if (value == null || isBranch().equals(false)) {
+            return null;
+        }
+
+        String branch = value.substring(value.indexOf(".")+1);
+        return branch.substring(branch.indexOf(".")+1);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
@@ -12,7 +12,7 @@ import java.util.Objects;
  */
 public class VersionTreeId extends RMObject {
 
-    public static final String BRANCH_VERSION = ".*[1-9][0-9]*[.].*[0-9].*[.].*[0-9].*";
+    public static final String BRANCH_VERSION = "[1-9][0-9]*[.][0-9]+[.][0-9]+";
     public static final String SIMPLE_VERSION = "[1-9][0-9]*";
 
     private String value;
@@ -35,9 +35,9 @@ public class VersionTreeId extends RMObject {
     @JsonIgnore
     @XmlTransient
     @RMProperty("is_branch")
-    public Boolean isBranch() {
+    public boolean isBranch() {
         if (value == null) {
-            return null;
+            return false;
         }
 
         if (value.matches(BRANCH_VERSION)) {
@@ -70,7 +70,7 @@ public class VersionTreeId extends RMObject {
     @JsonIgnore
     @XmlTransient
     public String getBranchNumber() {
-        if (value == null || isBranch().equals(false)) {
+        if (!isBranch()) {
             return null;
         }
 
@@ -81,7 +81,7 @@ public class VersionTreeId extends RMObject {
     @JsonIgnore
     @XmlTransient
     public String getBranchVersion() {
-        if (value == null || isBranch().equals(false)) {
+        if (!isBranch()) {
             return null;
         }
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
@@ -40,14 +40,15 @@ public class VersionTreeId extends RMObject {
             return null;
         }
 
-        if (value.matches(BRANCH_VERSION))
+        if (value.matches(BRANCH_VERSION)) {
             return true;
-        else {
+        } else {
             // checking if it is just a 1-part identifier or invalid
-            if (value.matches(SIMPLE_VERSION))
+            if (value.matches(SIMPLE_VERSION)) {
                 return false;
-            else    // TODO: what kind of exception should be thrown here?
+            } else {
                 throw new IllegalArgumentException("Invalid object. Version needs to be 1- or 3-part numeric identifier.");
+            }
         }
     }
 
@@ -61,8 +62,9 @@ public class VersionTreeId extends RMObject {
         if (isBranch()) {
             int dot = value.indexOf(".");
             return value.substring(0, dot);
-        } else
+        } else {
             return value;
+        }
     }
 
     @JsonIgnore

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
@@ -2,6 +2,7 @@ package com.nedap.archie.rm.support.identification;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nedap.archie.rm.RMObject;
+import com.nedap.archie.rminfo.RMProperty;
 
 import javax.xml.bind.annotation.XmlTransient;
 import java.util.Objects;
@@ -33,6 +34,7 @@ public class VersionTreeId extends RMObject {
 
     @JsonIgnore
     @XmlTransient
+    @RMProperty("is_branch")
     public Boolean isBranch() {
         if (value == null) {
             return null;

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/HierObjectIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/HierObjectIdTest.java
@@ -1,0 +1,35 @@
+package com.nedap.archie.rm.support.identification;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HierObjectIdTest {
+
+    @Test
+    public void getRoot() {
+        HierObjectId id = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals("fd0c55b8-a396-4ca1-8928-e12b88148359", id.getRoot().getValue());
+
+        HierObjectId id2 = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359");
+        assertEquals("fd0c55b8-a396-4ca1-8928-e12b88148359", id2.getRoot().getValue());
+    }
+
+    @Test
+    public void getExtension() {
+        HierObjectId id = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals("local.archie.org::1", id.getExtension());
+
+        HierObjectId id2 = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359");
+        assertEquals("", id2.getExtension());
+    }
+
+    @Test
+    public void hasExtension() {
+        HierObjectId id = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals(Boolean.TRUE, id.hasExtension());
+
+        HierObjectId id2 = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359");
+        assertEquals(Boolean.FALSE, id2.hasExtension());
+    }
+}

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/HierObjectIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/HierObjectIdTest.java
@@ -27,9 +27,9 @@ public class HierObjectIdTest {
     @Test
     public void hasExtension() {
         HierObjectId id = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
-        assertEquals(Boolean.TRUE, id.hasExtension());
+        assertTrue(id.hasExtension());
 
         HierObjectId id2 = new HierObjectId("fd0c55b8-a396-4ca1-8928-e12b88148359");
-        assertEquals(Boolean.FALSE, id2.hasExtension());
+        assertFalse(id2.hasExtension());
     }
 }

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/ObjectVersionIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/ObjectVersionIdTest.java
@@ -1,0 +1,35 @@
+package com.nedap.archie.rm.support.identification;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ObjectVersionIdTest {
+
+    @Test
+    public void getObjectId() {
+        ObjectVersionId versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals("fd0c55b8-a396-4ca1-8928-e12b88148359", versionId.getObjectId().getValue());
+    }
+
+    @Test
+    public void getCreatingSystemId() {
+        ObjectVersionId versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals("local.archie.org", versionId.getCreatingSystemId().getValue());
+    }
+
+    @Test
+    public void getVersionTreeId() {
+        ObjectVersionId versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals("1", versionId.getVersionTreeId().getValue());
+    }
+
+    @Test
+    public void isBranch() {
+        ObjectVersionId versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals(false, versionId.isBranch());
+
+        versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1.1.1");
+        assertEquals(true, versionId.isBranch());
+    }
+}

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/ObjectVersionIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/ObjectVersionIdTest.java
@@ -10,17 +10,26 @@ public class ObjectVersionIdTest {
     public void getObjectId() {
         ObjectVersionId versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
         assertEquals("fd0c55b8-a396-4ca1-8928-e12b88148359", versionId.getObjectId().getValue());
+
+        versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359", "local.archie.org", "1");
+        assertEquals("fd0c55b8-a396-4ca1-8928-e12b88148359", versionId.getObjectId().getValue());
     }
 
     @Test
     public void getCreatingSystemId() {
         ObjectVersionId versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
         assertEquals("local.archie.org", versionId.getCreatingSystemId().getValue());
+
+        versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359", "local.archie.org", "1");
+        assertEquals("local.archie.org", versionId.getCreatingSystemId().getValue());
     }
 
     @Test
     public void getVersionTreeId() {
         ObjectVersionId versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1");
+        assertEquals("1", versionId.getVersionTreeId().getValue());
+
+        versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359", "local.archie.org", "1");
         assertEquals("1", versionId.getVersionTreeId().getValue());
     }
 
@@ -30,6 +39,12 @@ public class ObjectVersionIdTest {
         assertEquals(false, versionId.isBranch());
 
         versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359::local.archie.org::1.1.1");
+        assertEquals(true, versionId.isBranch());
+
+        versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359", "local.archie.org", "1");
+        assertEquals(false, versionId.isBranch());
+
+        versionId = new ObjectVersionId("fd0c55b8-a396-4ca1-8928-e12b88148359", "local.archie.org", "1.1.1");
         assertEquals(true, versionId.isBranch());
     }
 }

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/VersionTreeIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/VersionTreeIdTest.java
@@ -51,7 +51,7 @@ public class VersionTreeIdTest {
         version = new VersionTreeId("1.1.1");
         assertEquals("1", version.getTrunkVersion());
 
-        version = new VersionTreeId("123.123.123");
+        version = new VersionTreeId("123.456.789");
         assertEquals("123", version.getTrunkVersion());
 
         // invalid entries

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/VersionTreeIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/VersionTreeIdTest.java
@@ -1,0 +1,82 @@
+package com.nedap.archie.rm.support.identification;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VersionTreeIdTest {
+
+    @Test
+    public void isBranch() {
+        VersionTreeId version = new VersionTreeId("1");
+        assertEquals(Boolean.FALSE, version.isBranch());
+
+        version = new VersionTreeId("1.1.1");
+        assertEquals(Boolean.TRUE, version.isBranch());
+
+        version = new VersionTreeId("123.123.123");
+        assertEquals(Boolean.TRUE, version.isBranch());
+
+        version = new VersionTreeId("2.0.0");
+        assertEquals(Boolean.TRUE, version.isBranch());
+
+        // invalid entries
+        version = new VersionTreeId("0.0.1");
+        assertThrows(IllegalArgumentException.class, version::isBranch);
+
+        version = new VersionTreeId("1.");
+        assertThrows(IllegalArgumentException.class, version::isBranch);
+
+        version = new VersionTreeId("1.1");
+        assertThrows(IllegalArgumentException.class, version::isBranch);
+
+        version = new VersionTreeId("1.1.");
+        assertThrows(IllegalArgumentException.class, version::isBranch);
+
+        version = new VersionTreeId(".1.");
+        assertThrows(IllegalArgumentException.class, version::isBranch);
+
+        version = new VersionTreeId("..1");
+        assertThrows(IllegalArgumentException.class, version::isBranch);
+    }
+
+    @Test
+    public void getTrunkVersion() {
+        VersionTreeId version = new VersionTreeId("1");
+        assertEquals("1", version.getTrunkVersion());
+
+        version = new VersionTreeId("43");
+        assertEquals("43", version.getTrunkVersion());
+
+        version = new VersionTreeId("1.1.1");
+        assertEquals("1", version.getTrunkVersion());
+
+        version = new VersionTreeId("123.123.123");
+        assertEquals("123", version.getTrunkVersion());
+
+        // invalid entries
+        version = new VersionTreeId("0.0.1");
+        assertThrows(IllegalArgumentException.class, version::getTrunkVersion);
+
+        version = new VersionTreeId("1.");
+        assertThrows(IllegalArgumentException.class, version::getTrunkVersion);
+    }
+
+    @Test
+    public void getBranchNumber() {
+        VersionTreeId version = new VersionTreeId("1.2.3");
+        assertEquals("2", version.getBranchNumber());
+
+        version = new VersionTreeId("123.456.789");
+        assertEquals("456", version.getBranchNumber());
+    }
+
+    @Test
+    public void getBranchVersion() {
+        VersionTreeId version = new VersionTreeId("1.2.3");
+        assertEquals("3", version.getBranchVersion());
+
+        version = new VersionTreeId("123.456.789");
+        assertEquals("789", version.getBranchVersion());
+    }
+}

--- a/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
+++ b/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
@@ -140,6 +140,10 @@ public class RMComparedWithBmmTest {
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "IMPORTED_VERSION", "canonical_form"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "extension"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "root"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "object_id"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "version_tree_id"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "creating_system_id"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "is_branch"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "ORIGINAL_VERSION", "is_branch"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "ORIGINAL_VERSION", "canonical_form"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "UID_BASED_ID", "extension"));
@@ -150,6 +154,10 @@ public class RMComparedWithBmmTest {
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION", "data"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION", "preceding_version_uid"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION", "canonical_form"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "trunk_version"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "branch_number"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "branch_version"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "is_branch"));
 
         //System.out.println(Joiner.on("\n").join(compared));
         List<ModelDifference> foundErrors = new ArrayList<>();


### PR DESCRIPTION
Adds methods for UIDBasedId, VersionTreeId and ObjectVersionId.

Following points are open or unclear for me:

I'm not sure what Archie's exception strategy is. I added `IllegalArgumentException` where the given input is not valid. Is that alright?

Also I had to remove `@XmlTransient` form `UIDBasedId.hasExtension()` because `CompositionTest.testEqual()` failed otherwise. I'm not sure if that's okay.

Added missing lines until the test in `RMComparedWithBmmTest.compareBmmWithRM()` was successful. Ok?