### PR TITLE
Fix double conversion of assumed values in ADL1.4 conversion

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14TermConstraintConverter.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14TermConstraintConverter.java
@@ -119,12 +119,6 @@ public class ADL14TermConstraintConverter {
                     ValueSet valueSet = findOrCreateValueSet(cTerminologyCode.getArchetype(), localCodes, cTerminologyCode);
                     cTerminologyCode.setConstraint(Lists.newArrayList(valueSet.getId()));
                 }
-                if(cTerminologyCode.getAssumedValue() != null) {
-                    TerminologyCode assumedValue = cTerminologyCode.getAssumedValue();
-                    String oldCode = assumedValue.getCodeString();
-                    String newCode = converter.convertValueCode(oldCode);
-                    assumedValue.setCodeString(newCode);
-                }
             } else if (isLocalCode && AOMUtils.isValueSetCode(termCode.getCodeString())) {
                 List<String> newConstraint = new ArrayList<>();
                 for(String constraint:cTerminologyCode.getConstraint()) {

--- a/tools/src/test/java/com/nedap/archie/adl14/AssumedValueConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/AssumedValueConversionTest.java
@@ -1,0 +1,42 @@
+package com.nedap.archie.adl14;
+
+import com.google.common.collect.Lists;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CAttribute;
+import com.nedap.archie.aom.primitives.CTerminologyCode;
+import com.nedap.archie.archetypevalidator.ArchetypeValidator;
+import com.nedap.archie.archetypevalidator.ValidationResult;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+public class AssumedValueConversionTest {
+
+    @Test
+    public void testAssumedValueConversion() throws Exception {
+        ADL14ConversionConfiguration conversionConfiguration = ConversionConfigForTest.getConfig();
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
+
+        Archetype adl14archetype;
+        try(InputStream stream = getClass().getResourceAsStream("openEHR-EHR-OBSERVATION.height.v2.adl")) {
+            adl14archetype = new ADL14Parser(BuiltinReferenceModels.getMetaModels()).parse(stream, conversionConfiguration);
+        }
+
+        ADL2ConversionResultList result = converter.convert(
+                Lists.newArrayList(adl14archetype));
+        Archetype archetype = result.getConversionResults().get(0).getArchetype();
+
+        CAttribute cAttribute = archetype.itemAtPath("/data[id2]/events[id3]/state[id14]/items[id15]/value[id9004]/defining_code");
+        CTerminologyCode cTerminologyCode = (CTerminologyCode) cAttribute.getChildren().get(0);
+
+        assertNull(cTerminologyCode.getAssumedValue().getTerminologyId());
+        assertEquals("at17", cTerminologyCode.getAssumedValue().getCodeString());
+
+        ValidationResult validationResult = new ArchetypeValidator(BuiltinReferenceModels.getMetaModels()).validate(archetype);
+
+        assertTrue(validationResult.toString(), validationResult.passes());
+    }
+}

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-OBSERVATION.height.v2.adl
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-OBSERVATION.height.v2.adl
@@ -1,0 +1,1236 @@
+﻿archetype (adl_version=1.4; uid=89e5e585-dfef-465f-b344-9b40d9410759)
+	openEHR-EHR-OBSERVATION.height.v2
+
+concept
+	[at0000]	-- Height/Length
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			author = <
+				["name"] = <"Jasmin Buck, Sebastian Garde">
+				["organisation"] = <"University of Heidelberg, Ocean Informatics">
+			>
+		>
+		["ru"] = <
+			language = <[ISO_639-1::ru]>
+			author = <
+				["name"] = <"Andrey Tsaplin">
+				["organisation"] = <"ДГП 99 г. Москвы">
+			>
+			accreditation = <"Russian Medical State University">
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			author = <
+				["name"] = <"Kirsi Poikela, Åsa Skagerhult">
+				["organisation"] = <"Tieto Sweden AB, Region Östergötland">
+				["email"] = <"ext.kirsi.poikela@tieto.com, asa.skagerhult@regionostergotland.se">
+			>
+		>
+		["fi"] = <
+			language = <[ISO_639-1::fi]>
+			author = <
+				["name"] = <"Vesa Peltola">
+				["organisation"] = <"Tieto Finland">
+				["email"] = <"vesa.peltola@tieto.com">
+			>
+		>
+		["es-ar"] = <
+			language = <[ISO_639-1::es-ar]>
+			author = <
+				["name"] = <"Dr. Leonardo Der Jachadurian">
+				["organisation"] = <"Bitios.com">
+			>
+			accreditation = <"Medical Doctor (Internal Medicine Specialist)">
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			author = <
+				["name"] = <"Lars Bitsch-Larsen">
+				["organisation"] = <"University Hospital of Bergen Norway.">
+			>
+			accreditation = <"MD,DEAA, MBA, specialist in anesthesia, specialist in tropical medicine">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			author = <
+				["name"] = <"Marco Borges">
+				["organisation"] = <"P2D">
+				["email"] = <"marco.borges@p2d.com.br">
+			>
+			accreditation = <"P2D Health Advisor Council">
+		>
+		["ar-sy"] = <
+			language = <[ISO_639-1::ar-sy]>
+			author = <
+				["name"] = <"Mona Saleh">
+			>
+		>
+		["fa"] = <
+			language = <[ISO_639-1::fa]>
+			author = <
+				["name"] = <"Shahla Foozonkhah">
+				["organisation"] = <"Ocean Informatics">
+			>
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			author = <
+				["name"] = <"Lin Zhang">
+				["organisation"] = <"BIPH">
+				["email"] = <"linforest@163.com">
+			>
+			accreditation = <"?">
+		>
+		["nl"] = <
+			language = <[ISO_639-1::nl]>
+			author = <
+				["name"] = <"Marja Buur">
+				["organisation"] = <"Medisch Centrum Alkmaar">
+				["email"] = <"m.buur-krom@mca.nl">
+			>
+		>
+	>
+description
+	original_author = <
+		["name"] = <"Sam Heard">
+		["organisation"] = <"Ocean Informatics">
+		["email"] = <"sam.heard@oceaninformatics.com">
+		["date"] = <"2006-03-09">
+	>
+	details = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			purpose = <"Zur Dokumentation der Körpergröße in einer gestreckten Position, von Scheitel bis Sohle. Dies kann sowohl genau als auch ungefähr erfolgen, und entweder in einer stehenden oder liegenden Position.">
+			use = <"Wird verwendet um die tatsächliche Körpegröße/-länge eines Individuums zu dokumentieren. Eine Aussage über die physische Unvollständigkeit des Körpers kann in den 'Einflussfaktoren' des Protokoll Elements dokumentiert werden. Dies ist der gewöhnliche Archetyp zur Dokumentation einer typischen Messung von Körpergröße/-länge, unabhängig von der klinischen Situation.
+Der Archetyp kann auch verwendet werden, um eine geschätze Größe/Länge zu dokumentatieren, wenn es nicht möglich ist, eine genaue Messung durchzuführen, z.B. bei der Messung bei einem unkooperativen Kind. Dies ist nicht explizit in dem Archetyp modelliert, da das openEHR Referenzmodell für jeden 'Quantity' Datentyp automatisch das Attribut 'Approximation' zur Verfügung stellt. Zum Zeitpunkt der Implementiertung könnte eine Benutzerschnittstelle es den Klinikern daher ermöglichen, z.B. ein entsprechendes Kontrollkästchen zu aktivieren.
+Im allgemeinen werden Längenmessungen für Kinder bis zwei Jahren empfohlen, sowie für Individuen, die nicht stehen können; Größenmessungen für alle anderen. Idealerweise wird die Größe auf beiden Beinen stehend gemessen, mit dem Gewicht gleichmäßig verteilt, den Hacken zusammen und beiden Gesäßbacken und Hacken in Kontakt mit einem senkrechten Brett. Körperlänge wird in einer voll ausgestreckten, liegenden Position gemessen; hierbei wird das Becken flach gehalten, die Beine ausgestreckt und die Füße gebeugt.
+Der Archetyp wird auch benutzt, um eine Zunahme/Abnahme der Körpergröße/-länge zu dokumentieren. Dies kann z.B. in einem Template modelliert werden, indem das 'Any event' auf ein Interval eingeschränkt wird, mit der zugehörigen mathematischen Funktion 'increase' or 'decrease'.">
+			keywords = <"Größe", "Länge", "Wachstum", "Schrumpfung">
+			misuse = <"Nicht zur Dokumentation der ersten Länge eines Neugeboren (Geburtslänge) - hier sollte der spezialisierte Archetyp OBSERVATION.height-birth verwendet werden.
+Nicht zur Dokumentation der angepassten Größe oder Körperlänge - z.B. der geschätzten vollen Größe einer Person mit Kontraktur der Extremitäten, basierend auf der Messung anderer Körperteile und/oder einem Algorithmus - hier sollte der spezialisierte Archetyp OBSERVATION.height-adjusted verwendet werden.
+Nicht zur Dokumentation von Wachstumsgeschwindigkeit.
+Nicht zur Dokumentation der Länge eines Objekts oder spezifischen Körperteils.">
+			copyright = <"© openEHR Foundation">
+		>
+		["ru"] = <
+			language = <[ISO_639-1::ru]>
+			purpose = <"Для записи длины тела человека от макушки до пяток - как фактических, так и приближенных, стоя или лежа.
+">
+			use = <"Для записи фактической длины тела индивида в любой момент времени. В случае необходимости физическая неполнота тела может быть записана в протоколе - элемент \"Смешанные факторы. Это обычный образец, который будет использоваться для типичного измерения  длины тела, независимо от клинических условий.
+Может также использоваться для записи приблизителной длины тела в клиническом сценарии, где не возможно измерить точную высоту или длину - например, у ребенка. Это обстоятельство явно не указывается в архетипе, так как модель openEHR позволяет использовать атрибут приближения для любого типа количественных данных. Например, в интерфейсе приложения пользователь может позволить врачам, выбрать надлежащим образом маркированных флажок рядом с полем данных Рост чтобы показать, что записано приблизительное значение, а не фактический.
+Измерения длины тела рекомендуется для детей младше 2 лет и лицам, которые не могут стоять, рост стоя, для всех остальных.
+В идеале, рост измеряется стоя на двух ногах с весом распределяется равномерно, пятки вместе, и обе ягодицы и пятки в контакте с вертикальной поверхностью, длина тела измеряется в вытянутом положении лежа таз находится на плоскости, ноги вытянуты и ноги согнуты .
+Используется для записи роста (ребёнка) и потери высоты. В случае необходимости, подобное применение настоящее время может быть смоделировано путем ограничения \"any event\", до интервала, с соответствующей математической функцией увеличения или уменьшения в шаблоне.
+">
+			keywords = <"сжатие", "Увеличение", "снижение", "высота потери", "Высота", "Длина", "рост">
+			misuse = <"Не следует использовать для записи длины тела новорожденного - использовать специализацию этого архетипа - см. OBSERVATION.height-birth.
+Не следует использовать для записи скорректированной длины тела, например, расчет предполажительного роста человека с контрактурами конечностей, на основании  измерения других частей телаи / или алгоритмов - используйте OBSERVATION.height-adjusted.
+Не следует использовать для записи скорости роста.
+Не использовать для записи длины объекта или определенной части тела.">
+			copyright = <"© openEHR Foundation">
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			purpose = <"Att dokumentera en individs kroppslängd från hjässa till fotsula - uppmätt eller uppskattad, samt i stående eller liggande ställning.">
+			use = <"Används vid de flesta mätningar av kroppslängd, oberoende av den kliniska situationen.
+
+Används för att dokumentera en individs uppmätta kroppslängd vid någon tidpunkt. Information rörande kroppens fysiska ofullständighet kan vid behov registreras i fältet \"Möjliga felkällor och påverkande faktorer\". 
+
+Används även för att dokumentera uppskattad kroppslängd i kliniska situationer där det inte är möjligt att mäta exakt kroppslängd, exempelvis vid mätning av ett icke samarbetsvilligt barn. Detta har inte modellerats explicit i arketypen eftersom OpenEHRs referensmodell tillåter uppskattningar för vilken datatyp för kvantitet som helst. En uppskattning anges genom att attributet Magnitude_status sätts till '~'. I praktisk tillämpning kan systemets användargränssnitt exempelvis ha en kryssruta intill fältet för kroppslängd för att indikera att den registrerade kroppslängden är uppskattad och inte faktisk. 
+
+Används för att dokumentera tillväxt och längdminskning. Detta kan modelleras genom att \"Tidsobestämd händelse\" begränsas till ett intervall i en template med tillhörande matematisk funktion för ökning eller minskning.">
+			keywords = <"krympning", "ökning", "minskning", "längd", "kroppslängd", "tillväxt">
+			misuse = <"Ska inte användas för att dokumentera justerad kroppslängd, exempelvis en beräkning av uppskattad kroppslängd för en person med extremitetkontrakturer baserat på andra kroppsdelsmätningar eller på en algoritm, använd då istället arketypen OBSERVATION.height-adjusted.
+
+Ska inte användas för att dokumentera tillväxthastighet.
+
+Ska inte användas för att dokumentera längd av ett objekt eller en viss kroppsdel.">
+		>
+		["fi"] = <
+			language = <[ISO_639-1::fi]>
+			purpose = <"*To record the length of the body from crown of head to sole of foot of an individual - both actual and approximate, and either in a standing or recumbent position.(en)">
+			use = <"*To be used for recording the actual height or body length of an individual at any point in time.  A statement identifying the physical incompleteness of the body can be recorded in the 'Confounding factors' protocol element, if required.  This is the usual archetype to be used for a typical measurement of height or body length, independent of the clinical setting.
+
+Can also be used for recording an approximation of height or body length measurement in a clinical scenario where it is not possible to measure an accurate height or length - for example, measuring an uncooperative child.  This is not modelled explicitly in the archetype as the openEHR Reference model allows approximations  for any Quantity data type by setting the attribute Magnitude_status to the value '~'.  At implementation, for example, an application user interface could allow clinicians to select an appropriately labelled check box adjacent to the Height data field to indicate that the recorded height is an approximation, rather than actual.
+
+In general, length measurements are recommended for children under 2 years of age and individuals who cannot stand; height measurements for all others.
+
+Ideally, height is measured standing on both feet with weight distributed evenly, heels together and both buttocks and heels in contact with a vertical back board; body length is measured in a fully extended, supine position with the pelvis flat, legs extended and feet flexed. 
+
+Use to record growth or loss of height.  This can currently be modelled by constraining the 'any event' to an interval event within a template, with the associated mathematical function of increase or decrease, as appropriate.(en)">
+			keywords = <"*shrinkage(en)", "*increase(en)", "*decrease(en)", "*height loss(en)", "*height(en)", "*length(en)", "*growth(en)">
+			misuse = <"*Not to be used to record the adjusted height or body length eg a calculation of the estimated full height of a person with limb contractures, based on other body part measurements and/or an algorithm - use OBSERVATION.height-adjusted.
+
+Not to be used to record growth velocity.
+
+Not to be used to record the length of an object or specific body part.(en)">
+		>
+		["es-ar"] = <
+			language = <[ISO_639-1::es-ar]>
+			purpose = <"Para registrar la longitud corporal desde la coronilla de la cabeza hasta la planta de los pies, en el momento actual y tanto en posición parada como recostada.">
+			use = <"Usar para registrar la altura o longitud corporal actuales en cualquier momento. En caso de amputaciones u otra causa de incompletitud corporal puede ser registrado en \"Factores de confusión\", si es requerido. Este es el arquetipo usual para ser usado en una medición típica de altura o longitud corporal, independientemente del contexto clínico.
+
+También puede ser usado para registrar una aproximación de la altura o longitud corporal en un contexto clínico donde no es posible realizar una medición exacta (Ej. en el caso de un niño que no coopera). Esto no es modelado explícitamente en el arquetipo como el modelo de referencia de openEHR permite el atributo de aproximación para cualquier tipo  de dato de Cantidad. En la implementación, por ejemplo, la interfaz con el usuario de una aplicación de software podría permitir a los médicos tildar un cuadro de opción adyacente al campo de datos de Altura, para indicar que el dato registrado es una aproximación, antes que el valor medido exacto.
+
+En general, la medición de la longitud corporal se recomienda para niños menores a los 2 años y para individuos que no pueden permanecer de pie; medir altura para todos los demás casos.
+
+Idealmente, la altura es medida de pie sobre ambos pies con el peso distribuido equitativamente entre ambos, con los talones juntos y ambos glúteos y talones en contacto con una tabla posterior vertical y recta; la longitud corporal se mide en posición recostada completamente extendida, con la pelvis plana, las piernas extendidas y los pies flexionados.
+
+Usar para registrar el crecimiento o la pérdida de altura. Esto puede ser habitualmente modelado restringiendo \"cualquier evento\" a un intervalo en la plantilla, con una función matemática que incrementa o decrementa, según sea apropiado.">
+			keywords = <"contracción", "aumentar", "disminuir", "pérdida de altura", "altura", "longitud corporal", "crecimiento", "talla", "estatura">
+			misuse = <"No usar para registrar la primer talla de un infante en un momento cercano a su nacimiento, usualmente denominado como \\\"altura al nacer\\\". Para este uso utilizar la especialización de este arquetipo (ver OBSERVATION.height-birth.)
+
+No usar para registrar la altura o la longitud corporal ajustados (Ej. el calculo de la altura total estimada de una persona con contracturas de miembros, basado en las mediciones realizadas en otras partes del cuerpo y/o un algoritmo) Usar para esta situación: OBSERVATION.height-adjusted.
+
+No usar para registrar velocidad de crecimiento.
+
+No usar para registrar la longitud de un objeto o de una parte del cuerpo específica.">
+			copyright = <"© openEHR Foundation">
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			purpose = <"Brukes til registrering av et individs høyde/lengde fra isse til fotsåle - både målt, estimert og justert, enten stående, tilbakelent eller liggende.">
+			use = <"Brukes til registrering av høyden eller lengden til et individ ved et gitt tidspunkt. En kommentar som identifiserer eventuelle fysiske mangler kan ved behov registreres i dataelementet \"Supplerende opplysninger\". Dette er standardarketypen som skal brukes for en vanlig måling av høyde eller lengde, uavhengig av klinisk miljø.
+
+Kan også brukes for registrering av estimert høyde eller lengde i en klinisk situasjon hvor det ikke er mulig å måle en nøyaktig høyde eller lengde - for eksempel måling av et ikke-samarbeidsvillig barn. Dette er ikke eksplisitt modellert inn i arketypen idet openEHR referansemodellen tillater estimater for datatypen kvantitet (magnitude_status settes til \"~\"). Ved implementasjon kan det for eksempel settes kryss i en boks ved siden av datafeltet for høyde/lengde for å indikere at den registrerte høyden/lengden er et estimat.
+
+Generelt sett er det anbefalt å måle lengde for barn under 2 år og individer som ikke kan stå, og høyde for alle andre.
+
+Ved registrering av den første lengden til et spedbarn kort tid etter fødselen, \"fødselslengde '- bruk hendelsen \"Fødsel\".
+
+Brukes til å registrere vekst eller tap av høyde. Dette kan modelleres ved å begrense \"Uspesifisert hendelse\" til en tidsintervallhendelse i en templat, og legge til en matematisk funksjon for økning eller minking, ettersom hva som passer.">
+			keywords = <"høydetap", "høyde", "lengde", "vekst", "høydevekst", "lengdevekst", "kroppshøyde", "kroppslengde">
+			misuse = <"Brukes ikke til å registrere justert høyde eller lengde, det vil si en beregning av den fulle høyden av en person som for eksempel mangler hele eller deler av underekstremitetene eller har kontrakturer. En justert høyde/lengde kan være basert på målinger av andre kroppsdeler samt en algoritme. Bruk spesfikke arketyper laget for dette formålet.
+
+Brukes ikke til å registrere veksthastighet.
+
+Brukes ikke til å registrere lengden av et ikke-kroppslig objekt eller en bestemt del av kroppen.">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			purpose = <"Para registar o comprimento do corpo de um indivíduo, medindo da coroa da cabeça a sola do pé.
+A medida pode ser tanto real como aproximada, quer seja com a posição do indivíduo de pé ou em decúbito dorsal.">
+			use = <"Usada para gravar a altura real ou comprimento do corpo de um indivíduo a qualquer momento.
+A indicação da imperfeição física do corpo pode ser gravado no elemento 'protocolo fatores de confusão', se necessário.
+Este é o arquétipo de uso habitual para a medição típica de altura ou comprimento do corpo, independente da situação clínica. 
+Também pode ser usado para a gravação de uma altura aproximada ou de medição do comprimento do corpo em um cenário clínico no qual não é possível medir uma altura ou comprimento exato - por exemplo, a medição de uma criança que não coopera. Isso não é modelada explicitamente no arquétipo como o modelo de referência openEHR permite que o atributo de aproximação para qualquer tipo de dados quantitativos. Na execução, por exemplo, uma interface de usuário do aplicativo pode permitir que os clínicos para selecionar uma caixa de seleção devidamente setados junto ao campo de dados de altura para indicar que a altura registrada é uma aproximação, ao invés de reais. 
+Em geral, as medidas de comprimento são recomendados para crianças menores de dois anos de idade e indivíduos que não podem ficar, as medições de altura para todos os outros. 
+Idealmente, a altura é medida em pé sobre dois pés com peso distribuído uniformemente, os calcanhares unidos e as duas nádegas e calcanhares em contato com uma placa vertical para trás; comprimento do corpo é medido em uma posição totalmente estendida, supino com a pelve plana, pernas estendidas e os pés flexionados. 
+Use para registar um crescimento e perda de altura. Isso pode ser modelado por restringir a 'qualquer evento' a um intervalo em um modelo associado com a função matemática de aumentar ou diminuir, conforme o caso.">
+			keywords = <"encolhimento", "crescimento", "diminuição", "diminuição da altura", "altura", "comprimento", "crescimento">
+			misuse = <"Não deve ser utilizado para gravar o primeiro comprimento de um bebê, logo após o nascimento. Para isso é designado o \"comprimento de nascimento\" - use a especialização desse arquétipo - ver OBSERVATION.height-birth.
+Não deve ser utilizado para registrar a altura ajustada ou comprimento do corpo por exemplo, um cálculo da altura estimada completo de uma pessoa com contraturas dos membros, com base em medições outro corpo e / ou um algoritmo - use OBSERVATION.height-adjusted.
+Não deve ser usado para registrar a velocidade de crescimento.
+Não deve ser utilizado para gravar o tamanho de um objeto ou parte específica do corpo.">
+			copyright = <"© openEHR Foundation">
+		>
+		["ar-sy"] = <
+			language = <[ISO_639-1::ar-sy]>
+			purpose = <"لتسجيل طول الجسم من تاج الرأس إلى أخمص القدم للفرد - يشتمل على كل من القياس التقديري و الحقيقي, سواء أكان الفرد واقفا أو مستلقيا.">
+			use = <"يستخدم لتسجيل الارتفاع أو الطول الحقيقي لجسم الفرد عند أي نقطة من الزمن. و هو بيان لتعريف عدم الاكتمال الجسدي للجسم, و يمكن تسجيله في عنصر العوامل المربكة, إذا لزم. 
+هذا هو النموذج المعتاد ليستخدم في القياس النمطي لارتفاع أو طول الجسم, مستقلا عن الإطار السريري.
+
+يمكن استخدامه أيضا في تسجيل قياس تقريبي لارتفاع أو طول الجسم في سيناريو سريري لا يمكن فيه قياس الطول أو الارتفاع بشكل حقيقي – مثلا, قياس طفل غير متعاون. 
+
+و ليس هذا متمثلا بشكل صريح في هذا النموذج حيث إن النموذج المرجعي للـ open EHR  
+يسمح بوجود صفة التقريب لأي نوع بيانات كمي.
+
+و عند التنفيذ, مثلا, الشاشة الإلكترونية تسمح للأطباء السريريين أن يختاروا زرا بجوار قياس الطول ليشير إلى أنه قياس تقريبي, و ليس حقيقيا.
+و بشكل عام, فإن قياسات الطول يستحسن استخدامها للأطفال أقل من عامين و للأفراد الذين لا يستطيعون الوقوف, أما قياسات الارتفاع فيمكن استخدامها لباقي الحالات.
+
+و الوضع المثالي لقياس الارتفاع يكون بالوقوف على القدمين مع توزيع الوزن بشكل متساوٍ, و وضع الكعبين متجاورين, و كلا الأليتين متلامستين مع لوح ظهري عمودي, و يتم قياس طول الجسم في وضع مستلقٍٍ متمدد بشكل تام مع استواء الحوض, و الأرجل ممتدة و الأقدام مرتخية.
+
+يستخدم لقياس النمو و النقص في الطول. و يمكن حاليا وضعه في نموذج (إحدى الوقائع) بتقييده ليمثل فاصلا في إحدى القوالب مع دالة حسابية مصاحبة لحساب الزيادة أو النقص متى كان ذلك مناسبا.">
+			keywords = <"الانكماش", "الزيادة", "النقص", "فقد الارتفاع", "الطول", "الارتفاع", "النمو">
+			misuse = <"لا يستخدم لتسجيل أول قياس لطول المولود بعد الولادة بفترة قصيرة, و الذي يشار إليه بالطول عند الولادة - و استخدم بدلا من ذلك النموذج المخصص بعنوان ملاحظة. الطول عند الولادة.
+لا يستخدم لتسجيل الطول أو الارتفاع المُصَحَّح مثل الطول الكلي التقديري للفرد الذي يعاني من تقلصات الأطراف, بناء على قياسات أجزاء أخرى من الجسم و / أو لوغاريتم - استخدم بدلا من ذلك نموذج ملاحظة . الطول المصحح. 
+لا يستخدم لقياس سرعة النمو.
+لا يستخدم لتسجيل طول شيئ ما أو جزء معين من الجسم.">
+			copyright = <"© openEHR Foundation">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record the length of the body from crown of head to sole of foot of an individual - either measured or approximated, and either in a standing or recumbent position.">
+			use = <"To be used for recording the measured height or body length of an individual at any point in time.  A statement identifying the physical incompleteness of the body can be recorded in the 'Confounding factors' protocol element, if required.  This is the usual archetype to be used for a typical measurement of height or body length, independent of the clinical setting.
+
+Can also be used for recording an approximation of height or body length measurement in a clinical scenario where it is not possible to measure an accurate height or length - for example, measuring an uncooperative child.  This is not modelled explicitly in the archetype as the openEHR Reference model allows approximations  for any Quantity data type by setting the attribute Magnitude_status to the value '~'.  At implementation, for example, an application user interface could allow clinicians to select an appropriately labelled check box adjacent to the Height data field to indicate that the recorded height is an approximation, rather than actual.
+
+In general, length measurements are recommended for children under 2 years of age and individuals who cannot stand; height measurements for all others.
+
+When recording the first length of an infant shortly after birth, \"birth length\", use the event \"Birth\".
+
+Use to record growth or loss of height.  This can currently be modelled by constraining the 'any event' to an interval event within a template, with the associated mathematical function of increase or decrease, as appropriate.">
+			keywords = <"shrinkage", "increase", "decrease", "height loss", "height", "length", "growth">
+			misuse = <"Not to be used to record an adjusted height, a calculation of the full height of a person who for example are missing parts or all of the lower limbs, or has contractures. A calculated body weight may be based on measurements of other body parts and an algorithm. Use specific archetypes for this purpose.
+
+Not to be used to record growth velocity.
+
+Not to be used to record the length of an object or specific body part.">
+			copyright = <"© openEHR Foundation">
+		>
+		["fa"] = <
+			language = <[ISO_639-1::fa]>
+			purpose = <"برای ثبت طول بدن از نوک سر تا کف پای فرد- بطور واقعی و تقریبی و در حالتهای ایستاده یا خوابیده ">
+			use = <"برای ثبت قد یا طول واقعی یک فرد در هر نقطه از زمان بکار برده می شود.عبارتی  که نواقص فیزیکی بدن را مشخص می کند  می تواند درصورت نیاز در بخش پروتکل \" فاکتورهای جانبی \"ثبت شود. ازاین الگو ساز می توان در اندازه گیری های معمول قد یا طول بدن مستقل از وضع بالینی استفاده نمود. 
+از این الگو ساز همچنین می توان برای ثبت تقریبی اندازه گیری قد یا طول بدن در سناریوهای بالینی استفاده نمود که امکان اندازه گیری دقیق قد یا طول وجود ندارد، به عنوان مثال اندازه گیری قد یا طول کودکی که همکاری نمی کند. این مورد بطور واضح در الگوساز مدل بندی نشده است ولی مدل مرجع \"اوپن ئی اچ ار\" ویژگی تقریب را برای هر نوع داده کمی اجازه می دهد. در پیاده سازی، برای مثال، یک واسط کاربری نرم افزار می تواند به کاربران اجازه دهد تا با انتخاب گزینه ای [چک باکس] درکنار محل مربوط به قد و با نشانه گذاری مناسب نشان دهند که قد ثبت شده اندازه ای است تقریبی و نه  واقعی.
+بطور عمومی اندازه گیری طول بدن برای کودکان زبر 2 سال و بزرگسالانی که نمی توانند بایستند  و انداز گیری قد برای سایر افراد توصیه می شود.
+بطور ایده آل قد بصورت ایستاده بر هر دو پا، پاشنه ها کنار هم ، باسن و پاشنه ها در راستای خط عمودی پشت  با توزیع وزن مساوی اندازه گیری می شود، طول بدن در حالت کاملا کشیده و طاقباز با لگن صاف، ساق های کشیده و پاهای جمع شده از مچ اندازه گیری می شود.
+این الگوساز برای ثبت رشد و افت قد استفاده می شود. در حال حاضر با مشروط کردن \"هر رویداد\" به دوره زمانی در نظر گرفته شده در الگو با عملگرهای ریاضی مرتبط با افزایش یا کاهش بصورت مناسب مدل بندی می شود
+ 
+">
+			keywords = <"انقباض", "افزایش", "کاهش", "افت قد", "قد", "طول", "رشد">
+			misuse = <"برای ثبت اولین اندازه گیری نوزاد بلافاصله بعد ازتولد به عنوان \"طول نوزاد هنگام تولد\" استفاده نمی شود، در این موارد از حالت تخصصی الگوساز استفاده شود. ببینید
+OBSERVATION.height-birth
+برای ثبت قد یا طول بدن معادل (تطبیق یافته)، مانند محاسبه تخمینی کل قد یک فرد با اندام منقبض، بر اساس اندازه گیری های بخشهایی از بدن و یا یک الگوریتم دیگر استفاده نشود. در این موارد از 
+OBSERVATION.height-adjusted
+استفاده کنید.
+برای ثبت رشد قد استفاده نکنید
+برای ثبت طول یک شی یا بخشهایی از بدن استفاده نکنید
+">
+			copyright = <"© openEHR Foundation">
+		>
+		["zh-cn"] = <
+			language = <[ISO_639-1::zh-cn]>
+			purpose = <"旨在用于记录个人身体从头顶至脚底的长度，同时适合于实测值和近似值以及直立位或卧位（平卧位）。">
+			use = <"用于记录个人在任何时间点（时刻）的实际身高/身长。必要时，可在方案元素“干扰因素”（Confounding factors）之中记录表明身体残缺情况的陈述。这是适用于记录典型的身高/身长测量结果的常规原始型，与临床场合无关。
+亦可用于记录在不可能测量准确身高/身长的临床场景下关于身高/身长的近似值。例如，孩子不配合测量。当前原始型并未对这种情况加以明确建模，因为openEHR参考模型（Reference model）允许关于任何数量型（Quantity）数据类型的近似值（Approximation）属性。比如，在实施时，应用程序用户界面可以允许临床医生选择身高数据栏旁边带有合适标签的复选框，以便表示当前所记录的身高仅为近似值，而不是实测值。
+一般而言，对于不到2岁的儿童以及无法站立的患者，推荐进行身长测量，而对于其他受检对象，则进行身高测量。
+理想情况下，测量身高时，受检对象应采取直立位，即体重均匀分布于两脚，脚跟并拢且臀部和脚跟均与背后的垂直背板接触；测量身长时，受检对象应采取卧位（平卧位），即身体完全伸展的卧位（平卧位），且骨盆平展，双腿伸展，脚部屈曲。
+用于记录身高的增长或减低。当前，可以通过适当采用关联有关于增高或降低的数学函数的模板，将“任何事件”（any event）限制到特定的时间区间，从而对此加以建模。">
+			keywords = <"缩短", "变矮", "增加", "增长", "增高", "减低", "降低", "减短", "高度损失", "身高降低", "身高丢失", "身高", "身长", "高度", "个子", "生长", "成长">
+			misuse = <"并非旨在用于记录婴儿出生之后不久的首次身长测量结果；后者被称为“出生身长”（birth length）；对此，请采用当前原始型的特化形式 - 参见出生身高原始型OBSERVATION.height-birth。
+并非旨在用于记录经过调整的身高/身长；例如，利用其他身体部分测量结果和/或某种算法，来计算存在肢体挛缩的受检对象的完整身高的估计值；对此，请采用调整型身高原始型OBSERVATION.height-adjusted。
+并非旨在用于记录身高增长速度或者说生长速度。
+并非旨在用于记录某种物体或特定身体组成部分的长度。">
+			copyright = <"© openEHR Foundation">
+		>
+		["nl"] = <
+			language = <[ISO_639-1::nl]>
+			purpose = <"Registreren van de lengte van het lichaam van hoofdkruin tot voetzool van een individu - zowel werkelijke als geschatte lengte en zowel in staande als liggende positie.">
+			use = <"Te gebruiken voor de registratie van de werkelijke lengte/hoogte van een individu op elk moment in de tijd. Een verklaring over fysieke onvolledigheid van het lichaam kan worden opgenomen in het protocol element ‘ beïnvloedende factoren’, indien nodig. Dit is het gebruikelijke archetype voor een typische meting van de hoogte of lengte, onafhankelijk van de klinische setting. 
+Kan ook worden gebruikt voor het opnemen van een schatting van de lengte/hoogte meting in een klinisch scenario, waarin het niet mogelijk is om een nauwkeurige lengte te meten - bijvoorbeeld het meten van een onwillig kind. 
+Dit is niet expliciet gemodelleerd in het archetype, omdat het openEHR Referentie model een schatting in ieder kwantitatief data type toestaat. Bij de uitvoering, bijvoorbeeld, zou een applicatie gebruikersinterface, een adequaat geëtiketteerd selectievakje kunnen aanbieden aan clinici, naast de gegevens over het gewicht, waarin door selecteren aangegeven kan worden dat het opgenomen gewicht een schatting is, in plaats van het werkelijke gewicht.
+
+In het engelse taaldomein wordt er verschil gemaakt tussen hoogte (height) en lengte (length), waarbij hoogte staande gemeten wordt en lengte liggend.
+In dat geval zijn lengte metingen aanbevolen voor kinderen onder de leeftijd van 2 jaar en personen die niet kunnen staan; hoogte metingen voor alle anderen. 
+Idealiter wordt de hoogte(NL: lengte) gemeten, staand op beide voeten met het gewicht gelijkmatig verdeeld, hielen tegen elkaar en beide billen en hakken in contact met een verticale achterkant; lichaamslengte wordt gemeten in een volledig uitgespreide rugligging met het bekken plat, benen gestrekt en voeten gebogen. 
+Wordt gebruikt voor het registreren van groei en verlies van lengte. Dit kan, in voorkomend geval, momenteel worden gemodelleerd, door het beperken van een 'any event', tot een interval in een template met bijbehorende rekenkundige functie van de groei of krimp.">
+			keywords = <"krimp", "groeien", "verlies", "lengte", "hoogte">
+			misuse = <"Niet te gebruiken ter registratie van de eerste lengte van een kind, spoedig na de geboorte, welke gekenmerkd wordt als de geboortelengte - gebruik hiervoor de specialisatie van dit archetype - zie OBSERVATION.height-birth.(OBSERVATION.lengte-geboorte).">
+			copyright = <"© openEHR Foundation">
+		>
+	>
+	lifecycle_state = <"published">
+	other_contributors = <"Silje Ljosland Bakke, Nasjonal IKT HF, Norway (openEHR Editor)", "Marja Buur, Medisch Centrum Alkmaar/ Code24, Netherlands", "Rong Chen, Cambio Healthcare Systems, Sweden", "Hans Demski, Helmholtz Zentrum München, Germany", "Paul Donaldson, Nursing Informatics Australia, Australia", "Sebastian Garde, Ocean Informatics, Germany", "Anneke Goossen, Results 4 Care, Netherlands", "Heather Grain, Llewelyn Grain Informatics, Australia", "Anne Harbison, Australia", "Sam Heard, Ocean Informatics, Australia", "Omer Hotomaroglu, Turkey", "Sundaresan Jagannathan, Scottish NHS, United Kingdom", "Andrew James, University of Toronto, Canada", "Heather Leslie, Atomica Informatics, Australia (openEHR Editor)", "Rikard Lovstrom, Swedish Medical Association, Sweden", "Ian McNicoll, freshEHR Clinical Informatics, United Kingdom (openEHR Editor)", "Jeroen Meintjen, Medisch Centrum Alkmaar, Netherlands", "Thilo Schuler, Germany", "Soon Ghee Yap, Singapore General Hospital, Singapore">
+	other_details = <
+		["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.">
+		["custodian_organisation"] = <"openEHR Foundation">
+		["references"] = <"Wilks Z, Bryan S, Mead V and Davies EH. Clinical guideline: Height, measuring a child [Internet]. London, United Kingdom: UCL Institute of Child Health; 2008 Apr 01 [cited 2009 Jul 28 ]. Available from: https://www.gosh.nhs.uk/health-professionals/clinical-guidelines/height-measuring-childyoung-person">
+		["current_contact"] = <"Heather Leslie, Atomica Informatics<heather.leslie@atomicainformatics.com>">
+		["original_namespace"] = <"org.openehr">
+		["original_publisher"] = <"openEHR Foundation">
+		["custodian_namespace"] = <"org.openehr">
+		["MD5-CAM-1.0.1"] = <"4EEDD6F370F6564F436D1933ED78638A">
+		["build_uid"] = <"3ea09983-ed68-49d5-943d-abc75bb901e2">
+		["revision"] = <"2.0.4">
+	>
+
+definition
+	OBSERVATION[at0000] matches {    -- Height/Length
+		data matches {
+			HISTORY[at0001] matches {    -- history
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..*} matches {    -- Any event
+						data matches {
+							ITEM_TREE[at0003] matches {    -- Simple
+								items cardinality matches {1..*; unordered} matches {
+									ELEMENT[at0004] matches {    -- Height/Length
+										value matches {
+											C_DV_QUANTITY <
+												property = <[openehr::122]>
+												list = <
+													["1"] = <
+														units = <"cm">
+														magnitude = <|0.0..1000.0|>
+													>
+													["2"] = <
+														units = <"[in_i]">
+														magnitude = <|0.0..250.0|>
+													>
+												>
+											>
+										}
+									}
+									ELEMENT[at0018] occurrences matches {0..1} matches {    -- Comment
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+								}
+							}
+						}
+						state matches {
+							ITEM_TREE[at0013] matches {    -- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0014] occurrences matches {0..1} matches {    -- Position
+										value matches {
+											DV_CODED_TEXT matches {
+												defining_code matches {
+													[local::
+													at0016,    -- Standing
+													at0020;    -- Lying
+													at0016]
+												}
+											}
+										}
+									}
+									ELEMENT[at0019] occurrences matches {0..1} matches {    -- Confounding factors
+										value matches {
+											DV_TEXT matches {*}
+										}
+									}
+								}
+							}
+						}
+					}
+					POINT_EVENT[at0021] occurrences matches {0..1} matches {    -- Birth
+						data matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/data[at0003]
+						}
+						state matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/state[at0013]
+						}
+					}
+				}
+			}
+		}
+		protocol matches {
+			ITEM_TREE[at0007] matches {    -- List
+				items cardinality matches {0..*; ordered} matches {
+					allow_archetype CLUSTER[at0011] occurrences matches {0..1} matches {    -- Device
+						include
+							archetype_id/value matches {/openEHR-EHR-CLUSTER\.device(-[a-zA-Z0-9_]+)*\.v1/}
+					}
+					allow_archetype CLUSTER[at0022] occurrences matches {0..*} matches {    -- Extension
+						include
+							archetype_id/value matches {/.*/}
+					}
+				}
+			}
+		}
+	}
+
+
+ontology
+	term_definitions = <
+		["nl"] = <
+			items = <
+				["at0000"] = <
+					text = <"Lengte">
+					description = <"De lichaamslengte wordt gemeten vanaf de kruin van het hoofd tot en met de voetzool. In het engelse taaldomein wordt er verschil gemaakt tussen hoogte (height) en lengte (length), waarbij hoogte staande gemeten wordt en lengte liggend.">
+				>
+				["at0001"] = <
+					text = <"history">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"Simple">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Lengte">
+					description = <"De lichaamslengte vanaf de kruin van het hoofd tot en met de voetzool.">
+				>
+				["at0007"] = <
+					text = <"List">
+					description = <"@ internal @">
+				>
+				["at0011"] = <
+					text = <"Apparaat">
+					description = <"Beschrijving van het bij de meting gebruikte apparaat.">
+				>
+				["at0013"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0014"] = <
+					text = <"Positie">
+					description = <"Positie tijdens de meting, van de gemeten persoon.">
+				>
+				["at0016"] = <
+					text = <"Staand">
+					description = <"De lengte is gemeten, staand op beide voeten met het gewicht gelijkmatig verdeeld, hielen tegen elkaar en beide billen en hakken in contact met een verticale achterkant.">
+				>
+				["at0018"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the measurement, not captured in other fields.(en)">
+				>
+				["at0019"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Narrative description of any issues or factors that may impact on the measurement. (en)">
+					comment = <"*For example: noting of amputation.(en)">
+				>
+				["at0020"] = <
+					text = <"Liggend">
+					description = <"De lengte is liggend gemeten, volledig uitgestrekt, plat bekken, benen gestrekt en voeten gebogen.">
+				>
+				["at0021"] = <
+					text = <"*Birth(en)">
+					description = <"*Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.(en)">
+				>
+				["at0022"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Height/Length">
+					description = <"Height, or body length, is measured from crown of head to sole of foot.">
+					comment = <"Height is measured with the individual in a standing position and body length in a recumbent position.">
+				>
+				["at0001"] = <
+					text = <"history">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any event">
+					description = <"Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.">
+				>
+				["at0003"] = <
+					text = <"Simple">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Height/Length">
+					description = <"The length of the body from crown of head to sole of foot.">
+				>
+				["at0007"] = <
+					text = <"List">
+					description = <"@ internal @">
+				>
+				["at0011"] = <
+					text = <"Device">
+					description = <"Description of the device used to measure height or body length.">
+				>
+				["at0013"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0014"] = <
+					text = <"Position">
+					description = <"Position of individual when measured.">
+				>
+				["at0016"] = <
+					text = <"Standing">
+					description = <"Height is measured standing on both feet with weight distributed evenly, heels together and both buttocks and heels in contact with a vertical back board.">
+				>
+				["at0018"] = <
+					text = <"Comment">
+					description = <"Additional narrative about the measurement, not captured in other fields.">
+				>
+				["at0019"] = <
+					text = <"Confounding factors">
+					description = <"Narrative description of any issues or factors that may impact on the measurement.">
+					comment = <"For example: noting of amputation.">
+				>
+				["at0020"] = <
+					text = <"Lying">
+					description = <"Length is measured in a fully extended, recumbent position with the pelvis flat, legs extended and feet flexed.">
+				>
+				["at0021"] = <
+					text = <"Birth">
+					description = <"Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.">
+				>
+				["at0022"] = <
+					text = <"Extension">
+					description = <"Additional information required to capture local content or to align with other reference models/formalisms.">
+					comment = <"For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.">
+				>
+			>
+		>
+		["de"] = <
+			items = <
+				["at0000"] = <
+					text = <"Größe/Länge">
+					description = <"Größe bzw. Körperlänge wird vom Scheitel bis zur Fußsohle gemessen. Größe wird in einer stehenden Position gemessen, Körperlänge in einer liegenden Position.">
+				>
+				["at0001"] = <
+					text = <"History">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"Simple">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Größe/Länge">
+					description = <"Die Länge des Körpers von Scheitel bis Sohle.">
+				>
+				["at0007"] = <
+					text = <"List">
+					description = <"@ internal @">
+				>
+				["at0011"] = <
+					text = <"Gerät">
+					description = <"Beschreibung des Geräts, das zur Messung der Größe oder Länge verwendet wurde.">
+				>
+				["at0013"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0014"] = <
+					text = <"Position">
+					description = <"Position des Individiums bei der Messung.">
+				>
+				["at0016"] = <
+					text = <"Stehend">
+					description = <"Größe wird stehend auf beiden Füßen gemessen, mit dem Gewicht gleichmäßig verteilt, den Hacken zusammen und beiden Gesäßbacken und Hacken in Kontakt mit einem senkrechten Brett.">
+				>
+				["at0018"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the measurement, not captured in other fields.(en)">
+				>
+				["at0019"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Narrative description of any issues or factors that may impact on the measurement. (en)">
+					comment = <"*For example: noting of amputation.(en)">
+				>
+				["at0020"] = <
+					text = <"Liegend">
+					description = <"Länge wird in einer voll ausgestreckten, liegenden Position gemessen. Hierbei wird das Becken flach gehalten, die Beine ausgestreckt und die Füße gebeugt.">
+				>
+				["at0021"] = <
+					text = <"*Birth(en)">
+					description = <"*Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.(en)">
+				>
+				["at0022"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["pt-br"] = <
+			items = <
+				["at0000"] = <
+					text = <"Altura / comprimento">
+					description = <"Altura ou comprimento do corpo, é medida a partir da coroa da cabeça a sola do pé.
+A altura é medida com o indivíduo na posição de pé e comprimento do corpo na posição decúbito dorsal.">
+					comment = <"A altura é medida com o indivíduo em uma posição em pé e o comprimento do corpo em uma posição reclinada.">
+				>
+				["at0001"] = <
+					text = <"history">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Qualquer evento">
+					description = <"Padrão, ponto não específico no tempo ou intrvalo que pode ser definido em um modelo ou em tempo de execução.">
+				>
+				["at0003"] = <
+					text = <"Simple">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Altura / comprimento">
+					description = <"O comprimento do corpo da coroa da cabeça a sola do pé.">
+				>
+				["at0007"] = <
+					text = <"List">
+					description = <"@ internal @">
+				>
+				["at0011"] = <
+					text = <"Dispositivo">
+					description = <"Descrição do dispositivo utilizado para medir altura ou comprimento do corpo.">
+				>
+				["at0013"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0014"] = <
+					text = <"Posição">
+					description = <"Posição individual quando medido.">
+				>
+				["at0016"] = <
+					text = <"De pé">
+					description = <"A altura é medida de pé sobre os dois pés com o peso distribuído uniformemente, calcanhares juntos e as nádegas e os calcanhares em contato com uma placa traseira vertical.">
+				>
+				["at0018"] = <
+					text = <"Comentário">
+					description = <"Narrativa adicional sobre a medida, não capturada em outros campos.">
+				>
+				["at0019"] = <
+					text = <"Fatores de confundimento">
+					description = <"Descrição narrativa de quaisquer problemas ou fatores que podem impactar a medição.">
+					comment = <"Por exemplo: observação de amputação.">
+				>
+				["at0020"] = <
+					text = <"Decúbito dorsal">
+					description = <"O comprimento é medido em uma posição totalmente estendida, deitada com a pelve plana, pernas estendidas e os pés flexionados.">
+				>
+				["at0021"] = <
+					text = <"Nascimento">
+					description = <"Normalmente a primeira medição de comprimento, registrada logo após o nascimento. Este evento será usado somente uma vez por registro.">
+				>
+				["at0022"] = <
+					text = <"Extensão">
+					description = <"Informação adicional requerida para capturar conteúdo local ou alinhar a outros modelos de referência/formalismos.">
+					comment = <"Por exemplo: requisitos de informações locais ou metadados adicionais para alinhar com equivalentes FHIR ou CIMI.">
+				>
+			>
+		>
+		["fa"] = <
+			items = <
+				["at0000"] = <
+					text = <"قد و یا طول">
+					description = <"قد یا طول بدن از نوک سر تا کف پا اندازه گیری می شود.بلندی در حالت ایستاده و طول بدن فرد در حالت خوابیده اندازه گیری می شود ">
+				>
+				["at0001"] = <
+					text = <"*history(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"*Simple(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"قد و یا طول">
+					description = <"طول فرد از نوک سر تا کف پا ">
+				>
+				["at0007"] = <
+					text = <"*List(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0011"] = <
+					text = <"تجهیز">
+					description = <"توصیف تجهیز استفاده شده برای اندازه گیری قد یا طول فرد">
+				>
+				["at0013"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0014"] = <
+					text = <"موقعیت">
+					description = <"وضعیت فرد در حال اندازه گیری">
+				>
+				["at0016"] = <
+					text = <"ایستاده">
+					description = <"قد بصورت ایستاده بر هر دو پا، پاشنه  ها کنار هم ، باسن و پاشنه ها در راستای خط عمودی پشت  با توزیع وزن مساوی اندازه گیری می شود">
+				>
+				["at0018"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the measurement, not captured in other fields.(en)">
+				>
+				["at0019"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Narrative description of any issues or factors that may impact on the measurement. (en)">
+					comment = <"*For example: noting of amputation.(en)">
+				>
+				["at0020"] = <
+					text = <"خوابیده">
+					description = <"  طول در حالت کاملا کشیده و طاقباز با لگن صاف، ساق های کشیده و پاهای جمع شده از مچ پا اندازه گیری می شود">
+				>
+				["at0021"] = <
+					text = <"*Birth(en)">
+					description = <"*Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.(en)">
+				>
+				["at0022"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["ar-sy"] = <
+			items = <
+				["at0000"] = <
+					text = <"الارتفاع / الطول">
+					description = <"الارتفاع أو طول الجسم, يتم قياسه من تاج الرأس إلى أخمص القدم. يتم قياس الارتفاع عندما يكون الفرد واقفا, و طول الجسم عندما يكون الفرد مستلقيا.">
+				>
+				["at0001"] = <
+					text = <"*history(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"*Simple(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"الارتفاع / الطول">
+					description = <"طول الجسم من تاج الرأس إلى أخمص القدم.">
+				>
+				["at0007"] = <
+					text = <"*List(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0011"] = <
+					text = <"الجهيزة">
+					description = <"وصف الجهيزة المستخدمة لقياس طول أو ارتفاع الجسم.">
+				>
+				["at0013"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0014"] = <
+					text = <"الوضع">
+					description = <"وضع الشخص عند القياس.">
+				>
+				["at0016"] = <
+					text = <"واقف">
+					description = <"يتم قياس الارتفاع و الفرد في وضع الوقوف على القدمين مع توزيع الوزن بشكل متساوٍ, و وضع الكعبين متجاورين, و كلا الأليتين متلامستين مع لوح ظهري عمودي.">
+				>
+				["at0018"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the measurement, not captured in other fields.(en)">
+				>
+				["at0019"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Narrative description of any issues or factors that may impact on the measurement. (en)">
+					comment = <"*For example: noting of amputation.(en)">
+				>
+				["at0020"] = <
+					text = <"مستلقٍ">
+					description = <"يتم قياس الطول في وضع مستلقٍ متمدد بشكل تام مع استواء الحوض, و الأرجل ممتدة و الأقدام مرتخية.">
+				>
+				["at0021"] = <
+					text = <"*Birth(en)">
+					description = <"*Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.(en)">
+				>
+				["at0022"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["es-ar"] = <
+			items = <
+				["at0000"] = <
+					text = <"Altura/Longitud corporal">
+					description = <"La altura o longitud corporal es medida desde la coronilla de la cabeza hasta la planta de los pies. La altura es medida con el individuo en posición erguida y la longitud corporal, en posición recostada.">
+				>
+				["at0001"] = <
+					text = <"*history(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"*Simple(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"Altura/Longitud corporal">
+					description = <"La longitud corporal desde la coronilla de la cabeza hasta la planta de los pies.">
+				>
+				["at0007"] = <
+					text = <"*List(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0011"] = <
+					text = <"Instrumento">
+					description = <"Descripción del dispositivo usado para medir la altura o la longitud corporal.">
+				>
+				["at0013"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0014"] = <
+					text = <"Posición">
+					description = <"Posición del individuo durante la medición de estatura.">
+				>
+				["at0016"] = <
+					text = <"De pie">
+					description = <"La altura se mide de pie, sobre ambos pies con el peso distribuido en forma homogénea, con los talones juntos y ambos glúteos y talones en contacto con una placa posterior vertical o pared.">
+				>
+				["at0018"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the measurement, not captured in other fields.(en)">
+				>
+				["at0019"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Narrative description of any issues or factors that may impact on the measurement. (en)">
+					comment = <"*For example: noting of amputation.(en)">
+				>
+				["at0020"] = <
+					text = <"Acostado">
+					description = <"La longitud corporal es medida en una posición recostada y completamente extendida, con la pelvis plana, las piernas extendidas y los pies flexionados.">
+				>
+				["at0021"] = <
+					text = <"*Birth(en)">
+					description = <"*Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.(en)">
+				>
+				["at0022"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["ru"] = <
+			items = <
+				["at0000"] = <
+					text = <"Рост/длина тела">
+					description = <"Рост или длина тела. Измеряется от макушки до пяток, стоя, или в вытянутом положении.">
+				>
+				["at0001"] = <
+					text = <"*history(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"*Simple(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"Рост/длина тела">
+					description = <"Рост или длина тела. Измеряется от макушки до пяток, стоя, или в вытянутом положении.">
+				>
+				["at0007"] = <
+					text = <"*List(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0011"] = <
+					text = <"Устройство">
+					description = <"Описание устройства для измерения роста и длины тела.">
+				>
+				["at0013"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0014"] = <
+					text = <"Положение">
+					description = <"Положение человека при измерении">
+				>
+				["at0016"] = <
+					text = <"Стоя">
+					description = <"Рост измеряется стоя на двух ногах с равномерно распределённым весом, пятки вместе, обе ягодицы и пятки в прижаты к вертикальной поверхности.">
+				>
+				["at0018"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the measurement, not captured in other fields.(en)">
+				>
+				["at0019"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Narrative description of any issues or factors that may impact on the measurement. (en)">
+					comment = <"*For example: noting of amputation.(en)">
+				>
+				["at0020"] = <
+					text = <"Лёжа">
+					description = <"Длина тела измеряется в полностью вытянутом положении лежа, таз находится на плоскости, ноги вытянуты и ноги согнуты .">
+				>
+				["at0021"] = <
+					text = <"*Birth(en)">
+					description = <"*Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.(en)">
+				>
+				["at0022"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["zh-cn"] = <
+			items = <
+				["at0000"] = <
+					text = <"身高/身长">
+					description = <"从头顶至脚底（足底）所测得的身高（高度）/身长（长度）。身高测量采用直立位，而身长测量则采用的是卧位（平卧位）。">
+				>
+				["at0001"] = <
+					text = <"*history(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"*Any event(en)">
+					description = <"*Default, unspecified point in time or interval event which may be explicitly defined in a template or at run-time.(en)">
+				>
+				["at0003"] = <
+					text = <"*Simple(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"身高/身长">
+					description = <"从头顶至脚底（足底）的身体高度或长度。">
+				>
+				["at0007"] = <
+					text = <"*List(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0011"] = <
+					text = <"装置">
+					description = <"关于用来测量身高/身长的装置的描述。">
+				>
+				["at0013"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0014"] = <
+					text = <"体位">
+					description = <"测量身高/身长时受检对象的体位或者说身体姿势。">
+				>
+				["at0016"] = <
+					text = <"直立位">
+					description = <"测量身高时受检对象采取的姿势为：体重均匀分布于两脚，脚跟并拢且臀部和脚跟均与背后的垂直背板接触。">
+				>
+				["at0018"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the measurement, not captured in other fields.(en)">
+				>
+				["at0019"] = <
+					text = <"*Confounding factors(en)">
+					description = <"*Narrative description of any issues or factors that may impact on the measurement. (en)">
+					comment = <"*For example: noting of amputation.(en)">
+				>
+				["at0020"] = <
+					text = <"卧位">
+					description = <"测量身长时受检对象采取的姿势为：身体完全伸展的卧位（平卧位），且骨盆平展，双腿伸展，脚部屈曲。">
+				>
+				["at0021"] = <
+					text = <"*Birth(en)">
+					description = <"*Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.(en)">
+				>
+				["at0022"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local content or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["sv"] = <
+			items = <
+				["at0000"] = <
+					text = <"Kroppslängd">
+					description = <"Kroppslängd mäts från hjässa till fotsula.">
+					comment = <"Kroppslängd mäts med individen stående eller liggande.">
+				>
+				["at0001"] = <
+					text = <"history">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Händelse">
+					description = <"Händelse, där tiden anges explicit i en template eller genereras automatiskt av vissa IT-system.">
+				>
+				["at0003"] = <
+					text = <"Simple">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Kroppslängd">
+					description = <"Kroppslängd från hjässa till fotsula.">
+				>
+				["at0007"] = <
+					text = <"List">
+					description = <"@ internal @">
+				>
+				["at0011"] = <
+					text = <"Utrustning">
+					description = <"Beskrivning av den utrustning som används vid mätning av kroppslängd.">
+				>
+				["at0013"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0014"] = <
+					text = <"Kroppsställning">
+					description = <"Individens kroppsställning vid mätning.">
+				>
+				["at0016"] = <
+					text = <"Stående">
+					description = <"Kroppslängden mäts i stående ställning med jämn viktfördelning mellan fötterna, hälarna ihop, samt skinkor och hälar i kontakt med en vertikal yta.">
+				>
+				["at0018"] = <
+					text = <"Kommentar">
+					description = <"Kommentarer avseende mätningen av kroppslängden som inte beskrivs i övriga fält.">
+				>
+				["at0019"] = <
+					text = <"Möjliga felkällor och påverkande faktorer">
+					description = <"Beskrivning av faktorer och felkällor som kan påverka mätningen av kroppslängd.">
+					comment = <"Exempelvis notering om amputation.">
+				>
+				["at0020"] = <
+					text = <"Liggande">
+					description = <"Kroppslängden mäts i liggande helt utsträckt ställning med bäckenet platt, benen utsträckta och fötterna vinklade.">
+				>
+				["at0021"] = <
+					text = <"Födelse">
+					description = <"Vanligtvis den första mätningen av barnet strax efter födseln. Den här händelsen används endast en gång per patientjournal.">
+				>
+				["at0022"] = <
+					text = <"Tilläggsinformation">
+					description = <"Plats för att infoga tilläggsinformation som krävs för lokala anpassningar eller anpassning till andra referensmodeller eller formella krav.">
+					comment = <"Exempelvis lokala informationskrav eller metadata för anpassning till FHIR- eller CIMI-motsvarigheter.">
+				>
+			>
+		>
+		["fi"] = <
+			items = <
+				["at0000"] = <
+					text = <"Pituus">
+					description = <"Kehon pituus mitataan päälaesta jalkapohjaan.">
+					comment = <"Height is measured with the individual in a standing position and body length in a recumbent position.">
+				>
+				["at0001"] = <
+					text = <"history">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Mikä tahansa tapahtuma">
+					description = <"Oletusarvoinen, määrittämättömänä ajanhetkenä tai ajanjaksolla ilmenevä tapahtuma, joka voi olla määritetty tarkasti jossakin mallissa tai suorituksen aikana.">
+				>
+				["at0003"] = <
+					text = <"Simple">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Pituus">
+					description = <"Kehon pituus päälaesta jalkapohjaan.">
+				>
+				["at0007"] = <
+					text = <"List">
+					description = <"@ internal @">
+				>
+				["at0011"] = <
+					text = <"Laite">
+					description = <"Laite, jolla kehon pituus mitataan.">
+				>
+				["at0013"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0014"] = <
+					text = <"Asento">
+					description = <"Henkilön asento mitattaessa.">
+				>
+				["at0016"] = <
+					text = <"Seisten">
+					description = <"Pituus mitataan henkilön seistessä molemmilla jaloilla paino tasaisesti kummallakin jalalla, kantapäät samalla viivalla ja sekä pakarat että kantapäät kosketuksissa pystysuoraan taustaan henkilön takana.">
+				>
+				["at0018"] = <
+					text = <"Kommentti">
+					description = <"Mittauksen kertomusmuodossa olevat lisätiedot, joita ei voida ilmoittaa muissa kentissä.">
+				>
+				["at0019"] = <
+					text = <"Sekoittavat tekijät">
+					description = <"Kertomusmuodossa oleva kuvaus ongelmista tai tekijöistä, jotka saattavat vaikuttaa mittaukseen.">
+					comment = <"For example: noting of amputation.">
+				>
+				["at0020"] = <
+					text = <"Makuulla">
+					description = <"Pituus mitataan henkilön ollessa täysin ojentuneena makaavassa asennossa lantio kiinni alustassa, jalat ojentuneina ja jalkaterät taivutettuina.">
+				>
+				["at0021"] = <
+					text = <"Syntymä">
+					description = <"Usually the first length measurement, recorded soon after birth. This event will only be used once per health record
+.">
+				>
+				["at0022"] = <
+					text = <"Laajennus">
+					description = <"Lisätiedot, joita tarvitaan paikallisen sisällön kirjaamiseksi tai yhtenäistämiseksi muiden viitemallien tai formalismien kanssa.">
+					comment = <"For example: local information requirements or additional metadata to align with FHIR or CIMI equivalents.">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["at0000"] = <
+					text = <"Høyde/Lengde">
+					description = <"Individets høyde eller lengde målt fra isse til fotsåle.">
+					comment = <"Høyde måles stående og lengde liggende.">
+				>
+				["at0001"] = <
+					text = <"history">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Uspesifisert hendelse">
+					description = <"Standard, uspesifisert tidspunkt eller tidsintervall som kan defineres mer eksplisitt i et templat eller i en applikasjon.">
+				>
+				["at0003"] = <
+					text = <"Simple">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Høyde/lengde">
+					description = <"Høyde/lengde fra isse til fotsåle.">
+				>
+				["at0007"] = <
+					text = <"List">
+					description = <"@ internal @">
+				>
+				["at0011"] = <
+					text = <"Måleutstyr">
+					description = <"Beskrivelse av måleutstyret brukt til måling av høyde eller lengde.">
+				>
+				["at0013"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0014"] = <
+					text = <"Kroppsstilling">
+					description = <"Individets kroppsstilling på måletidspunktet.">
+				>
+				["at0016"] = <
+					text = <"Stående">
+					description = <"Høyde måles optimalt uten sko, uten sokker (for å se fotstillingen skikkelig), rumpen inntil veggen, skuldrene inntil veggen, hodet i Frankfurt stilling (nedre orbitalkant horisontalt med ytre øregang). En skal si til vedkommende \"stå rett\", men ikke skyve opp hodet.">
+				>
+				["at0018"] = <
+					text = <"Kommentar">
+					description = <"Ytterligere beskrivelse av målingen av høyde/lengde som ikke dekkes i andre felt.">
+				>
+				["at0019"] = <
+					text = <"Konfunderende faktorer">
+					description = <"Registrering av faktorer som kan ha innflytelse på måling av kroppslengden.">
+					comment = <"For eksempel: Notat om amputasjon, lue, håroppsett, klemmer eller lignende.">
+				>
+				["at0020"] = <
+					text = <"Liggende">
+					description = <"Lengde måles i en helt utstrakt, liggende posisjon med bekkenet flatt, beina strekte og føtter verken flektert eller ekstendert.">
+				>
+				["at0021"] = <
+					text = <"Fødsel">
+					description = <"Den første lengden målt etter fødselen. Denne hendelsen skal kun benyttes én gang per journal.">
+				>
+				["at0022"] = <
+					text = <"Tilleggsinformasjon">
+					description = <"Ytterligere informasjon som trengs for å kunne registrere lokalt definert innhold eller for å tilpasse til andre referansemodeller/formalismer.">
+					comment = <"For eksempel lokale informasjonsbehov eller ytterligere metadata for å kunne tilpasse til tilsvarende konsepter i FHIR eller CIMI.">
+				>
+			>
+		>
+	>


### PR DESCRIPTION
Assumed values were sometimes double converted in the ADL1.4 -> ADL2 conversion, resulting in invalid archetypes. This PR removes one of those conversions and adds a test.