### PR TITLE
Fix validation with different RM Version in parent and child archetype

### DIFF
--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/ArchetypeValidator.java
@@ -129,6 +129,7 @@ public class ArchetypeValidator {
             for(TemplateOverlay overlay:((Template) archetype).getTemplateOverlays()) {
                 //validate the overlays first, but make sure to do that only once (so don't call this same method!)
                 getValidationResult(overlay.getArchetypeId().toString(), extraRepository);
+                combinedModels.selectModel(archetype);
             }
         }
 
@@ -143,6 +144,7 @@ public class ArchetypeValidator {
         Archetype flatParent = null;
         if(archetype.isSpecialized()) {
             ValidationResult parentValidationResult = getValidationResult(archetype.getParentArchetypeId(), repository);
+            combinedModels.selectModel(archetype);
             if(parentValidationResult != null) {
                 if(parentValidationResult.passes()) {
                     flatParent = parentValidationResult.getFlattened();

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -9,6 +9,7 @@ import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.ReferenceModels;
 import org.junit.Before;
 import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import java.io.IOException;
 import java.util.List;
@@ -196,6 +197,26 @@ public class ArchetypeValidatorTest {
             ValidationResult validationResult = new ArchetypeValidator(models).validate(incorrectChildArchetype, repository);
             assertOneError(validationResult, ErrorType.VARXS);
         }
+    }
+
+    @Test
+    public void parentWithDifferentRmRelease() throws IOException, ADLParseException {
+        //the parent has an older RM Release than the parent, and the child contains a couple of new features
+        //not available in the parent. One could say the parent needs to be upgraded to the new version
+        //however this has some actual use cases where the parent in the CKM still has the old version, and you want
+        //to use new features like DV_SCALE - as in this particular example. So this should just work.
+        Archetype parent = parse("/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.child.v0.0.1.adls");
+        Archetype child = parse("/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.parent.v1.1.0.adls");
+        InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
+        repository.addArchetype(parent);
+        repository.addArchetype(child);
+        ArchetypeValidator archetypeValidator = new ArchetypeValidator(BuiltinReferenceModels.getMetaModels());
+        ValidationResult validatedParent = archetypeValidator.validate(parent, repository);
+        ValidationResult validatedChild = archetypeValidator.validate(child, repository);
+
+
+        assertTrue(validatedChild.getErrors().toString(), validatedChild.passes());
+        assertTrue(validatedChild.getErrors().toString(), validatedParent.passes());
     }
 
 

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -205,18 +205,32 @@ public class ArchetypeValidatorTest {
         //not available in the parent. One could say the parent needs to be upgraded to the new version
         //however this has some actual use cases where the parent in the CKM still has the old version, and you want
         //to use new features like DV_SCALE - as in this particular example. So this should just work.
-        Archetype parent = parse("/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.child.v0.0.1.adls");
-        Archetype child = parse("/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.parent.v1.1.0.adls");
-        InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
-        repository.addArchetype(parent);
-        repository.addArchetype(child);
-        ArchetypeValidator archetypeValidator = new ArchetypeValidator(BuiltinReferenceModels.getMetaModels());
-        ValidationResult validatedParent = archetypeValidator.validate(parent, repository);
-        ValidationResult validatedChild = archetypeValidator.validate(child, repository);
+        Archetype child = parse("/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.child.v0.0.1.adls");
+        Archetype parent = parse("/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.parent.v1.1.0.adls");
+        {
+            InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
+            repository.addArchetype(child);
+            repository.addArchetype(parent);
 
+            ArchetypeValidator archetypeValidator = new ArchetypeValidator(BuiltinReferenceModels.getMetaModels());
+            ValidationResult validatedChild = archetypeValidator.validate(child, repository);
+            ValidationResult validatedParent = archetypeValidator.validate(parent, repository);
 
-        assertTrue(validatedChild.getErrors().toString(), validatedChild.passes());
-        assertTrue(validatedChild.getErrors().toString(), validatedParent.passes());
+            assertTrue(validatedChild.getErrors().toString(), validatedChild.passes());
+            assertTrue(validatedParent.getErrors().toString(), validatedParent.passes());
+        }
+        {
+            InMemoryFullArchetypeRepository repository = new InMemoryFullArchetypeRepository();
+            repository.addArchetype(child);
+            repository.addArchetype(parent);
+            
+            ArchetypeValidator archetypeValidator = new ArchetypeValidator(BuiltinReferenceModels.getMetaModels());
+            ValidationResult validatedParent = archetypeValidator.validate(parent, repository);
+            ValidationResult validatedChild = archetypeValidator.validate(child, repository);
+
+            assertTrue(validatedChild.getErrors().toString(), validatedChild.passes());
+            assertTrue(validatedParent.getErrors().toString(), validatedParent.passes());
+        }
     }
 
 

--- a/tools/src/test/resources/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.child.v0.0.1.adls
+++ b/tools/src/test/resources/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.child.v0.0.1.adls
@@ -1,0 +1,42 @@
+archetype (adl_version=2.0.6; rm_release=1.1.0)
+    openEHR-EHR-CLUSTER.child.v0.0.1
+
+specialize
+    openEHR-EHR-CLUSTER.parent.v1
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Jelte Zeilstra">
+    >
+
+definition
+    CLUSTER[id1.1] matches {    -- Cluster
+        items cardinality matches {1..*; unordered} matches {
+            ELEMENT[id2] matches {    -- Element
+                value matches {
+                    DV_SCALE[id0.9001] matches {
+                        [value, symbol] matches {
+                            [{1.0}, {[at0.2]}]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1.1"] = <
+                text = <"Cluster">
+                description = <"Cluster">
+            >
+            ["at0.2"] = <
+                text = <"A symbol">
+                description = <"A symbol">
+            >
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.parent.v1.1.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/archetypevalidator/rm_version/openEHR-EHR-CLUSTER.parent.v1.1.0.adls
@@ -1,0 +1,31 @@
+archetype (adl_version=2.0.6; rm_release=1.0.4)
+    openEHR-EHR-CLUSTER.parent.v1.1.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Jelte Zeilstra">
+    >
+
+definition
+    CLUSTER[id1] matches {
+        items matches {
+            ELEMENT[id2]
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"Cluster">
+                description = <"Cluster">
+            >
+            ["id2"] = <
+                text = <"Element">
+                description = <"Element">
+            >
+        >
+    >


### PR DESCRIPTION
Fix the archetype validator for the case when a specialised archetype has a different RM version that its parent.