### PR TITLE
When rules are parsed from JSON OPT instead of ADL, fix integer -> lo…

### DIFF
--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ConstantEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/ConstantEvaluator.java
@@ -15,7 +15,16 @@ import java.util.List;
 public class ConstantEvaluator implements Evaluator<Constant<?>> {
     @Override
     public ValueList evaluate(RuleEvaluation<?> evaluation, Constant<?> statement) {
-        return new ValueList(statement.getValue(), PrimitiveType.fromExpressionType(statement.getType()));
+        return new ValueList(convertNumber(statement.getValue()), PrimitiveType.fromExpressionType(statement.getType()));
+    }
+
+    private Object convertNumber(Object value) {
+        if(value instanceof Integer) {
+            return ((Integer) value).longValue();
+        } else if(value instanceof Float) {
+            return ((Float) value).doubleValue();
+        }
+        return value;
     }
 
     @Override

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
@@ -50,7 +50,6 @@ public class BinaryOperatorTest {
     @Test
     public void plusReal() {
         testBinaryOperator(7d, ExpressionType.REAL, 4d, 3d, OperatorKind.plus);
-
     }
 
     @Test
@@ -89,6 +88,18 @@ public class BinaryOperatorTest {
         testBinaryOperator(true, ExpressionType.BOOLEAN, true, false, OperatorKind.or);
         testBinaryOperator(true, ExpressionType.BOOLEAN, false, true, OperatorKind.or);
         testBinaryOperator(true, ExpressionType.BOOLEAN, true, true, OperatorKind.or);
+    }
+
+    @Test
+    public void integerLongConversion() {
+        //integers must be automatically converted to Longs in ConstantEvaluator
+        testBinaryOperator(8l, ExpressionType.INTEGER, 2, 3l, OperatorKind.exponent);
+    }
+
+    @Test
+    public void floatToDoubleConversion() {
+        //floats must be automatically converted to Doubles in ConstantEvaluator
+        testBinaryOperator(8.0d, ExpressionType.INTEGER, 2.0f, 3l, OperatorKind.exponent);
     }
 
 


### PR DESCRIPTION
…ng + float -> double conversion

The problem is: when parsing this in OPT JSON form, things that were Longs and Doubles can be parsed as Integer and Float. This solves it by fixing the evaluator

alternative would be to preprocess all assertions. This is both a simpler fix, and more robust in the sense that it cannot be forgotten to preprocess them.