### PR TITLE
Fix archetype slot regex in ADL1.4 conversion

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14NodeIDConverter.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14NodeIDConverter.java
@@ -366,7 +366,7 @@ public class ADL14NodeIDConverter {
                             pattern = pattern.substring(1, pattern.length() - 1);
                             Matcher matcher = ARCHETYPE_ID_ENDS_WITH_VERSION_PATTERN_REPLACE.matcher(pattern);
                             if(matcher.find()) {
-                                pattern = "/" + matcher.replaceAll("${version}\\.*${end}") + "/";
+                                pattern = "/" + matcher.replaceAll("${version}\\\\..*${end}") + "/";
                                 cString.getConstraint().remove(0);
                                 cString.getConstraint().add(pattern);
                             }

--- a/tools/src/test/java/com/nedap/archie/adl14/ArchetypeSlotConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/ArchetypeSlotConversionTest.java
@@ -30,13 +30,13 @@ public class ArchetypeSlotConversionTest {
             Archetype archetype = result.getConversionResults().get(0).getArchetype();
             ArchetypeSlot slot = archetype.itemAtPath("/data/events[1]/state[id23]/items[id56]");
             String includesPattern = getPattern(slot.getIncludes().get(0));
-            assertEquals("/openEHR-EHR-CLUSTER\\.inspired_oxygen(-[a-zA-Z0-9_]+)*\\.v1.*/", includesPattern);
+            assertEquals("/openEHR-EHR-CLUSTER\\.inspired_oxygen(-[a-zA-Z0-9_]+)*\\.v1\\..*/", includesPattern);
 
             ArchetypeSlot slot2 = archetype.itemAtPath("/protocol/items[1]");
             String includesPattern2 = getPattern(slot2.getIncludes().get(0));
             String excludesPattern2 = getPattern(slot2.getExcludes().get(0));
             assertEquals("/.*/", includesPattern2);
-            assertEquals("/openEHR-EHR-CLUSTER\\.level_of_exertion-excluded.v1.*/", excludesPattern2);
+            assertEquals("/openEHR-EHR-CLUSTER\\.level_of_exertion-excluded.v1\\..*/", excludesPattern2);
         }
     }
 


### PR DESCRIPTION
In the ADL1.4 to ADL2 conversion the regular expressions are appended with `.*` to match the full ADL2 archetype ids. E.g. a regex ending in `\.v1` will be changed to `\.v1.*` to match an archetype id ending in `v1.0.0`. However this will also match for example `v13.0.0`.

This PR changes this behaviour to appending `\..*` so the regex will match `v1.0.0` but not `v13.0.0`.

Example from the [height archetype](https://ckm.openehr.org/ckm/archetypes/1013.1.3210):

ADL1.4:
```
					allow_archetype CLUSTER[at0011] occurrences matches {0..1} matches {    -- Device
						include
							archetype_id/value matches {/openEHR-EHR-CLUSTER\.device(-[a-zA-Z0-9_]+)*\.v1/}
					}
```

ADL2 (old):
```
                    allow_archetype CLUSTER[id12] occurrences matches {0..1} matches {     -- Device
                        include
                            archetype_id/value matches {/openEHR-EHR-CLUSTER\.device(-[a-zA-Z0-9_]+)*\.v1.*/}
                    }
```

ADL2 (new):
```
                    allow_archetype CLUSTER[id12] occurrences matches {0..1} matches {     -- Device
                        include
                            archetype_id/value matches {/openEHR-EHR-CLUSTER\.device(-[a-zA-Z0-9_]+)*\.v1\..*/}
                    }
```