### PR TITLE
Add missing setThisAsParent for the description of an Activity

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Activity.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Activity.java
@@ -65,6 +65,7 @@ public class Activity extends Locatable {
 
     public void setDescription(ItemStructure description) {
         this.description = description;
+        setThisAsParent(description, "description");
     }
 
     public DvParsable getTiming() {


### PR DESCRIPTION
This bug resulted in the path of the description within an Activity in an RM_OBJECT to be "/".