### PR TITLE
Remove Java versions 9 and 10 which are not supported by Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,14 +12,6 @@ blocks:
           commands:
             - sem-version java 1.8
             - ./gradlew clean build
-        - name: Java 9 build
-          commands:
-            - sem-version java 9
-            - ./gradlew clean build
-        - name: Java 10 build
-          commands:
-            - sem-version java 10
-            - ./gradlew clean build
         - name: Java 11 build
           commands:
             - sem-version java 11


### PR DESCRIPTION
Semaphore CI doesn't support Java versions 9 and 10 and since today this makes the tests fail, see semaphoreci/toolbox#239. This PR removes the Java 9 and 10 jobs from the Semaphore CI configuration.