### PR TITLE
fix getFlatProperties behaviour for DV_INTERVAL

### DIFF
--- a/referencemodels/src/test/java/org/openehr/referencemodels/BuiltInReferenceModelsTest.java
+++ b/referencemodels/src/test/java/org/openehr/referencemodels/BuiltInReferenceModelsTest.java
@@ -5,7 +5,9 @@ import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeHRID;
 import com.nedap.archie.rminfo.MetaModels;
 import org.junit.Test;
+import org.openehr.bmm.core.BmmClass;
 import org.openehr.bmm.core.BmmModel;
+import org.openehr.bmm.core.BmmProperty;
 import org.openehr.bmm.v2.validation.BmmRepository;
 import org.openehr.bmm.v2.validation.BmmValidationResult;
 
@@ -29,6 +31,18 @@ public class BuiltInReferenceModelsTest {
         assertEquals(33, bmmRepository.getModels().size());
         assertEquals(31, bmmRepository.getValidModels().size());
         assertEquals(2, bmmRepository.getInvalidModels().size());
+    }
+
+    @Test
+    public void providesFlatPropertiesOfDvInterval(){
+        BmmModel model = BuiltinReferenceModels.getBmmRepository().getModel("openehr_rm_1.0.2").getModel();
+        BmmClass dvInterval = model.getClassDefinition("DV_INTERVAL");
+
+        BmmProperty<?> upper = dvInterval.getFlatProperties().get("upper");
+        assertEquals("DV_ORDERED", upper.getType().getEffectiveType().typeBaseName());
+
+        BmmProperty<?> lower = dvInterval.getFlatProperties().get("lower");
+        assertEquals("DV_ORDERED", lower.getType().getEffectiveType().typeBaseName());
     }
 
     @Test


### PR DESCRIPTION
[DV_INTERVAL](https://specifications.openehr.org/releases/RM/Release-1.1.0/data_types.html#_dv_interval_class) has the property of having a type parameter T constrained to DV_ORDERED, which is what it uses to provide the type parameter T of its parent type Interval<T>. This type parameter in turn determines the types of `lower` and `upper ` fields of [Interval](https://specifications.openehr.org/releases/BASE/latest/foundation_types.html#_interval_class) Interval's default type constraint is Ordered.

Currently, BMM has no semantics of telling how a type parameter is used, so it is up to implementers to make sure that BMM representation of DV_INTERVAL behaves correctly. This pull request changes the behaviour of `getFlatProperties` method so that when called on DV_INTERVAL, the properties upper and lower have the correct DV_ORDERED type, instead of the more general Ordered type. I had to write the test for this fix in the reference models module, due to requirement of using a repository instance to query properties. I could write a test that creates a specific context where only the minimum subset of BMM model that's required to test this behaviour is available, but I took the easy way out and cheated by writing an integration test where a unit test would be appropriate :) 

The solution itself is hacky, but this is a specific case for a specific type, and unless it proves to be prevalent all over the BMM, I'd follow this 'pragmatic' approach.