### PR TITLE
Json schema improvements

### DIFF
--- a/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
+++ b/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
@@ -213,7 +213,13 @@ public class JSONSchemaCreator {
             descendants.add(BmmDefinitions.typeNameToClassKey(type.getName()));
             addConcreteElse = true;
         }
+
         boolean genericType = type instanceof BmmGenericClass;
+        for(String descendant:descendants) {
+            if(bmmModel.getClassDefinition(descendant) instanceof BmmGenericClass) {
+                genericType = true; // it would be better to generate either an enum OR a couple of patterns, but not now
+            }
+        }
 
         if(descendants.isEmpty()) {
             //this is an object of which only an abstract class exists.

--- a/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
+++ b/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
@@ -154,6 +154,10 @@ public class JSONSchemaCreator {
                 .add("required", required)
                 .add("properties", properties);
 
+        if(bmmClass.getDocumentation() != null) {
+            definition.add("description", bmmClass.getDocumentation());
+        }
+
         if(!allowAdditionalProperties && atLeastOneProperty) {
             definition.add("additionalProperties", false);
         }
@@ -166,6 +170,9 @@ public class JSONSchemaCreator {
             if(containerProperty.getCardinality() != null && containerProperty.getCardinality().getLower() > 0) {
                 propertyDef.add("minItems", containerProperty.getCardinality().getLower());
             }
+        }
+        if(bmmProperty.getDocumentation() != null) {
+            propertyDef.add("description", bmmProperty.getDocumentation());
         }
     }
 

--- a/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
+++ b/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
@@ -213,6 +213,7 @@ public class JSONSchemaCreator {
             descendants.add(BmmDefinitions.typeNameToClassKey(type.getName()));
             addConcreteElse = true;
         }
+        boolean genericType = type instanceof BmmGenericClass;
 
         if(descendants.isEmpty()) {
             //this is an object of which only an abstract class exists.
@@ -221,12 +222,30 @@ public class JSONSchemaCreator {
             return createType("object");
         } else if (descendants.size() > 1) {
             JsonArrayBuilder array = jsonFactory.createArrayBuilder();
-            if(!addConcreteElse) {
-                array.add(createRequiredArray("_type"));
+
+            JsonObjectBuilder requiredType = addConcreteElse? jsonFactory.createObjectBuilder() : createRequiredArray("_type");
+
+            if(!genericType) {
+                JsonObjectBuilder typeDefinition = jsonFactory.createObjectBuilder()
+                        .add("type", "string");
+
+                JsonArrayBuilder enumValues = jsonFactory.createArrayBuilder();
+                for (String descendant : descendants) {
+                    enumValues.add(descendant);
+                }
+                typeDefinition.add("enum", enumValues);
+                JsonObjectBuilder typePropertyCheck = jsonFactory.createObjectBuilder()
+                        .add("_type", typeDefinition);
+                requiredType.add("properties", typePropertyCheck);
             }
+            array.add(requiredType);
+
             for(String descendant:descendants) {
                 JsonObjectBuilder typePropertyCheck = createConstType(descendant);
                 JsonObjectBuilder typeCheck = jsonFactory.createObjectBuilder().add("properties", typePropertyCheck);
+                if(addConcreteElse) {
+                    typeCheck.addAll(createRequiredArray("_type"));
+                }
 
                 JsonObjectBuilder typeReference = createReference(descendant);
                 //IF the type matches

--- a/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
+++ b/tools/src/main/java/com/nedap/archie/json/JSONSchemaCreator.java
@@ -307,11 +307,24 @@ public class JSONSchemaCreator {
 
     private JsonObjectBuilder createConstType(String rootType) {
 
-        return jsonFactory.createObjectBuilder()
-                .add("_type", jsonFactory.createObjectBuilder()
-                    .add("type", "string").add("pattern", "^" + rootType + "(<.*>)?$")
-                    //.add("const", rootType)
-                );
+        boolean generic = false;
+
+        BmmClass classDefinition = bmmModel.getClassDefinition(rootType);
+
+        if(classDefinition == null || classDefinition instanceof BmmGenericClass) {
+            generic = true;
+        }
+        if(generic) {
+            return jsonFactory.createObjectBuilder()
+                    .add("_type", jsonFactory.createObjectBuilder()
+                                    .add("type", "string").add("pattern", "^" + rootType + "<.*>$")
+                    );
+        } else {
+            return jsonFactory.createObjectBuilder()
+                    .add("_type", jsonFactory.createObjectBuilder()
+                            .add("const", rootType)
+                    );
+        }
     }
 
     private JsonObjectBuilder createRequiredArray(String... requiredFields) {

--- a/tools/src/test/java/com/nedap/archie/json/JSONSchemaCreatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/JSONSchemaCreatorTest.java
@@ -17,7 +17,7 @@ public class JSONSchemaCreatorTest {
 
     @Test
     public void createSchema() {
-        BmmModel model = BuiltinReferenceModels.getBmmRepository().getModel("openehr_rm_1.0.4").getModel();
+        BmmModel model = BuiltinReferenceModels.getBmmRepository().getModel("openehr_rm_1.1.0").getModel();
         JsonObject jsonObject = new JSONSchemaCreator().create(model);
 
         Map<String, Object> config = new HashMap();
@@ -30,7 +30,7 @@ public class JSONSchemaCreatorTest {
 
     @Test
     public void createSchemaWithoutAdditionalProperties() {
-        BmmModel model = BuiltinReferenceModels.getBmmRepository().getModel("openehr_rm_1.0.4").getModel();
+        BmmModel model = BuiltinReferenceModels.getBmmRepository().getModel("openehr_rm_1.1.0").getModel();
         JsonObject jsonObject = new JSONSchemaCreator().allowAdditionalProperties(false).create(model);
 
         Map<String, Object> config = new HashMap();


### PR DESCRIPTION
based on suggestions by Kristoffer Lundberg
- add a default type for when in polymorphic types the default is used and _type is omitted
- added enum values for _type when it is not generic, to ensure no other types can be used
- switch the JsonSchemaCreatorTest to model 1.1.0
- only generate generics parameters for generic classes in _type properties

Note: this is a pull request to the invariant_checking branch, and must only be merged after that

The output of the entire thing: https://gist.github.com/pieterbos/ff8a9c67fd3d346b423a8cd69befe67a