### PR TITLE
Fix that empty strings are not serialized to JSON

### DIFF
--- a/archie-utils/src/main/java/com/nedap/archie/json/ExcludeEmptyCollectionsFilter.java
+++ b/archie-utils/src/main/java/com/nedap/archie/json/ExcludeEmptyCollectionsFilter.java
@@ -20,7 +20,7 @@ public class ExcludeEmptyCollectionsFilter {
             return ((Collection) o).size() == 0;
         }
 
-        if (o.getClass().isArray()) {
+        if (o instanceof Object[]) {
             return ((Object[]) o).length == 0;
         }
 

--- a/archie-utils/src/main/java/com/nedap/archie/json/ExcludeEmptyCollectionsFilter.java
+++ b/archie-utils/src/main/java/com/nedap/archie/json/ExcludeEmptyCollectionsFilter.java
@@ -1,0 +1,30 @@
+package com.nedap.archie.json;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class ExcludeEmptyCollectionsFilter {
+    @Override
+    // Return true to exclude
+    public boolean equals(Object o) {
+
+        // Exclude Null
+        if (o == null) {
+            return true;
+        }
+
+        if (o instanceof Map) {
+            return ((Map) o).size() == 0;
+        }
+        if (o instanceof Collection) {
+            return ((Collection) o).size() == 0;
+        }
+
+        if (o.getClass().isArray()) {
+            return ((Object[]) o).length == 0;
+        }
+
+        // Include everything else
+        return false;
+    }
+}

--- a/archie-utils/src/main/java/com/nedap/archie/json/JacksonUtil.java
+++ b/archie-utils/src/main/java/com/nedap/archie/json/JacksonUtil.java
@@ -86,7 +86,12 @@ public class JacksonUtil {
         objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         objectMapper.enable(DeserializationFeature.UNWRAP_SINGLE_VALUE_ARRAYS);
         if(!configuration.isSerializeEmptyCollections()) {
-            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+            objectMapper.setDefaultPropertyInclusion(
+                    JsonInclude.Value.construct(
+                            JsonInclude.Include.CUSTOM,
+                            JsonInclude.Include.USE_DEFAULTS,
+                            ExcludeEmptyCollectionsFilter.class,
+                            null));
         }
         if(configuration.isFailOnUnknownProperties()) {
             objectMapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/tools/src/test/java/com/nedap/archie/json/RMJacksonTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/RMJacksonTest.java
@@ -1,14 +1,16 @@
 package com.nedap.archie.json;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nedap.archie.rm.RMObject;
 import com.nedap.archie.rm.composition.Composition;
+import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.datavalues.quantity.datetime.DvDuration;
 import org.junit.Test;
 import org.threeten.extra.PeriodDuration;
 
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -76,5 +78,57 @@ public class RMJacksonTest {
 
         String s = objectMapper.writeValueAsString(dvDuration);
         assertTrue(s.contains("-P10Y10DT12H20S"));
+    }
+
+    @Test
+    public void emptyDvTextIsIcnluded() throws JsonProcessingException {
+        RMJacksonConfiguration configuration = new RMJacksonConfiguration();
+        configuration.setSerializeEmptyCollections(false);
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(configuration);
+        DvText dvText = new DvText("");
+
+
+        String actualJson = objectMapper.writeValueAsString(dvText);
+        assertEquals(
+                        removeWhiteSpaces("{\n"
+                                + "  \"@type\" : \"DV_TEXT\",\n"
+                                + "  \"value\" : \"\"\n"
+                                + "}"), removeWhiteSpaces(actualJson));
+    }
+
+    @Test
+    public void emptyCollectionIsNotIncluded() throws JsonProcessingException {
+        RMJacksonConfiguration configuration = new RMJacksonConfiguration();
+        configuration.setSerializeEmptyCollections(false);
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(configuration);
+        DvText dvText = new DvText("");
+        dvText.setMappings(new ArrayList<>());
+
+
+        String actualJson = objectMapper.writeValueAsString(dvText);
+        assertEquals(
+                removeWhiteSpaces("{\n"
+                        + "  \"@type\" : \"DV_TEXT\",\n"
+                        + "  \"value\" : \"\"\n"
+                        + "}"), removeWhiteSpaces(actualJson));
+    }
+
+    @Test
+    public void emptyCollectionInCollection() throws JsonProcessingException {
+        RMJacksonConfiguration configuration = new RMJacksonConfiguration();
+        configuration.setSerializeEmptyCollections(false);
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(configuration);
+        Map<String, Map<String, String>> map = new LinkedHashMap<>();
+        map.put("test", new LinkedHashMap<>());
+
+
+        String actualJson = objectMapper.writeValueAsString(map);
+        assertEquals(
+                removeWhiteSpaces("{\"test\":{}}"),
+                removeWhiteSpaces(actualJson));
+    }
+
+    String removeWhiteSpaces(String input) {
+        return input.replaceAll("\\s+", "");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/openEHR/archie/issues/359

note that this changes another behaviour: a collection or map containing an empty collection or empty map before did not serialize this value. so a map containing:
```
{
   "test": {}
}
```

Was previously serialized as `{}`. This is now the full above form. This can be changed back to `{}`, but I think the full form is probably better.

the same behaviour also applies to `[{}, null]`, which will now include null, or `[[], [1,2,3]]`, now the [] will be included. 

Discussion: is this a desireable change?
