### PR TITLE
Fixes #345, exception in EHR_URI invariant when URI scheme is null

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvEHRURI.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvEHRURI.java
@@ -34,6 +34,6 @@ public class DvEHRURI extends DvURI {
 
     @Invariant("Scheme_valid")
     public boolean schemeValid() {
-        return getValue() == null || getValue().getScheme().equalsIgnoreCase(OpenEhrDefinitions.EHR_SCHEME);
+        return getValue() == null || (getValue().getScheme() != null && getValue().getScheme().equalsIgnoreCase(OpenEhrDefinitions.EHR_SCHEME));
     }
 }

--- a/tools/src/test/java/com/nedap/archie/rmobjectvalidator/invariants/datavalues/DvEhrUriInvariantTest.java
+++ b/tools/src/test/java/com/nedap/archie/rmobjectvalidator/invariants/datavalues/DvEhrUriInvariantTest.java
@@ -1,8 +1,15 @@
 package com.nedap.archie.rmobjectvalidator.invariants.datavalues;
 
 import com.nedap.archie.rm.datavalues.DvEHRURI;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.rmobjectvalidator.RMObjectValidationMessage;
+import com.nedap.archie.rmobjectvalidator.RMObjectValidator;
 import com.nedap.archie.rmobjectvalidator.invariants.InvariantTestUtil;
 import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class DvEhrUriInvariantTest {
 
@@ -14,5 +21,22 @@ public class DvEhrUriInvariantTest {
     @Test
     public void invalid() {
         InvariantTestUtil.assertInvariantInvalid(new DvEHRURI("https://something/something"), "Scheme_valid", "/");
+    }
+
+
+    @Test
+    public void invalid2() {
+        RMObjectValidator validator = new RMObjectValidator(ArchieRMInfoLookup.getInstance(), (templateId) -> null);
+        List<RMObjectValidationMessage> messages = validator.validate(new DvEHRURI(""));
+        assertEquals(messages.toString(), 2, messages.size());
+        assertEquals("Invariant Value_valid failed on type DV_EHR_URI", messages.get(0).getMessage());
+        assertEquals("/", messages.get(0).getPath());
+        assertEquals("Invariant Scheme_valid failed on type DV_EHR_URI", messages.get(1).getMessage());
+        assertEquals("/", messages.get(1).getPath());
+    }
+
+    @Test
+    public void invalid3() {
+        InvariantTestUtil.assertInvariantInvalid(new DvEHRURI("target1"), "Scheme_valid", "/");
     }
 }


### PR DESCRIPTION
This threw an exception, instead of a nice validation error in case there was no scheme defined.

Since scheme must be the ehr scheme, a URI without a scheme is now considered to be invalid.