### PR TITLE
Fix validation of templates with invalid template overlays

### DIFF
--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
@@ -156,6 +156,7 @@ public class ArchetypeValidator {
                     messages.add(message);
                     result.setErrors(messages);
                     result.setSourceArchetype(archetype);
+                    repository.setValidationResult(result);
                     return result;
                 }
             }

--- a/tools/src/test/resources/adl2-tests/validity/templates/openEHR-EHR-COMPOSITION.base.adls
+++ b/tools/src/test/resources/adl2-tests/validity/templates/openEHR-EHR-COMPOSITION.base.adls
@@ -1,0 +1,33 @@
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-EHR-COMPOSITION.base.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Jelte Zeilstra">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Base for template">
+		>
+	>
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	lifecycle_state = <"unstable">
+
+definition
+	COMPOSITION[id1]
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Composition">
+				description = <"Composition">
+			>
+		>
+	>

--- a/tools/src/test/resources/adl2-tests/validity/templates/openEHR-EHR-COMPOSITION.t_invalid_overlay_parent.v1.0.0.adls
+++ b/tools/src/test/resources/adl2-tests/validity/templates/openEHR-EHR-COMPOSITION.t_invalid_overlay_parent.v1.0.0.adls
@@ -1,0 +1,64 @@
+template (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-EHR-COMPOSITION.t_invalid_overlay_parent.v1.0.0
+
+specialize
+    openEHR-EHR-COMPOSITION.base.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Jelte Zeilstra">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Test template with template overlay with invalid parent">
+		>
+	>
+	other_details = <
+		["regression"] = <"OVERLAY_VALIDATION_FAILED">
+	>
+	lifecycle_state = <"unstable">
+
+definition
+	COMPOSITION[id1.1] matches {
+		content matches {
+			use_archetype OBSERVATION[id0.2, openEHR-EHR-OBSERVATION.ovl-invalid_parent-001.v1.0.0]
+		}
+	}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1.1"] = <
+				text = <"Composition">
+				description = <"Composition">
+			>
+			["id0.2"] = <
+				text = <"Observation">
+				description = <"Observation">
+			>
+		>
+	>
+
+------------------------------------------------------------------------
+template_overlay
+    openEHR-EHR-OBSERVATION.ovl-invalid_parent-001.v1.0.0
+
+specialize
+    openEHR-EHR-OBSERVATION.non_existent_parent.v1.0.0
+
+definition
+    OBSERVATION[id1.1.1]
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1.1.1"] = <
+                text = <"Template overlay with invalid parent">
+                description = <"Template overlay with invalid parent">
+            >
+        >
+    >

--- a/tools/src/test/resources/adl2-tests/validity/templates/openEHR-EHR-OBSERVATION.non_existent_parent.adls
+++ b/tools/src/test/resources/adl2-tests/validity/templates/openEHR-EHR-OBSERVATION.non_existent_parent.adls
@@ -1,0 +1,36 @@
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-EHR-OBSERVATION.non_existent_parent.v1.0.0
+
+specialize
+    openEHR-EHR-OBSERVATION.doesnt_exist.v1
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Jelte Zeilstra">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Observation with non-existent parent">
+		>
+	>
+	other_details = <
+		["regression"] = <"VASID">
+	>
+	lifecycle_state = <"unstable">
+
+definition
+	OBSERVATION[id1.1]
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1.1"] = <
+				text = <"Observation">
+				description = <"Observation">
+			>
+		>
+	>


### PR DESCRIPTION
Validation of templates with template overlays with missing parent archetypes threw [IllegalArgumentExceptions in the Flattener](https://github.com/openEHR/archie/blob/860715fa942479b8efeb7af1fb3ce6d925bea9a1/tools/src/main/java/com/nedap/archie/flattener/Flattener.java#L132) because

* ValidationResults with PARENT_VALIDATION_FAILED errors weren't added to the ArchetypeRepository.
* The validator tried to flatten the template even if the template overlays were invalid.

This PR fixes both issues.