### PR TITLE
Remove unused buildscript dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
-    classpath 'org.owasp:dependency-check-gradle:6.1.2'
-  }
-
-
-}
-
-
 repositories {
   mavenCentral()
 }
@@ -38,7 +25,6 @@ gradle.ext.isParallel = hasProperty('org.gradle.parallel') ? project.property('o
 
 subprojects {
   apply plugin: 'java'
-  apply plugin: 'org.owasp.dependencycheck'
   apply from: "${gradleScriptDir}/publish-maven.gradle"
 
  // plugins {


### PR DESCRIPTION
- the nexus staging plugin was never used - we still use the webinterface to release. Could be scripted later, but then with a newer plugin, not the old nexus staging one
- owasp dependency checks are not integrated in the build process. The github/dependabot checks already do this,s o this can be safely removed without losing access to alerts.