### PR TITLE
Throw an Exception when ADL parse errors occur

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
@@ -57,40 +57,44 @@ public class ADL14Parser {
     }
 
     public Archetype parse(CharStream stream, ADL14ConversionConfiguration conversionConfiguration) throws ADLParseException {
-
         errors = new ANTLRParserErrors();
         errorListener = new ArchieErrorListener(errors);
         errorListener.setLogEnabled(logEnabled);
         Archetype result = null;
-        try {
-            lexer = new Adl14Lexer(stream);
-            lexer.addErrorListener(errorListener);
-            parser = new Adl14Parser(new CommonTokenStream(lexer));
-            parser.addErrorListener(errorListener);
-            tree = parser.adl(); // parse
 
-            ADL14Listener listener = new ADL14Listener(errors, conversionConfiguration);
-            walker = new ParseTreeWalker();
-            walker.walk(listener, tree);
-            result = listener.getArchetype();
-            ArchetypeParsePostProcesser.fixArchetype(result);
-            if (metaModels != null) {
-                metaModels.selectModel(result);
-                if (metaModels.getSelectedBmmModel() != null) {
-                    ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
-                    imposer.setSingleOrMultiple(result.getDefinition());
-                } else if (metaModels.getSelectedModelInfoLookup() != null) {
-                    ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
-                    imposer.setSingleOrMultiple(result.getDefinition());
-                }
-            }
-            return result;
-        } finally {
-            if(errors.hasErrors()) {
-                throw new ADLParseException(errors, result);
-            }
+        lexer = new Adl14Lexer(stream);
+        lexer.addErrorListener(errorListener);
+        parser = new Adl14Parser(new CommonTokenStream(lexer));
+        parser.addErrorListener(errorListener);
+        tree = parser.adl(); // parse
+
+        if(errors.hasErrors()) {
+            result = convertToAOM(conversionConfiguration);
+            throw new ADLParseException(errors, result);
         }
 
+        result = convertToAOM(conversionConfiguration);
+        return result;
+
+    }
+
+    private Archetype convertToAOM(ADL14ConversionConfiguration conversionConfiguration) {
+        ADL14Listener listener = new ADL14Listener(errors, conversionConfiguration);
+        walker = new ParseTreeWalker();
+        walker.walk(listener, tree);
+        Archetype result = listener.getArchetype();
+        ArchetypeParsePostProcesser.fixArchetype(result);
+        if (metaModels != null) {
+            metaModels.selectModel(result);
+            if (metaModels.getSelectedBmmModel() != null) {
+                ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
+                imposer.setSingleOrMultiple(result.getDefinition());
+            } else if (metaModels.getSelectedModelInfoLookup() != null) {
+                ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
+                imposer.setSingleOrMultiple(result.getDefinition());
+            }
+        }
+        return result;
     }
 
     public ANTLRParserErrors getErrors() {

--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.adl14;
 
 import com.nedap.archie.adl14.treewalkers.ADL14Listener;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.antlr.Adl14Lexer;
 import com.nedap.archie.adlparser.antlr.Adl14Parser;
 import com.nedap.archie.adlparser.modelconstraints.BMMConstraintImposer;
@@ -47,42 +48,48 @@ public class ADL14Parser {
         this.metaModels = models;
     }
 
-    public Archetype parse(String adl, ADL14ConversionConfiguration conversionConfiguration) {
+    public Archetype parse(String adl, ADL14ConversionConfiguration conversionConfiguration) throws ADLParseException {
         return parse(CharStreams.fromString(adl), conversionConfiguration);
     }
 
-    public Archetype parse(InputStream stream, ADL14ConversionConfiguration conversionConfiguration) throws IOException {
+    public Archetype parse(InputStream stream, ADL14ConversionConfiguration conversionConfiguration) throws IOException, ADLParseException {
         return parse(CharStreams.fromStream(new BOMInputStream(stream), Charset.availableCharsets().get("UTF-8")), conversionConfiguration);
     }
 
-    public Archetype parse(CharStream stream, ADL14ConversionConfiguration conversionConfiguration) {
+    public Archetype parse(CharStream stream, ADL14ConversionConfiguration conversionConfiguration) throws ADLParseException {
 
         errors = new ANTLRParserErrors();
         errorListener = new ArchieErrorListener(errors);
         errorListener.setLogEnabled(logEnabled);
+        Archetype result = null;
+        try {
+            lexer = new Adl14Lexer(stream);
+            lexer.addErrorListener(errorListener);
+            parser = new Adl14Parser(new CommonTokenStream(lexer));
+            parser.addErrorListener(errorListener);
+            tree = parser.adl(); // parse
 
-        lexer = new Adl14Lexer(stream);
-        lexer.addErrorListener(errorListener);
-        parser = new Adl14Parser(new CommonTokenStream(lexer));
-        parser.addErrorListener(errorListener);
-        tree = parser.adl(); // parse
-
-        ADL14Listener listener = new ADL14Listener(errors, conversionConfiguration);
-        walker= new ParseTreeWalker();
-        walker.walk(listener, tree);
-        Archetype result = listener.getArchetype();
-        ArchetypeParsePostProcesser.fixArchetype(result);
-        if (metaModels != null) {
-            metaModels.selectModel(result);
-            if(metaModels.getSelectedBmmModel() != null) {
-                ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
-                imposer.setSingleOrMultiple(result.getDefinition());
-            } else if (metaModels.getSelectedModelInfoLookup() != null) {
-                ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
-                imposer.setSingleOrMultiple(result.getDefinition());
+            ADL14Listener listener = new ADL14Listener(errors, conversionConfiguration);
+            walker = new ParseTreeWalker();
+            walker.walk(listener, tree);
+            result = listener.getArchetype();
+            ArchetypeParsePostProcesser.fixArchetype(result);
+            if (metaModels != null) {
+                metaModels.selectModel(result);
+                if (metaModels.getSelectedBmmModel() != null) {
+                    ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
+                    imposer.setSingleOrMultiple(result.getDefinition());
+                } else if (metaModels.getSelectedModelInfoLookup() != null) {
+                    ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
+                    imposer.setSingleOrMultiple(result.getDefinition());
+                }
+            }
+            return result;
+        } finally {
+            if(errors.hasErrors()) {
+                throw new ADLParseException(errors, result);
             }
         }
-        return result;
 
     }
 

--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14Parser.java
@@ -62,13 +62,14 @@ public class ADL14Parser {
         errorListener = new ArchieErrorListener(errors);
         errorListener.setLogEnabled(logEnabled);
         Archetype result = null;
-        try {
-            lexer = new Adl14Lexer(stream);
-            lexer.addErrorListener(errorListener);
-            parser = new Adl14Parser(new CommonTokenStream(lexer));
-            parser.addErrorListener(errorListener);
-            tree = parser.adl(); // parse
 
+        lexer = new Adl14Lexer(stream);
+        lexer.addErrorListener(errorListener);
+        parser = new Adl14Parser(new CommonTokenStream(lexer));
+        parser.addErrorListener(errorListener);
+        tree = parser.adl(); // parse
+
+        try {
             ADL14Listener listener = new ADL14Listener(errors, conversionConfiguration);
             walker = new ParseTreeWalker();
             walker.walk(listener, tree);

--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParseException.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParseException.java
@@ -1,10 +1,7 @@
 package com.nedap.archie.adlparser;
 
 import com.nedap.archie.antlr.errors.ANTLRParserErrors;
-import com.nedap.archie.antlr.errors.ANTLRParserMessage;
 import com.nedap.archie.aom.Archetype;
-
-import java.text.ParseException;
 
 public class ADLParseException extends Exception {
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParseException.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParseException.java
@@ -1,0 +1,47 @@
+package com.nedap.archie.adlparser;
+
+import com.nedap.archie.antlr.errors.ANTLRParserErrors;
+import com.nedap.archie.antlr.errors.ANTLRParserMessage;
+import com.nedap.archie.aom.Archetype;
+
+import java.text.ParseException;
+
+public class ADLParseException extends Exception {
+
+    private Archetype archetype;
+    private ANTLRParserErrors errors;
+
+    /**
+     * Constructs a ParseException with the specified detail message and
+     * offset.
+     * A detail message is a String that describes this particular exception.
+     *
+     * @param errors      the parser errors that led to this Exception
+     * @param archetype   the partially parsed Archetype
+     */
+    public ADLParseException(ANTLRParserErrors errors, Archetype archetype) {
+        super(errors.toString());
+        this.errors = errors;
+        this.archetype = archetype;
+    }
+
+
+    /**
+     * The parser does a best effort to even generate an arcehtype when there are parse errors.
+     * This is not guaranteed to be complete - in fact it likely is not, but it can be used for modeling tools to at least
+     * show part of the archetype in case of errors.
+     * If an archetype could not be constructed, returns null.
+     * @return the partially parsed archetype, or null if partial parsig failed
+     */
+    public Archetype getArchetype() {
+        return archetype;
+    }
+
+    /**
+     * Get the ANTLRParserErrors that occurred during parsing.
+     * @return the ANTLRParserErrors that occurred during parsing
+     */
+    public ANTLRParserErrors getErrors() {
+        return errors;
+    }
+}

--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParseException.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParseException.java
@@ -1,7 +1,10 @@
 package com.nedap.archie.adlparser;
 
 import com.nedap.archie.antlr.errors.ANTLRParserErrors;
+import com.nedap.archie.antlr.errors.ANTLRParserMessage;
 import com.nedap.archie.aom.Archetype;
+
+import java.text.ParseException;
 
 public class ADLParseException extends Exception {
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
@@ -84,13 +84,14 @@ public class ADLParser {
         errorListener = new ArchieErrorListener(errors);
         errorListener.setLogEnabled(logEnabled);
         Archetype result = null;
-        try {
-            lexer = new AdlLexer(stream);
-            lexer.addErrorListener(errorListener);
-            parser = new AdlParser(new CommonTokenStream(lexer));
-            parser.addErrorListener(errorListener);
-            tree = parser.adl(); // parse
 
+        lexer = new AdlLexer(stream);
+        lexer.addErrorListener(errorListener);
+        parser = new AdlParser(new CommonTokenStream(lexer));
+        parser.addErrorListener(errorListener);
+        tree = parser.adl(); // parse
+
+        try {
             ADLListener listener = new ADLListener(errors, metaModels);
             walker = new ParseTreeWalker();
             walker.walk(listener, tree);

--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
@@ -70,46 +70,53 @@ public class ADLParser {
         this.modelConstraintImposer = null;
     }
 
-    public Archetype parse(String adl) {
+    public Archetype parse(String adl) throws ADLParseException {
         return parse(CharStreams.fromString(adl));
     }
 
-    public Archetype parse(InputStream stream) throws IOException {
+    public Archetype parse(InputStream stream) throws ADLParseException, IOException {
         return parse(CharStreams.fromStream(new BOMInputStream(stream), Charset.availableCharsets().get("UTF-8")));
     }
 
-    public Archetype parse(CharStream stream) {
+    public Archetype parse(CharStream stream) throws ADLParseException {
 
         errors = new ANTLRParserErrors();
         errorListener = new ArchieErrorListener(errors);
         errorListener.setLogEnabled(logEnabled);
+        Archetype result = null;
+        try {
+            lexer = new AdlLexer(stream);
+            lexer.addErrorListener(errorListener);
+            parser = new AdlParser(new CommonTokenStream(lexer));
+            parser.addErrorListener(errorListener);
+            tree = parser.adl(); // parse
 
-        lexer = new AdlLexer(stream);
-        lexer.addErrorListener(errorListener);
-        parser = new AdlParser(new CommonTokenStream(lexer));
-        parser.addErrorListener(errorListener);
-        tree = parser.adl(); // parse
+            ADLListener listener = new ADLListener(errors, metaModels);
+            walker = new ParseTreeWalker();
+            walker.walk(listener, tree);
+            result = listener.getArchetype();
+            //set some values that are not directly in ODIN or ADL
+            ArchetypeParsePostProcesser.fixArchetype(result);
 
-        ADLListener listener = new ADLListener(errors, metaModels);
-        walker= new ParseTreeWalker();
-        walker.walk(listener, tree);
-        Archetype result = listener.getArchetype();
-        //set some values that are not directly in ODIN or ADL
-        ArchetypeParsePostProcesser.fixArchetype(result);
-
-        if(modelConstraintImposer != null && result.getDefinition() != null) {
-            modelConstraintImposer.imposeConstraints(result.getDefinition());
-        } else if (metaModels != null) {
-            metaModels.selectModel(result);
-            if(metaModels.getSelectedBmmModel() != null) {
-                ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
-                imposer.setSingleOrMultiple(result.getDefinition());
-            } else if (metaModels.getSelectedModelInfoLookup() != null) {
-                ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
-                imposer.setSingleOrMultiple(result.getDefinition());
+            if (modelConstraintImposer != null && result.getDefinition() != null) {
+                modelConstraintImposer.imposeConstraints(result.getDefinition());
+            } else if (metaModels != null) {
+                metaModels.selectModel(result);
+                if (metaModels.getSelectedBmmModel() != null) {
+                    ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
+                    imposer.setSingleOrMultiple(result.getDefinition());
+                } else if (metaModels.getSelectedModelInfoLookup() != null) {
+                    ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
+                    imposer.setSingleOrMultiple(result.getDefinition());
+                }
+            }
+            return result;
+        } finally {
+            if (errors.hasErrors()) {
+                throw new ADLParseException(errors, result);
             }
         }
-        return result;
+
 
     }
 

--- a/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/ADLParser.java
@@ -84,50 +84,40 @@ public class ADLParser {
         errorListener = new ArchieErrorListener(errors);
         errorListener.setLogEnabled(logEnabled);
         Archetype result = null;
+        try {
+            lexer = new AdlLexer(stream);
+            lexer.addErrorListener(errorListener);
+            parser = new AdlParser(new CommonTokenStream(lexer));
+            parser.addErrorListener(errorListener);
+            tree = parser.adl(); // parse
 
-        lexer = new AdlLexer(stream);
-        lexer.addErrorListener(errorListener);
-        parser = new AdlParser(new CommonTokenStream(lexer));
-        parser.addErrorListener(errorListener);
-        tree = parser.adl(); // parse
+            ADLListener listener = new ADLListener(errors, metaModels);
+            walker = new ParseTreeWalker();
+            walker.walk(listener, tree);
+            result = listener.getArchetype();
+            //set some values that are not directly in ODIN or ADL
+            ArchetypeParsePostProcesser.fixArchetype(result);
 
-        if (errors.hasErrors()) {
-            try {
-                result = convertToAOM();
-            } finally {
+            if (modelConstraintImposer != null && result.getDefinition() != null) {
+                modelConstraintImposer.imposeConstraints(result.getDefinition());
+            } else if (metaModels != null) {
+                metaModels.selectModel(result);
+                if (metaModels.getSelectedBmmModel() != null) {
+                    ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
+                    imposer.setSingleOrMultiple(result.getDefinition());
+                } else if (metaModels.getSelectedModelInfoLookup() != null) {
+                    ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
+                    imposer.setSingleOrMultiple(result.getDefinition());
+                }
+            }
+            return result;
+        } finally {
+            if (errors.hasErrors()) {
                 throw new ADLParseException(errors, result);
             }
         }
 
-        result = convertToAOM();
-        return result;
 
-
-
-    }
-
-    private Archetype convertToAOM() {
-
-        ADLListener listener = new ADLListener(errors, metaModels);
-        walker = new ParseTreeWalker();
-        walker.walk(listener, tree);
-        Archetype result = listener.getArchetype();
-        //set some values that are not directly in ODIN or ADL
-        ArchetypeParsePostProcesser.fixArchetype(result);
-
-        if (modelConstraintImposer != null && result.getDefinition() != null) {
-            modelConstraintImposer.imposeConstraints(result.getDefinition());
-        } else if (metaModels != null) {
-            metaModels.selectModel(result);
-            if (metaModels.getSelectedBmmModel() != null) {
-                ModelConstraintImposer imposer = new BMMConstraintImposer(metaModels.getSelectedBmmModel());
-                imposer.setSingleOrMultiple(result.getDefinition());
-            } else if (metaModels.getSelectedModelInfoLookup() != null) {
-                ModelConstraintImposer imposer = new ReflectionConstraintImposer(metaModels.getSelectedModelInfoLookup());
-                imposer.setSingleOrMultiple(result.getDefinition());
-            }
-        }
-        return result;
     }
 
     public ANTLRParserErrors getErrors() {

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.rmobjectvalidator;
 
+import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeConstraint;
 
 /**
@@ -11,6 +12,7 @@ public class RMObjectValidationMessage {
     private String path;
     private String humanReadableArchetypePath;
     private String message;
+    private String archetypeId;
 
     private RMObjectValidationMessageType type;
 
@@ -20,13 +22,19 @@ public class RMObjectValidationMessage {
     }
 
     public RMObjectValidationMessage(ArchetypeConstraint constraint, String actualPath, String message, RMObjectValidationMessageType type) {
-        this(actualPath, constraint == null ? null : constraint.getPath(), constraint == null ? null : constraint.getLogicalPath(), message, type);
+        this(actualPath,
+                getArchetypeId(constraint),
+                constraint == null ? null : constraint.getPath(),
+                constraint == null ? null : constraint.getLogicalPath(),
+                message,
+                type);
     }
 
 
     // Constructors with attribute assignment
-    public RMObjectValidationMessage(String path, String archetypePath, String humanPath, String message, RMObjectValidationMessageType type) {
+    public RMObjectValidationMessage(String path, String archetypeId, String archetypePath, String humanPath, String message, RMObjectValidationMessageType type) {
         this.path = path;
+        this.archetypeId = archetypeId;
         this.archetypePath = archetypePath;
         this.humanReadableArchetypePath = humanPath;
         this.message = message;
@@ -39,14 +47,37 @@ public class RMObjectValidationMessage {
         this.message = e.getMessage();
     }
 
+    /**
+     * Get the archetype id of the archetype used for validation, if available. Usually this will be the id of the OPT provided to the
+     * RMObjectValidator. However, if archetype slots where used, it will return the id of the archetype in the slot instead.
+     * It will return null in case no archetype was available or the validation error was not due to an archetype constraint
+     * for example, validations from the RM instead of the archetype.
+     * @return the archetype id of the used archetype for validation, or null if none was available
+     */
+    public String getArchetypeId() {
+        return archetypeId;
+    }
+
+    /**
+     * Get the path in the archetype that this validation refers to - used to retrieve the constraint that was used to generate this error
+     * @return the path of the constraint that was used to generate this error in the archetype
+     */
     public String getArchetypePath() {
         return archetypePath;
     }
 
+    /**
+     * returns the path in the RM Object that resulted in this validation message.
+     * @return The path in the RM Object that resulted in this validation message.
+     */
     public String getPath() {
         return path;
     }
 
+    /**
+     * Returns the type of the validation message.
+     * @return the type of the validation message
+     */
     public RMObjectValidationMessageType getType() {
         return type;
     }
@@ -55,15 +86,34 @@ public class RMObjectValidationMessage {
         this.type = type;
     }
 
+    /**
+     * Get the human readable path in the archetype that this validation refers to - used to retrieve the constraint that was used to generate this error
+     * @return the human readablepath of the constraint that was used to generate this error in the archetype
+     */
     public String getHumanReadableArchetypePath() {
         return humanReadableArchetypePath;
     }
 
+    /**
+     * Gets the validation message, which is a human readable string indicating the cause of this validation message.
+     * @return the validation message
+     */
     public String getMessage() {
         return message;
     }
 
     public String toString() {
         return RMObjectValidationMessageIds.rm_VALIDATION_MESSAGE_TO_STRING.getMessage(humanReadableArchetypePath == null ? path : humanReadableArchetypePath, path, message);
+    }
+
+    private static String getArchetypeId(ArchetypeConstraint constraint) {
+        if(constraint == null) {
+            return null;
+        }
+        Archetype archetype = constraint.getArchetype();
+        if(archetype != null) {
+            return archetype.getArchetypeId().getFullId();
+        }
+        return null;
     }
 }

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
@@ -1,6 +1,5 @@
 package com.nedap.archie.rmobjectvalidator;
 
-import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeConstraint;
 
 /**
@@ -12,7 +11,6 @@ public class RMObjectValidationMessage {
     private String path;
     private String humanReadableArchetypePath;
     private String message;
-    private String archetypeId;
 
     private RMObjectValidationMessageType type;
 
@@ -22,19 +20,13 @@ public class RMObjectValidationMessage {
     }
 
     public RMObjectValidationMessage(ArchetypeConstraint constraint, String actualPath, String message, RMObjectValidationMessageType type) {
-        this(actualPath,
-                getArchetypeId(constraint),
-                constraint == null ? null : constraint.getPath(),
-                constraint == null ? null : constraint.getLogicalPath(),
-                message,
-                type);
+        this(actualPath, constraint == null ? null : constraint.getPath(), constraint == null ? null : constraint.getLogicalPath(), message, type);
     }
 
 
     // Constructors with attribute assignment
-    public RMObjectValidationMessage(String path, String archetypeId, String archetypePath, String humanPath, String message, RMObjectValidationMessageType type) {
+    public RMObjectValidationMessage(String path, String archetypePath, String humanPath, String message, RMObjectValidationMessageType type) {
         this.path = path;
-        this.archetypeId = archetypeId;
         this.archetypePath = archetypePath;
         this.humanReadableArchetypePath = humanPath;
         this.message = message;
@@ -47,37 +39,14 @@ public class RMObjectValidationMessage {
         this.message = e.getMessage();
     }
 
-    /**
-     * Get the archetype id of the archetype used for validation, if available. Usually this will be the id of the OPT provided to the
-     * RMObjectValidator. However, if archetype slots where used, it will return the id of the archetype in the slot instead.
-     * It will return null in case no archetype was available or the validation error was not due to an archetype constraint
-     * for example, validations from the RM instead of the archetype.
-     * @return the archetype id of the used archetype for validation, or null if none was available
-     */
-    public String getArchetypeId() {
-        return archetypeId;
-    }
-
-    /**
-     * Get the path in the archetype that this validation refers to - used to retrieve the constraint that was used to generate this error
-     * @return the path of the constraint that was used to generate this error in the archetype
-     */
     public String getArchetypePath() {
         return archetypePath;
     }
 
-    /**
-     * returns the path in the RM Object that resulted in this validation message.
-     * @return The path in the RM Object that resulted in this validation message.
-     */
     public String getPath() {
         return path;
     }
 
-    /**
-     * Returns the type of the validation message.
-     * @return the type of the validation message
-     */
     public RMObjectValidationMessageType getType() {
         return type;
     }
@@ -86,34 +55,15 @@ public class RMObjectValidationMessage {
         this.type = type;
     }
 
-    /**
-     * Get the human readable path in the archetype that this validation refers to - used to retrieve the constraint that was used to generate this error
-     * @return the human readablepath of the constraint that was used to generate this error in the archetype
-     */
     public String getHumanReadableArchetypePath() {
         return humanReadableArchetypePath;
     }
 
-    /**
-     * Gets the validation message, which is a human readable string indicating the cause of this validation message.
-     * @return the validation message
-     */
     public String getMessage() {
         return message;
     }
 
     public String toString() {
         return RMObjectValidationMessageIds.rm_VALIDATION_MESSAGE_TO_STRING.getMessage(humanReadableArchetypePath == null ? path : humanReadableArchetypePath, path, message);
-    }
-
-    private static String getArchetypeId(ArchetypeConstraint constraint) {
-        if(constraint == null) {
-            return null;
-        }
-        Archetype archetype = constraint.getArchetype();
-        if(archetype != null) {
-            return archetype.getArchetypeId().getFullId();
-        }
-        return null;
     }
 }

--- a/tools/src/test/java/com/nedap/archie/adl14/ADL14ExternalTerminologyConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/ADL14ExternalTerminologyConversionTest.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.adl14;
 
 import com.google.common.collect.Lists;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.utils.AOMUtils;
@@ -19,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 public class ADL14ExternalTerminologyConversionTest {
 
     @Test
-    public void terminologyBindingsConverted() throws IOException {
+    public void terminologyBindingsConverted() throws IOException, ADLParseException {
         ADL14ConversionConfiguration conversionConfiguration = ConversionConfigForTest.getConfig();
         ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
         //apply the first conversion and store the log. It has created an at code to bind to [openehr::124], used in a DV_QUANTITY.property

--- a/tools/src/test/java/com/nedap/archie/adlparser/LargeSetOfADLsTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/LargeSetOfADLsTest.java
@@ -36,12 +36,9 @@ public class LargeSetOfADLsTest {
                 logger.info("trying to parse " + file);
                 ADLParser parser = new ADLParser();
                 parser.parse(stream);
-                if(parser.errorListener.getErrors().getErrors().size() > 0) {
-                    parseErrors.put(file, parser.errorListener.getErrors());
-                }
-                if(parser.getTree().exception != null) {
-                    exceptions.put(file, parser.getTree().exception);
-                }
+
+            } catch (ADLParseException parseException) {
+                parseErrors.put(file, parseException.getErrors());
             } catch (Exception e) {
                 exceptions.put(file, e);
             }

--- a/tools/src/test/java/com/nedap/archie/aom/ArchetypeTerminologyTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/ArchetypeTerminologyTest.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.aom;
 
 import com.nedap.archie.ArchieLanguageConfiguration;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.archetypevalidator.ValidationResult;
 import com.nedap.archie.flattener.Flattener;
 import com.nedap.archie.flattener.FlattenerConfiguration;
@@ -23,7 +24,7 @@ public class ArchetypeTerminologyTest {
     }
     
     @Test
-    public void termForUseArchetype() throws IOException {
+    public void termForUseArchetype() throws IOException, ADLParseException {
         //getting the term for a use archetype is a bit of a tricky situation - it's not for the 'id1' code,
         //it's for the code in the parent. So do some specific test here
         InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.archetypevalidator;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
@@ -198,7 +199,7 @@ public class ArchetypeValidatorTest {
     }
 
 
-    private Archetype parse(String filename) throws IOException {
+    private Archetype parse(String filename) throws IOException, ADLParseException {
         archetype = parser.parse(ArchetypeValidatorTest.class.getResourceAsStream(filename));
         assertTrue(parser.getErrors().toString(), parser.getErrors().hasNoErrors());
         return archetype;

--- a/tools/src/test/java/com/nedap/archie/creation/ExampleJsonInstanceGeneratorTest.java
+++ b/tools/src/test/java/com/nedap/archie/creation/ExampleJsonInstanceGeneratorTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Joiner;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.OperationalTemplate;
@@ -232,14 +233,14 @@ public class ExampleJsonInstanceGeneratorTest {
     }
 
 
-    private OperationalTemplate createOPT(String s2) throws IOException {
+    private OperationalTemplate createOPT(String s2) throws IOException, ADLParseException {
         Archetype archetype = parse(s2);
         InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
         repository.addArchetype(archetype);
         return (OperationalTemplate) new Flattener(repository, BuiltinReferenceModels.getMetaModels()).createOperationalTemplate(true).flatten(archetype);
     }
 
-    private Archetype parse(String filename) throws IOException {
+    private Archetype parse(String filename) throws IOException, ADLParseException {
         ADLParser parser = new ADLParser();
         Archetype archetype;
         try(InputStream stream =  getClass().getResourceAsStream(filename)) {

--- a/tools/src/test/java/com/nedap/archie/flattener/InMemoryFullArchetypeRepositoryTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/InMemoryFullArchetypeRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.flattener;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.OperationalTemplate;
@@ -19,7 +20,7 @@ public class InMemoryFullArchetypeRepositoryTest {
     InMemoryFullArchetypeRepository inMemoryFullArchetypeRepository;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws IOException, ADLParseException {
         //Create versioned archetypes
         List<Archetype> archetypes = new ArrayList<>();
         archetypes.add(new ADLParser().parse(

--- a/tools/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/RulesFlattenerTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.flattener;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.CObject;
@@ -45,7 +46,7 @@ public class RulesFlattenerTest {
     }
 
     @Test
-    public void specializedRules() {
+    public void specializedRules() throws ADLParseException {
         Archetype flattened = flattener.flatten(specializedRules);
         assertEquals(5, flattened.getRules().getRules().size()); //three original rules, one overwritten, one added
 
@@ -63,7 +64,7 @@ public class RulesFlattenerTest {
         checkCorrectSyntax(flattened);
     }
 
-    private void checkCorrectSyntax(Archetype flattened) {
+    private void checkCorrectSyntax(Archetype flattened) throws ADLParseException {
         String serialized= ADLArchetypeSerializer.serialize(flattened);
         ADLParser parser = new ADLParser();
         parser.parse(serialized);

--- a/tools/src/test/java/com/nedap/archie/flattener/SiblingOrderFlattenerTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/SiblingOrderFlattenerTest.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.flattener;
 
 import com.google.common.collect.Lists;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.aom.Archetype;
 
 import com.nedap.archie.aom.ArchetypeSlot;
@@ -143,11 +144,11 @@ public class SiblingOrderFlattenerTest {
 
     }
 
-    private Archetype parse(String fileName) throws IOException {
+    private Archetype parse(String fileName) throws IOException, ADLParseException {
         return FlattenerTestUtil.parse("/com/nedap/archie/flattener/siblingorder/" + fileName);
     }
 
-    private Archetype parseAndFlatten(String fileName) throws IOException {
+    private Archetype parseAndFlatten(String fileName) throws IOException, ADLParseException {
         Archetype result = parse(fileName);
         ReferenceModels models = new ReferenceModels();
         models.registerModel(ArchieRMInfoLookup.getInstance());

--- a/tools/src/test/java/com/nedap/archie/flattener/specexamples/FlattenerTestUtil.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/specexamples/FlattenerTestUtil.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.flattener.specexamples;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.adlparser.modelconstraints.RMConstraintImposer;
 import com.nedap.archie.aom.Archetype;
@@ -12,7 +13,7 @@ import static org.junit.Assert.fail;
 
 public class FlattenerTestUtil {
 
-    public static Archetype parse(String filename) throws IOException {
+    public static Archetype parse(String filename) throws IOException, ADLParseException {
         ADLParser parser = new ADLParser();
         InputStream stream = FlattenerTestUtil.class.getResourceAsStream(filename);
         if(stream == null) {

--- a/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.json.flat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.OperationalTemplate;
@@ -108,7 +109,7 @@ public class FlatJsonGeneratorTest {
         assertEquals("Systolic", stringObjectMap.get("/data[id2]/events[id7,1]/data[id4]/items[id5]/name/value"));
     }
 
-    private OperationalTemplate parseBloodPressure() throws IOException {
+    private OperationalTemplate parseBloodPressure() throws IOException, ADLParseException {
         try (InputStream stream = getClass().getResourceAsStream(BLOOD_PRESSURE_PATH)) {
             Archetype bloodPressure = new ADLParser(BuiltinReferenceModels.getMetaModels()).parse(stream);
             Flattener flattener = new Flattener(new SimpleArchetypeRepository(), BuiltinReferenceModels.getMetaModels(), FlattenerConfiguration.forOperationalTemplate());

--- a/tools/src/test/java/com/nedap/archie/rmobjectvalidator/RmObjectValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rmobjectvalidator/RmObjectValidatorTest.java
@@ -2,6 +2,7 @@ package com.nedap.archie.rmobjectvalidator;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.archetypevalidator.ArchetypeValidatorTest;
@@ -130,7 +131,7 @@ public class RmObjectValidatorTest {
         assertFalse(validate.isEmpty());
     }
 
-    private Archetype parse(String filename) throws IOException {
+    private Archetype parse(String filename) throws IOException, ADLParseException {
         Archetype archetype = parser.parse(ArchetypeValidatorTest.class.getResourceAsStream(filename));
         assertTrue(parser.getErrors().toString(), parser.getErrors().hasNoErrors());
         return archetype;

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.rules.evaluation;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.adlparser.modelconstraints.RMConstraintImposer;
 import com.nedap.archie.aom.Archetype;
@@ -72,7 +73,7 @@ public class ParsedRulesEvaluationTest {
 
     }
 
-    private Archetype parse(String filename) throws IOException {
+    private Archetype parse(String filename) throws IOException, ADLParseException {
         archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream(filename));
         assertTrue(parser.getErrors().toString(), parser.getErrors().hasNoErrors());
         return archetype;
@@ -654,7 +655,7 @@ public class ParsedRulesEvaluationTest {
     }
 
     @Test
-    public void flattenedRules() throws IOException {
+    public void flattenedRules() throws IOException, ADLParseException {
         Archetype valueSet = parse("matches_valueset.adls");
         Archetype parent = parse("termcodeparent.adls");
         InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLArchetypeSerializerParserRoundtripTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLArchetypeSerializerParserRoundtripTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.serializer.adl;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.CAttribute;
@@ -92,7 +93,7 @@ public class ADLArchetypeSerializerParserRoundtripTest {
         Assert.assertThat(parsed.getDescription().getLicence(), is("license with a \\\"-mark" ));
     }
 
-    private Archetype roundtrip(Archetype archetype) throws IOException {
+    private Archetype roundtrip(Archetype archetype) throws ADLParseException {
         String serialized = ADLArchetypeSerializer.serialize(archetype);
         logger.info(serialized);
 
@@ -103,11 +104,11 @@ public class ADLArchetypeSerializerParserRoundtripTest {
         return result;
     }
 
-    private Archetype load(String resourceName) throws IOException {
+    private Archetype load(String resourceName) throws IOException, ADLParseException {
         return new ADLParser().parse(ADLArchetypeSerializerTest.class.getResourceAsStream(resourceName));
     }
 
-    private Archetype loadRoot(String resourceName) throws IOException {
+    private Archetype loadRoot(String resourceName) throws IOException, ADLParseException {
         return new ADLParser().parse(ADLArchetypeSerializerTest.class.getClassLoader().getResourceAsStream(resourceName));
     }
 

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLArchetypeSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLArchetypeSerializerTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.serializer.adl;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import org.junit.Test;
@@ -95,11 +96,11 @@ public class ADLArchetypeSerializerTest {
         assertThat(serialized, containsString("[\"local_name\"] = <\"consultation start time\">"));
    }
 
-    private Archetype load(String resourceName) throws IOException {
+    private Archetype load(String resourceName) throws ADLParseException, IOException {
         return new ADLParser().parse(ADLArchetypeSerializerTest.class.getResourceAsStream(resourceName));
     }
 
-    private Archetype loadRoot(String resourceName) throws IOException {
+    private Archetype loadRoot(String resourceName) throws ADLParseException, IOException {
         return new ADLParser().parse(ADLArchetypeSerializerTest.class.getClassLoader().getResourceAsStream(resourceName));
     }
 

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.serializer.adl;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeSlot;
@@ -24,11 +25,11 @@ public class ADLDefinitionSerializerTest {
 
 
     @BeforeClass
-    public static void setupClass() throws IOException {
+    public static void setupClass() throws IOException, ADLParseException {
         archetypePrimitives = load("openEHR-TEST_PKG-WHOLE.primitive_types.v1.adls");
     }
 
-    private static Archetype load(String resourceName) throws IOException {
+    private static Archetype load(String resourceName) throws IOException, ADLParseException {
         return new ADLParser().parse(ADLDefinitionSerializerTest.class.getResourceAsStream(resourceName));
     }
 
@@ -268,7 +269,7 @@ public class ADLDefinitionSerializerTest {
     }
 
     @Test
-    public void serializeCArchetypeRoot() throws IOException {
+    public void serializeCArchetypeRoot() throws IOException, ADLParseException {
         Archetype archetype = loadRoot("adl2-tests/features/aom_structures/use_archetype/openEHR-EHR-COMPOSITION.ext_ref.v1.0.0.adls");
 
         List<CObject> archetypeRoots = archetype.getDefinition().getAttribute("content").getChildren();
@@ -280,7 +281,7 @@ public class ADLDefinitionSerializerTest {
     }
 
     @Test
-    public void serializeCComplexObjectProxy() throws IOException {
+    public void serializeCComplexObjectProxy() throws IOException, ADLParseException {
         Archetype archetype = loadRoot("adl2-tests/features/aom_structures/use_node/openEHR-DEMOGRAPHIC-PERSON.use_node_occurrences.v1.0.0.adls");
 
         CObject parentCObj = archetype.getDefinition().itemAtPath("/contacts[id10]");
@@ -330,7 +331,7 @@ public class ADLDefinitionSerializerTest {
         return serializer.getBuilder().toString();
     }
 
-    private Archetype loadRoot(String resourceName) throws IOException {
+    private Archetype loadRoot(String resourceName) throws IOException, ADLParseException {
         return new ADLParser().parse(ADLArchetypeSerializerTest.class.getClassLoader().getResourceAsStream(resourceName));
     }
 

--- a/tools/src/test/java/com/nedap/archie/serializer/rules/ADLRulesSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/rules/ADLRulesSerializerTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.serializer.rules;
 
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.rules.evaluation.ParsedRulesEvaluationTest;
@@ -83,7 +84,7 @@ public class ADLRulesSerializerTest {
     }
 
 
-    private Archetype load(String resourceName) throws IOException {
+    private Archetype load(String resourceName) throws IOException, ADLParseException {
         return new ADLParser().parse(ParsedRulesEvaluationTest.class.getResourceAsStream(resourceName));
 
     }

--- a/tools/src/test/java/com/nedap/archie/testutil/TestUtil.java
+++ b/tools/src/test/java/com/nedap/archie/testutil/TestUtil.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.testutil;
 
 import com.google.common.collect.Lists;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.aom.Archetype;
@@ -143,7 +144,7 @@ public class TestUtil {
         return (o2 instanceof CPrimitiveObject) && Objects.equals(((CPrimitiveObject<?, ?>) o2).getConstraint(), o1.getConstraint());
     }
 
-    public static Archetype parseFailOnErrors(String resourceName) throws IOException {
+    public static Archetype parseFailOnErrors(String resourceName) throws IOException, ADLParseException {
         ADLParser parser = new ADLParser();
         try(InputStream stream = TestUtil.class.getResourceAsStream(resourceName)) {
             if(stream == null) {


### PR DESCRIPTION
This PR replaces the current behaviour of the ADL and ADL 1.4 parser, where calling code must actively check for errors, with an exception on parser errors. It still is a best effort parser, in the sense that it will actually try to construct an archetype object out of the ADL file even with errors. it can be retrieved from the exception, or from the `ADLParser` object.

If an exception occurred during the best-effort parsing step, it is currently silently ignored, and the archetype will be set to `null`, indicating that best effort parsing failed. Point of discussion: should we improve that, and how?

the drawback is that for warnings, one still need to check the errors parameter. However, there are very little possible warnings. Most are about ambiguity, and that's usually a problem with the grammar rather than the ADL file, and already correctly handled into a correct result by ANTLR.

Instead of this approach, it is also possible to make an ADLParseResult object, with the fields:
```
Archetype archetype
ANTLRParseErrors errors;
```
However that means a major API change, instead of this much more minor one, and I think this way of throwing Exceptions on actual exceptions is nice to do.