### PR TITLE
Added @XmlRootElement annotation to Section

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Section.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Section.java
@@ -12,6 +12,7 @@ import com.nedap.archie.rmutil.InvariantUtil;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.Objects;
 /**
  * Created by pieter.bos on 04/11/15.
  */
+@XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SECTION", propOrder = {
         "items"


### PR DESCRIPTION
As mentioned in https://nedap-healthcare.slack.com/archives/C011NLRNSRJ/p1626249569149300, the `@XmlRootElement`  should be added to a `Section`. This was tested locally for the case that was mentioned and no longer gave the error. I'm not sure how to test this.. So if needed, suggestions are welcome.