### PR TITLE
Fix attributes from tuples in parse post processor

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
+++ b/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
@@ -51,9 +51,11 @@ public class ArchetypeParsePostProcesser {
                 workList.addAll(attribute.getChildren());
             }
             if(cObject instanceof CComplexObject) {
-                for(CAttributeTuple tuple:((CComplexObject) cObject).getAttributeTuples()) {
+                CComplexObject cComplexObject = (CComplexObject) cObject;
+                for(CAttributeTuple tuple: cComplexObject.getAttributeTuples()) {
                     for(CAttribute attribute:tuple.getMembers()) {
                         attribute.setSocParent(tuple);
+                        cComplexObject.replaceAttribute(attribute);
                     }
                 }
 


### PR DESCRIPTION
When parsing JSON or XML Archetypes, the tuple attributes also present as regular attributes are wrong: they do not have their soc parent set. They are also copies of the c_attributes, rather than the same one.

This fixes it by replacing the attribute by the attributes from the tuple.