### PR TITLE
Upgrade antlr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .idea
 out/
 test-output/
+grammars/gen

--- a/grammars/build.gradle
+++ b/grammars/build.gradle
@@ -1,7 +1,7 @@
 description = "grammars for parsing ADL, ODIN and xpath"
 apply plugin: 'antlr'
 
-ext.antlrVersion = '4.9.1'
+ext.antlrVersion = '4.9.2'
 
 generateGrammarSource { //antlr4
   outputDirectory = new File("${project.buildDir}/generated-src/antlr/main/com/nedap/archie/adlparser/antlr".toString())
@@ -15,5 +15,5 @@ classes {
 
 dependencies {
   antlr "org.antlr:antlr4:${antlrVersion}"
-  compile 'org.antlr:antlr4-runtime:4.9.1'
+  compile 'org.antlr:antlr4-runtime:4.9.2'
 }


### PR DESCRIPTION
The auto-dependency update is not complete for ANTLR. This PR does this instead.

Also added grammars/gen to the gitignore. I suspect it's being added by intellij, but it should not be checked in.