### PR TITLE
Fix xml namespace

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/LanguageSection.java
+++ b/aom/src/main/java/com/nedap/archie/aom/LanguageSection.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nedap.archie.base.OpenEHRBase;
 import com.nedap.archie.base.terminology.TerminologyCode;
 
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/aom/src/main/java/com/nedap/archie/aom/OperationalTemplate.java
+++ b/aom/src/main/java/com/nedap/archie/aom/OperationalTemplate.java
@@ -1,16 +1,26 @@
 package com.nedap.archie.aom;
 
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.aom.utils.AOMUtils;
 import com.nedap.archie.paths.PathSegment;
+import com.nedap.archie.xml.adapters.ArchetypeTerminologyAdapter;
+import com.nedap.archie.xml.adapters.StringDictionaryUtil;
+import com.nedap.archie.xml.types.StringDictionaryItem;
+import com.nedap.archie.xml.types.XmlArchetypeTerminology;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,10 +36,71 @@ public class OperationalTemplate extends AuthoredArchetype {
     /**
      * terminology extracts from subarchetypes, for example snomed codes, multiple choice thingies, etc
      */
-    @XmlElement(name="terminology_extracts") //TODO: requires an adapter for JAXB to work
+    @XmlTransient
     private Map<String, ArchetypeTerminology> terminologyExtracts = new ConcurrentHashMap<>();//TODO: is this correct?
-    @XmlElement(name="component_terminologies") //TODO: requires an adapter for JAXB to work
+    @XmlTransient
     private Map<String, ArchetypeTerminology> componentTerminologies = new ConcurrentHashMap<>();
+
+    @XmlElement(name="terminology_extracts")
+    private List<XmlArchetypeTerminology> xmlTerminologyExtracts;
+    @XmlElement(name="component_terminologies")
+    private List<XmlArchetypeTerminology> xmlComponentTerminologies;
+
+    @Override
+    public void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+        super.afterUnmarshal(unmarshaller, parent);
+        if(xmlTerminologyExtracts != null) {
+            ArchetypeTerminologyAdapter archetypeTerminologyAdapter = new ArchetypeTerminologyAdapter();
+            for(XmlArchetypeTerminology terminology:xmlTerminologyExtracts) {
+                try {
+                    ArchetypeTerminology converted = archetypeTerminologyAdapter.unmarshal(terminology);
+                    terminologyExtracts.put(terminology.getArchetypeId(), converted);
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        if(xmlComponentTerminologies != null) {
+            ArchetypeTerminologyAdapter archetypeTerminologyAdapter = new ArchetypeTerminologyAdapter();
+            for(XmlArchetypeTerminology terminology:xmlComponentTerminologies) {
+                try {
+                    ArchetypeTerminology converted = archetypeTerminologyAdapter.unmarshal(terminology);
+                    componentTerminologies.put(terminology.getArchetypeId(), converted);
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    // Invoked by Marshaller after it has created an instance of this object.
+    @Override
+    public boolean beforeMarshal(Marshaller marshaller) {
+        super.beforeMarshal(marshaller);
+        if(terminologyExtracts != null && !terminologyExtracts.isEmpty()) {
+            ArchetypeTerminologyAdapter archetypeTerminologyAdapter = new ArchetypeTerminologyAdapter();
+            xmlTerminologyExtracts = new ArrayList<>();
+            for(Map.Entry<String, ArchetypeTerminology> terminology:terminologyExtracts.entrySet()) {
+                XmlArchetypeTerminology converted = archetypeTerminologyAdapter.marshal(terminology.getValue());
+                converted.setArchetypeId(terminology.getKey());
+                xmlTerminologyExtracts.add(converted);
+            }
+        } else {
+            xmlTerminologyExtracts = null;
+        }
+        if(componentTerminologies != null && !componentTerminologies.isEmpty()) {
+            ArchetypeTerminologyAdapter archetypeTerminologyAdapter = new ArchetypeTerminologyAdapter();
+            xmlComponentTerminologies = new ArrayList<>();
+            for(Map.Entry<String, ArchetypeTerminology> terminology:componentTerminologies.entrySet()) {
+                XmlArchetypeTerminology converted = archetypeTerminologyAdapter.marshal(terminology.getValue());
+                converted.setArchetypeId(terminology.getKey());
+                xmlComponentTerminologies.add(converted);
+            }
+        } else {
+            xmlComponentTerminologies = null;
+        }
+        return true;
+    }
 
 
     public Map<String, ArchetypeTerminology> getTerminologyExtracts() {

--- a/aom/src/main/java/com/nedap/archie/aom/package-info.java
+++ b/aom/src/main/java/com/nedap/archie/aom/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.aom;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/package-info.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.aom.primitives;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/aom/src/main/java/com/nedap/archie/aom/terminology/ArchetypeTerminology.java
+++ b/aom/src/main/java/com/nedap/archie/aom/terminology/ArchetypeTerminology.java
@@ -30,14 +30,11 @@ public class ArchetypeTerminology extends ArchetypeModelObject {
     private String originalLanguage;
     @XmlElement(name="concept_code")
     private String conceptCode;
-    @XmlTransient//TODO!
-    //@XmlElement(name="term_definitions")
+    @XmlTransient //converted to XmlArchetypeTerminology, so not used in jaxb
     private Map<String, Map<String, ArchetypeTerm>> termDefinitions = new ConcurrentHashMap<>();
-    //@XmlElement(name="term_bindings")
-    @XmlTransient//TODO!
+    @XmlTransient //converted to XmlArchetypeTerminology, so not used in jaxb
     private Map<String, Map<String, URI>> termBindings = new ConcurrentHashMap<>();
-    //@XmlElement(name="terminology_extracts")
-    @XmlTransient//TODO!
+    @XmlTransient //converted to XmlArchetypeTerminology, so not used in jaxb
     private Map<String, Map<String, ArchetypeTerm>> terminologyExtracts = new ConcurrentHashMap<>();
     @XmlElement(name="value_sets")
     private Map<String, ValueSet> valueSets = new ConcurrentHashMap<>();

--- a/aom/src/main/java/com/nedap/archie/aom/terminology/package-info.java
+++ b/aom/src/main/java/com/nedap/archie/aom/terminology/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.aom.terminology;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/aom/src/main/java/com/nedap/archie/rules/package-info.java
+++ b/aom/src/main/java/com/nedap/archie/rules/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rules;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/aom/src/main/java/com/nedap/archie/xml/adapters/ArchetypeTerminologyAdapter.java
+++ b/aom/src/main/java/com/nedap/archie/xml/adapters/ArchetypeTerminologyAdapter.java
@@ -10,6 +10,7 @@ import com.nedap.archie.xml.types.XmlArchetypeTerminology;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.Map;
 public class ArchetypeTerminologyAdapter extends XmlAdapter<XmlArchetypeTerminology, ArchetypeTerminology> {
 
     @Override
-    public XmlArchetypeTerminology marshal(ArchetypeTerminology terminology) throws Exception {
+    public XmlArchetypeTerminology marshal(ArchetypeTerminology terminology) {
         if(terminology == null) {
             return null;
         }
@@ -71,7 +72,7 @@ public class ArchetypeTerminologyAdapter extends XmlAdapter<XmlArchetypeTerminol
     }
 
     @Override
-    public ArchetypeTerminology unmarshal(XmlArchetypeTerminology xmlTerminology) throws Exception {
+    public ArchetypeTerminology unmarshal(XmlArchetypeTerminology xmlTerminology) throws URISyntaxException {
         if(xmlTerminology == null) {
             return null;
         }
@@ -97,7 +98,7 @@ public class ArchetypeTerminologyAdapter extends XmlAdapter<XmlArchetypeTerminol
         return result;
     }
 
-    private Map<String, Map<String, URI>> convertIntoTermBindingsMap(List<TermBindingSet> termBindings) throws Exception{
+    private Map<String, Map<String, URI>> convertIntoTermBindingsMap(List<TermBindingSet> termBindings) throws URISyntaxException {
         Map<String, Map<String, URI>> result = new LinkedHashMap<>();
         for(TermBindingSet set:termBindings) {
             Map<String, URI> termMap = StringDictionaryUtil.convertStringDictionaryListToUriMap(set.getItems());

--- a/aom/src/main/java/com/nedap/archie/xml/adapters/StringDictionaryMapAdapter.java
+++ b/aom/src/main/java/com/nedap/archie/xml/adapters/StringDictionaryMapAdapter.java
@@ -1,0 +1,21 @@
+package com.nedap.archie.xml.adapters;
+
+import com.nedap.archie.aom.TranslationDetails;
+import com.nedap.archie.xml.types.StringDictionaryItem;
+import com.nedap.archie.xml.types.XmlTranslationDetails;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+public class StringDictionaryMapAdapter extends XmlAdapter<ArrayList<StringDictionaryItem>, LinkedHashMap<String, String>> {
+    @Override
+    public LinkedHashMap<String, String> unmarshal(ArrayList<StringDictionaryItem> v) throws Exception {
+        return StringDictionaryUtil.convertStringDictionaryListToStringMap(v);
+    }
+
+    @Override
+    public ArrayList<StringDictionaryItem> marshal(LinkedHashMap<String, String> v) throws Exception {
+        return StringDictionaryUtil.convertStringMapIntoStringDictionaryList(v);
+    }
+}

--- a/aom/src/main/java/com/nedap/archie/xml/adapters/StringDictionaryUtil.java
+++ b/aom/src/main/java/com/nedap/archie/xml/adapters/StringDictionaryUtil.java
@@ -53,11 +53,11 @@ public class StringDictionaryUtil {
         return termMap;
     }
 
-    public static Map<String, String> convertStringDictionaryListToStringMap(List<StringDictionaryItem> items) {
+    public static LinkedHashMap<String, String> convertStringDictionaryListToStringMap(List<StringDictionaryItem> items) {
         if(items == null) {
             return null;
         }
-        Map<String, String> termMap = new LinkedHashMap<>();
+        LinkedHashMap<String, String> termMap = new LinkedHashMap<>();
         for(StringDictionaryItem term:items) {
             termMap.put(term.getId(),term.getValue());
         }

--- a/aom/src/main/java/com/nedap/archie/xml/types/XmlArchetypeTerminology.java
+++ b/aom/src/main/java/com/nedap/archie/xml/types/XmlArchetypeTerminology.java
@@ -18,6 +18,8 @@ import java.util.List;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XmlArchetypeTerminology {
 
+    @XmlAttribute(name="archetype_id")
+    private String archetypeId;
     @XmlAttribute(name="is_differential")
     private Boolean differential;
     @XmlAttribute(name="original_language")
@@ -33,6 +35,14 @@ public class XmlArchetypeTerminology {
     private List<CodeDefinitionSet> terminologyExtracts = new ArrayList<>();
     @XmlElement(name="value_sets")
     private List<ValueSet> valueSets = new ArrayList<>();
+
+    public String getArchetypeId() {
+        return archetypeId;
+    }
+
+    public void setArchetypeId(String archetypeId) {
+        this.archetypeId = archetypeId;
+    }
 
     public List<CodeDefinitionSet> getTermDefinitions() {
         return termDefinitions;

--- a/aom/src/main/java/com/nedap/archie/xml/types/XmlResourceDescription.java
+++ b/aom/src/main/java/com/nedap/archie/xml/types/XmlResourceDescription.java
@@ -42,7 +42,7 @@ public class XmlResourceDescription {
     private List<StringDictionaryItem> conversionDetails;
     @XmlElement(name = "other_details")
     private List<StringDictionaryItem> otherDetails;
-    @XmlElement(required = true, type = ResourceDescriptionItem.class)
+    @XmlElement(required = true, type = XmlResourceDescriptionItem.class)
     private List<XmlResourceDescriptionItem> details;
 
     public List<StringDictionaryItem> getOriginalAuthor() {

--- a/aom/src/main/java/com/nedap/archie/xml/types/package-info.java
+++ b/aom/src/main/java/com/nedap/archie/xml/types/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.xml.types;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/archie-utils/src/main/java/com/nedap/archie/xml/JAXBUtil.java
+++ b/archie-utils/src/main/java/com/nedap/archie/xml/JAXBUtil.java
@@ -39,6 +39,7 @@ public class JAXBUtil {
                 classes.addAll(ArchieRMInfoLookup.getInstance().getRmTypeNameToClassMap().values());
                 //extra classes from the adapters package that are not directly referenced.\
                 classes.add(XmlResourceDescriptionItem.class);
+                removeClasses(classes);
                 archieJaxbContext = JAXBContext.newInstance(classes.toArray(new Class[0]));
             } catch (JAXBException e) {
                 throw new RuntimeException(e);//programmer error, tests will fail
@@ -51,6 +52,7 @@ public class JAXBUtil {
             List<Class<?>> classes = Lists.newArrayList(ArchieAOMInfoLookup.getInstance().getRmTypeNameToClassMap().values());
             //extra classes from the adapters package that are not directly referenced.\
             classes.add(XmlResourceDescriptionItem.class);
+            removeClasses(classes);
             return JAXBContext.newInstance(classes.toArray(new Class[0]));
         } catch (JAXBException e) {
             throw new RuntimeException(e);//programmer error, tests will fail
@@ -64,6 +66,13 @@ public class JAXBUtil {
         } catch (JAXBException e) {
             throw new RuntimeException(e);//programmer error, tests will fail
         }
+    }
+
+    private static void removeClasses(List<Class<?>> classes) {
+        //remove classes that are adapted to other classes anyway, particularly those using maps
+        classes.remove(ResourceDescription.class);
+        classes.remove(ResourceDescriptionItem.class);
+        classes.remove(LanguageSection.class);
     }
 
 }

--- a/archie-utils/src/main/java/com/nedap/archie/xml/JAXBUtil.java
+++ b/archie-utils/src/main/java/com/nedap/archie/xml/JAXBUtil.java
@@ -1,6 +1,12 @@
 package com.nedap.archie.xml;
 
 import com.google.common.collect.Lists;
+import com.nedap.archie.aom.AuthoredResource;
+import com.nedap.archie.aom.LanguageSection;
+import com.nedap.archie.aom.ResourceDescription;
+import com.nedap.archie.aom.ResourceDescriptionItem;
+import com.nedap.archie.aom.TranslationDetails;
+import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.rminfo.ArchieAOMInfoLookup;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.xml.types.XmlResourceDescriptionItem;
@@ -62,6 +68,7 @@ public class JAXBUtil {
     public static synchronized JAXBContext createRMContext() {
         try {
             List<Class<?>> classes = Lists.newArrayList(ArchieRMInfoLookup.getInstance().getRmTypeNameToClassMap().values());
+            removeClasses(classes);
             return JAXBContext.newInstance(classes.toArray(new Class[0]));
         } catch (JAXBException e) {
             throw new RuntimeException(e);//programmer error, tests will fail
@@ -70,9 +77,19 @@ public class JAXBUtil {
 
     private static void removeClasses(List<Class<?>> classes) {
         //remove classes that are adapted to other classes anyway, particularly those using maps
-        classes.remove(ResourceDescription.class);
-        classes.remove(ResourceDescriptionItem.class);
-        classes.remove(LanguageSection.class);
+        removeAllInstances(classes, ResourceDescription.class);
+        removeAllInstances(classes, ResourceDescriptionItem.class);
+        removeAllInstances(classes, LanguageSection.class);
+        removeAllInstances(classes, ArchetypeTerminology.class);
+        removeAllInstances(classes, TranslationDetails.class);
+        removeAllInstances(classes, AuthoredResource.class);
+    }
+
+    private static <T> void removeAllInstances(List<T> something, T instance) {
+        boolean found;
+        do {
+             found = something.remove(instance);
+        } while(found);
     }
 
 }

--- a/base/src/main/java/com/nedap/archie/base/package-info.java
+++ b/base/src/main/java/com/nedap/archie/base/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.base;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/base/src/main/java/com/nedap/archie/base/terminology/package-info.java
+++ b/base/src/main/java/com/nedap/archie/base/terminology/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.base.terminology;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/base/src/main/java/com/nedap/archie/definitions/package-info.java
+++ b/base/src/main/java/com/nedap/archie/definitions/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.definitions;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.archetyped;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.changecontrol;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Activity.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Activity.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 /**
  * Created by pieter.bos on 04/11/15.
  */
-@XmlRootElement(name = "activity", namespace = "http://schemas.openehr.org/v1" )
+@XmlRootElement(name = "activity" )
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ACTIVITY", propOrder = {
         "description",

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/package-info.java
@@ -1,0 +1,6 @@
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
+
+package com.nedap.archie.rm.composition;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/package-info.java
@@ -1,0 +1,8 @@
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1", /*xmlns = {@XmlNs(prefix = "", namespaceURI = "http://schemas.openehr.org/v1")
+
+}*/ elementFormDefault = XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
+
+package com.nedap.archie.rm.datastructures;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datatypes/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datatypes/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.datatypes;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvText.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvText.java
@@ -8,6 +8,7 @@ import com.nedap.archie.rmutil.InvariantUtil;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Objects;
 /**
  * Created by pieter.bos on 04/11/15.
  */
+@XmlRootElement(name = "DV_TEXT")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DV_TEXT", propOrder = {
         "value",

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.datavalues.encapsulated;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.datavalues;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.datavalues.quantity.datetime;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.datavalues.quantity;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/timespecification/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/timespecification/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.datavalues.timespecification;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/demographic/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.demographic;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/directory/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/directory/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.directory;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.ehr;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.generic;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/integration/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/integration/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.integration;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/security/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/security/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.security;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/package-info.java
@@ -1,5 +1,5 @@
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1",  elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED, attributeFormDefault = javax.xml.bind.annotation.XmlNsForm.UNQUALIFIED)
 
-package com.nedap.archie.rm;
+package com.nedap.archie.rm.support.identification;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -214,8 +214,8 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
         addClass(Link.class);
         addClass(Archetyped.class);
         addClass(ArchetypeHRID.class);
-       // addClass(AuthoredResource.class);
-       // addClass(TranslationDetails.class);
+        addClass(AuthoredResource.class);
+        addClass(TranslationDetails.class);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -214,8 +214,8 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
         addClass(Link.class);
         addClass(Archetyped.class);
         addClass(ArchetypeHRID.class);
-        addClass(AuthoredResource.class);
-        addClass(TranslationDetails.class);
+       // addClass(AuthoredResource.class);
+       // addClass(TranslationDetails.class);
     }
 
     @Override

--- a/openehr-rm/src/test/resources/com/nedap/archie/rm/composition/test_all_types.fixed.v1.xml
+++ b/openehr-rm/src/test/resources/com/nedap/archie/rm/composition/test_all_types.fixed.v1.xml
@@ -1,4 +1,5 @@
 <composition archetype_node_id="openEHR-EHR-COMPOSITION.test_all_types.v1"
+             xmlns="http://schemas.openehr.org/v1"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <name>
         <value>Test all types</value>

--- a/tools/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
+++ b/tools/src/main/java/com/nedap/archie/query/APathToXPathConverter.java
@@ -117,13 +117,26 @@ public class APathToXPathConverter {
         for(int i = 0; i < tree.getChildCount(); i++) {
             ParseTree child = tree.getChild(i);
             if(child instanceof TerminalNode) {
-                boolean shouldAppendSpace = literalsThatShouldHaveSpacing.contains(child.getText().toLowerCase());
-                if(shouldAppendSpace) {
-                    output.append(" ");
+                boolean continueIf = true;
+                if(!inPredicate && child.getText().equals("/")) {
+                    if(i + 1 < tree.getChildCount()) {
+                        if(!tree.getChild(i+1).getText().equals("/")) {
+                            output.append("/");
+                            output.append(ArchieNamespaceResolver.OPENEHR_NS_PREFIX);
+                            output.append(":");
+                            continueIf = false;
+                        }
+                    }
                 }
-                output.append(child.getText());
-                if(shouldAppendSpace) {
-                    output.append(" ");
+                if (continueIf) {
+                    boolean shouldAppendSpace = literalsThatShouldHaveSpacing.contains(child.getText().toLowerCase());
+                    if (shouldAppendSpace) {
+                        output.append(" ");
+                    }
+                    output.append(child.getText());
+                    if (shouldAppendSpace) {
+                        output.append(" ");
+                    }
                 }
             } else if (child instanceof AndExprContext) {
                 for(int j = 0; j < child.getChildCount(); j++) {
@@ -155,7 +168,7 @@ public class APathToXPathConverter {
                     output.append("position() = ");
                     output.append(child.getText());
                 } else if(filterExprContext.primaryExpr().Literal() != null) {
-                    output.append("name/value = ");
+                    output.append("openehr:name/openehr:value = ");
                     output.append(child.getText());
                 } else {
                     writeTree(output, child, inPredicate);

--- a/tools/src/main/java/com/nedap/archie/query/ArchieNamespaceResolver.java
+++ b/tools/src/main/java/com/nedap/archie/query/ArchieNamespaceResolver.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
  */
 class ArchieNamespaceResolver implements NamespaceContext {
 
+    public static final String OPENEHR_NS_PREFIX = "openehr";
     private final Document document;
 
     public ArchieNamespaceResolver(Document document) {
@@ -20,12 +21,17 @@ class ArchieNamespaceResolver implements NamespaceContext {
     public String getNamespaceURI(String prefix) {
         if (prefix.equals(XMLConstants.DEFAULT_NS_PREFIX)) {
             return document.lookupNamespaceURI(null);
+        } else if(prefix.equals(OPENEHR_NS_PREFIX)) {
+            return "http://schemas.openehr.org/v1";
         } else {
             return document.lookupNamespaceURI(prefix);
         }
     }
 
     public String getPrefix(String namespaceURI) {
+        if(namespaceURI.equalsIgnoreCase("http://schemas.openehr.org/v1")) {
+            return OPENEHR_NS_PREFIX;
+        }
         return document.lookupPrefix(namespaceURI);
     }
 

--- a/tools/src/main/java/com/nedap/archie/query/RMQueryContext.java
+++ b/tools/src/main/java/com/nedap/archie/query/RMQueryContext.java
@@ -12,6 +12,7 @@ import javax.xml.bind.Binder;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -21,7 +22,9 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * It's done by converting the RM objects into an XML-DOM using JAXB's Binder. XPATH is then evaluated against the DOM.
@@ -57,7 +60,7 @@ public class RMQueryContext {
             this.rootNode = rootNode;
             this.modelInfoLooup = lookup;
             this.binder = jaxbContext.createBinder();
-            domForQueries = createBlankDOMDocument(true);
+            domForQueries = createBlankDOMDocument(false);
 
             binder.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             //Marshall Query object to a blank DOM document.
@@ -100,8 +103,6 @@ public class RMQueryContext {
 
             String convertedQuery = APathToXPathConverter.convertQueryToXPath(query, firstXPathNode);
             XPath xpath = xPathFactory.newXPath();
-
-
             xpath.setNamespaceContext(new ArchieNamespaceResolver(domForQueries));
             NodeList foundNodes = (NodeList) xpath.evaluate(convertedQuery, domForQueries, XPathConstants.NODESET);
 

--- a/tools/src/main/java/com/nedap/archie/query/RMQueryContext.java
+++ b/tools/src/main/java/com/nedap/archie/query/RMQueryContext.java
@@ -67,7 +67,7 @@ public class RMQueryContext {
             //Binder will maintains association between two views.
             binder.marshal( rootNode/*new JAXBElement<Query>(qname, Query.class, query)*/  , domForQueries);
 
-            firstXPathNode = domForQueries.getFirstChild().getNodeName();
+            firstXPathNode = ArchieNamespaceResolver.OPENEHR_NS_PREFIX + ":" + domForQueries.getFirstChild().getNodeName();
 
             //print to stdout
 //            Marshaller marshaller = jaxbContext.createMarshaller();
@@ -124,6 +124,9 @@ public class RMQueryContext {
             //JAXB sometimes has trouble binding primitive values. Looks like a bug in Xerces
             //very annoying. Here's our workaround: lookup the parent node and manually get the correct attribute
             String nodeName = node.getNodeName();
+//            if(nodeName.contains(":")) {
+//                nodeName = nodeName.substring(nodeName.indexOf(":")+1);
+//            }
             //the parent usually can be found easily
             Object parent = binder.getJAXBNode(node.getParentNode());
             if(parent == null) {

--- a/tools/src/main/java/com/nedap/archie/query/UniqueNodePathBuilder.java
+++ b/tools/src/main/java/com/nedap/archie/query/UniqueNodePathBuilder.java
@@ -24,9 +24,16 @@ public class UniqueNodePathBuilder {
             String archetypeNodeId = Optional.ofNullable(node.getAttributes().getNamedItem("archetype_node_id"))
                 .map(Node::getNodeValue)
                 .orElse(null);
-            String pathSegment = new PathSegment(node.getNodeName(), archetypeNodeId, findNodeIndex(node, parent)).toString();
+            String pathSegment = new PathSegment(removeNameSpace(node.getNodeName()), archetypeNodeId, findNodeIndex(node, parent)).toString();
             return constructPathInner(parent).append(pathSegment);
         }
+    }
+
+    private static String removeNameSpace(String nodeName) {
+        if(nodeName.contains(":")) {
+            return nodeName.substring(nodeName.indexOf(":")+1);
+        }
+        return nodeName;
     }
 
     private static Integer findNodeIndex(Node node, Node parent) {

--- a/tools/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
+++ b/tools/src/test/java/com/nedap/archie/query/RMQueryContextTest.java
@@ -45,7 +45,7 @@ public class RMQueryContextTest {
 
         RMQueryContext queryContext = getQueryContext();
         assertEquals(Lists.newArrayList(composition.getContext()), queryContext.findList("/context"));
-        DvText text = (DvText) queryContext.findList("/context/other_context/items[name/value = 'Qualification']/items[id5]/value").get(0);
+        DvText text = (DvText) queryContext.findList("/context/other_context/items[openehr:name/openehr:value = 'Qualification']/items[id5]/value").get(0);
         assertNotNull(text);
     }
 
@@ -91,8 +91,10 @@ public class RMQueryContextTest {
 
 
         //and check that retrieving a sub-element also retrieves more than one element
-        List<RMObjectWithPath> values = queryContext.findList("/context/other_context[id2]/items[id3]/items[id5]/value");
+        List<RMObjectWithPath> values = queryContext.findListWithPaths("/context/other_context[id2]/items[id3]/items[id5]/value");
         assertEquals(2, values.size());
+        assertEquals("/context/other_context[id2]/items[id3,1]/items[id5,2]/value", values.get(0).getPath());
+        assertEquals("/context/other_context[id2]/items[id3,2]/items[id5,2]/value", values.get(1).getPath());
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBAOMRoundTripTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBAOMRoundTripTest.java
@@ -95,6 +95,7 @@ public class JAXBAOMRoundTripTest {
 
         Flattener flattener = new Flattener(repository, BuiltinReferenceModels.getAvailableModelInfoLookups()).createOperationalTemplate(true);
         Archetype operationalTemplate = flattener.flatten(bloodPressureComposition);
+        operationalTemplate.getOtherMetaData().put("test", "something");
         String xml = marshal(operationalTemplate);
         System.out.println(xml);
 

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBAOMTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBAOMTest.java
@@ -66,7 +66,7 @@ public class JAXBAOMTest {
     @Test
     public void parseCDuration() throws Exception {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<archetype is_generated=\"false\" is_differential=\"false\" xmlns:ns2=\"http://schemas.openehr.org/v1\">\n" +
+                "<archetype is_generated=\"false\" is_differential=\"false\" xmlns=\"http://schemas.openehr.org/v1\">\n" +
                 "    <description/>\n" +
                 "    <original_language>\n" +
                 "        <terminology_id>ISO_639-1</terminology_id>\n" +

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBRMRoundTripTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBRMRoundTripTest.java
@@ -11,9 +11,11 @@ import com.nedap.archie.rm.datavalues.quantity.datetime.DvDate;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDateTime;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvTime;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.rminfo.MetaModels;
 import com.nedap.archie.testutil.TestUtil;
 import org.junit.Before;
 import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import javax.xml.bind.Marshaller;
 import java.io.StringReader;
@@ -40,7 +42,7 @@ public class JAXBRMRoundTripTest {
     @Before
     public void setup() {
         testUtil = new TestUtil();
-        parser = new ADLParser(new RMConstraintImposer());
+        parser = new ADLParser(BuiltinReferenceModels.getMetaModels());
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBRMTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBRMTest.java
@@ -6,8 +6,10 @@ import com.nedap.archie.rm.datavalues.quantity.datetime.DvDuration;
 import org.junit.Test;
 import org.threeten.extra.PeriodDuration;
 
+import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.time.Period;
@@ -25,7 +27,8 @@ public class JAXBRMTest {
         StringWriter writer = new StringWriter();
         Marshaller marshaller = JAXBUtil.getArchieJAXBContext().createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-        marshaller.marshal(element, writer);
+        JAXBElement<Element> element1 = new JAXBElement<>(new QName("http://schemas.openehr.org/v1", "element"), Element.class, null, element);
+        marshaller.marshal(element1, writer);
         String xml = writer.toString();
         assertTrue(xml, xml.contains("P10D"));
     }
@@ -46,7 +49,7 @@ public class JAXBRMTest {
     @Test
     public void parseDuration() throws Exception {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<element archetype_node_id=\"id6\" xmlns:ns2=\"http://schemas.openehr.org/v1\">\n" +
+                "<element archetype_node_id=\"id6\" xmlns=\"http://schemas.openehr.org/v1\">\n" +
                 "    <name>\n" +
                 "        <value>duration</value>\n" +
                 "    </name>\n" +
@@ -62,7 +65,7 @@ public class JAXBRMTest {
     @Test
     public void parseNegativeDuration() throws Exception {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<element archetype_node_id=\"id6\" xmlns:ns2=\"http://schemas.openehr.org/v1\">\n" +
+                "<element archetype_node_id=\"id6\" xmlns=\"http://schemas.openehr.org/v1\">\n" +
                 "    <name>\n" +
                 "        <value>duration</value>\n" +
                 "    </name>\n" +

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBRMTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBRMTest.java
@@ -81,7 +81,7 @@ public class JAXBRMTest {
     @Test
     public void parseNegativePeriodDuration() throws Exception {
         String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-                "<element archetype_node_id=\"id6\" xmlns:ns2=\"http://schemas.openehr.org/v1\">\n" +
+                "<element archetype_node_id=\"id6\" xmlns=\"http://schemas.openehr.org/v1\">\n" +
                 "    <name>\n" +
                 "        <value>duration</value>\n" +
                 "    </name>\n" +


### PR DESCRIPTION
Fixes #343 . Adds the http://schemas.openehr.org/v1 namespace to the JAXB-bindings.

note that this is a breaking change:
- parsing XML documents without  a namespace will no longer work, unless a namespace unaware XMLReader is passed to JAXB
- generated XML documents will now have a namespace
- the RMQueryContext automatically adds namespaces for element/node names, but NOT in predicates, because it does not know what is an element and what is an element. So XPath lookup with element predicates such as `[name/value = '...']` will have to be changed to `[openehr:name/openehr:value = '...']. The regular path lookup remains unchanged.