### PR TITLE
Fixes JSON deserialization issue with path_segments

### DIFF
--- a/openehr-rm/src/test/java/com/nedap/archie/rm/composition/CompositionTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/composition/CompositionTest.java
@@ -1,10 +1,15 @@
 package com.nedap.archie.rm.composition;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nedap.archie.json.JacksonUtil;
+import com.nedap.archie.json.RMJacksonConfiguration;
 import com.nedap.archie.xml.JAXBUtil;
 import org.junit.Test;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
+import java.io.IOException;
+import java.io.StringWriter;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,6 +20,46 @@ public class CompositionTest {
         Unmarshaller unmarshaller = JAXBUtil.getArchieJAXBContext().createUnmarshaller();
         Composition composition1 = (Composition) unmarshaller.unmarshal(getClass().getResourceAsStream("test_all_types.fixed.v1.xml"));
         Composition composition2 = (Composition) unmarshaller.unmarshal(getClass().getResourceAsStream("test_all_types.fixed.v1.xml"));
-        assertEquals(composition1,composition2);
+        assertEquals(composition1, composition2);
+    }
+
+    @Test
+    public void testJsonStandardConfig() throws IOException {
+        Composition expected = parseJson("validation_composition_test.v0.json");
+        RMJacksonConfiguration standardConfig = RMJacksonConfiguration.createStandardsCompliant();
+
+        Composition actual = processComposition(expected, standardConfig);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testJsonDefaultConfig() throws IOException {
+        Composition expected = parseJson("validation_composition_test.v0.json");
+        RMJacksonConfiguration config = new RMJacksonConfiguration();
+
+        Composition actual = processComposition(expected, config);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testJsonJavascriptConfig() throws IOException {
+        Composition expected = parseJson("validation_composition_test.v0.json");
+        RMJacksonConfiguration javascriptConfig = RMJacksonConfiguration.createConfigForJavascriptUsage();
+
+        Composition actual = processComposition(expected, javascriptConfig);
+        assertEquals(expected, actual);
+    }
+
+    private Composition processComposition(Composition original, RMJacksonConfiguration configuration) throws IOException {
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(configuration);
+
+        StringWriter json = new StringWriter();
+        objectMapper.writeValue(json, original);
+        return objectMapper.readValue(json.toString(), Composition.class);
+    }
+
+    private Composition parseJson(String resourceName) throws IOException {
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(RMJacksonConfiguration.createStandardsCompliant());
+        return objectMapper.readValue(getClass().getResourceAsStream(resourceName), Composition.class);
     }
 }

--- a/openehr-rm/src/test/resources/com/nedap/archie/rm/composition/validation_composition_test.v0.json
+++ b/openehr-rm/src/test/resources/com/nedap/archie/rm/composition/validation_composition_test.v0.json
@@ -1,0 +1,1395 @@
+{
+  "_type": "COMPOSITION",
+  "language": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_639-1"
+    },
+    "code_string": "ru"
+  },
+  "territory": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": {
+      "_type": "TERMINOLOGY_ID",
+      "value": "ISO_3166-1"
+    },
+    "code_string": "US"
+  },
+  "category": {
+    "_type": "DV_CODED_TEXT",
+    "defining_code": {
+      "_type": "CODE_PHRASE",
+      "terminology_id": {
+        "_type": "TERMINOLOGY_ID",
+        "value": "openehr"
+      },
+      "code_string": "433"
+    },
+    "value": "event"
+  },
+  "composer": {
+    "_type": "PARTY_IDENTIFIED",
+    "name": "Alexander Ziborov",
+    "external_ref": {
+      "_type": "PARTY_REF",
+      "id": {
+        "_type": "GENERIC_ID",
+        "scheme": "scheme",
+        "value": "value"
+      },
+      "namespace": "local",
+      "type": "PERSON"
+    }
+  },
+  "context": {
+    "_type": "EVENT_CONTEXT",
+    "start_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2021-10-22T15:34:09.788+03:00"
+    },
+    "end_time": {
+      "_type": "DV_DATE_TIME",
+      "value": "2021-10-22T15:34:09.788+03:00"
+    },
+    "setting": {
+      "_type": "DV_CODED_TEXT",
+      "defining_code": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "openehr"
+        },
+        "code_string": "238"
+      },
+      "value": "other care"
+    },
+    "health_care_facility": {
+      "_type": "PARTY_IDENTIFIED",
+      "name": "Company",
+      "external_ref": {
+        "_type": "PARTY_REF",
+        "id": {
+          "_type": "GENERIC_ID",
+          "scheme": "scheme",
+          "value": "9905"
+        },
+        "namespace": "namespace",
+        "type": "ORGANISATION"
+      }
+    },
+    "participations": [
+      {
+        "_type": "PARTICIPATION",
+        "function": {
+          "_type": "DV_TEXT",
+          "value": "unknown"
+        },
+        "performer": {
+          "_type": "PARTY_IDENTIFIED",
+          "name": "Firstname Lastname 1",
+          "external_ref": {
+            "_type": "PARTY_REF",
+            "id": {
+              "_type": "GENERIC_ID",
+              "scheme": "scheme",
+              "value": "8469"
+            },
+            "namespace": "namespace",
+            "type": "PERSON"
+          }
+        },
+        "mode": {
+          "_type": "DV_CODED_TEXT",
+          "defining_code": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": {
+              "_type": "TERMINOLOGY_ID",
+              "value": "openehr"
+            },
+            "code_string": "217"
+          },
+          "value": "signing (face-to-face)"
+        }
+      },
+      {
+        "_type": "PARTICIPATION",
+        "function": {
+          "_type": "DV_TEXT",
+          "value": "unknown"
+        },
+        "performer": {
+          "_type": "PARTY_IDENTIFIED",
+          "name": "Firstname Lastname 2",
+          "external_ref": {
+            "_type": "PARTY_REF",
+            "id": {
+              "_type": "GENERIC_ID",
+              "scheme": "scheme",
+              "value": "4873"
+            },
+            "namespace": "namespace",
+            "type": "PERSON"
+          }
+        },
+        "mode": {
+          "_type": "DV_CODED_TEXT",
+          "defining_code": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": {
+              "_type": "TERMINOLOGY_ID",
+              "value": "openehr"
+            },
+            "code_string": "209"
+          },
+          "value": "SMS message"
+        }
+      }
+    ]
+  },
+  "content": [
+    {
+      "_type": "SECTION",
+      "items": [
+        {
+          "_type": "EVALUATION",
+          "data": {
+            "_type": "ITEM_SINGLE",
+            "item": {
+              "_type": "ELEMENT",
+              "value": {
+                "_type": "DV_TEXT",
+                "value": "Element #1 1"
+              },
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "Element #1"
+              },
+              "archetype_node_id": "at0002"
+            },
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "One"
+            },
+            "archetype_node_id": "at0001"
+          },
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "Evaluation #1"
+          },
+          "language": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": {
+              "_type": "TERMINOLOGY_ID",
+              "value": "ISO_639-1"
+            },
+            "code_string": "ru"
+          },
+          "encoding": {
+            "_type": "CODE_PHRASE",
+            "terminology_id": {
+              "_type": "TERMINOLOGY_ID",
+              "value": "IANA_character-sets"
+            },
+            "code_string": "UTF-8"
+          },
+          "subject": {
+            "_type": "PARTY_SELF"
+          },
+          "archetype_details": {
+            "_type": "ARCHETYPED",
+            "archetype_id": {
+              "_type": "ARCHETYPE_ID",
+              "value": "openEHR-EHR-EVALUATION.validation_evaliation_test.v0"
+            },
+            "rm_version": "1.0.1"
+          },
+          "archetype_node_id": "openEHR-EHR-EVALUATION.validation_evaliation_test.v0",
+          "other_participations": [
+            {
+              "_type": "PARTICIPATION",
+              "function": {
+                "_type": "DV_TEXT",
+                "value": "unknown"
+              },
+              "performer": {
+                "_type": "PARTY_IDENTIFIED",
+                "name": "Firstname Lastname 1",
+                "external_ref": {
+                  "_type": "PARTY_REF",
+                  "id": {
+                    "_type": "GENERIC_ID",
+                    "scheme": "scheme",
+                    "value": "5116"
+                  },
+                  "namespace": "namespace",
+                  "type": "PERSON"
+                }
+              },
+              "mode": {
+                "_type": "DV_CODED_TEXT",
+                "defining_code": {
+                  "_type": "CODE_PHRASE",
+                  "terminology_id": {
+                    "_type": "TERMINOLOGY_ID",
+                    "value": "openehr"
+                  },
+                  "code_string": "217"
+                },
+                "value": "signing (face-to-face)"
+              }
+            },
+            {
+              "_type": "PARTICIPATION",
+              "function": {
+                "_type": "DV_TEXT",
+                "value": "unknown"
+              },
+              "performer": {
+                "_type": "PARTY_IDENTIFIED",
+                "name": "Firstname Lastname 2",
+                "external_ref": {
+                  "_type": "PARTY_REF",
+                  "id": {
+                    "_type": "GENERIC_ID",
+                    "scheme": "scheme",
+                    "value": "8674"
+                  },
+                  "namespace": "namespace",
+                  "type": "PERSON"
+                }
+              },
+              "mode": {
+                "_type": "DV_CODED_TEXT",
+                "defining_code": {
+                  "_type": "CODE_PHRASE",
+                  "terminology_id": {
+                    "_type": "TERMINOLOGY_ID",
+                    "value": "openehr"
+                  },
+                  "code_string": "206"
+                },
+                "value": "asynchronous text; email; fax; letter; handwritten note; SMS message"
+              }
+            }
+          ]
+        }
+      ],
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Section #1"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-SECTION.validation_section_test.v0"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-SECTION.validation_section_test.v0"
+    },
+    {
+      "_type": "EVALUATION",
+      "data": {
+        "_type": "ITEM_SINGLE",
+        "item": {
+          "_type": "ELEMENT",
+          "value": {
+            "_type": "DV_TEXT",
+            "value": "Element #2 1"
+          },
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "Element #2"
+          },
+          "archetype_node_id": "at0002"
+        },
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "One"
+        },
+        "archetype_node_id": "at0001"
+      },
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Evaluation #2 with single element structure"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "ru"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.validation_evaliation_test.v0"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.validation_evaliation_test.v0",
+      "other_participations": [
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 1",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "5622"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "209"
+            },
+            "value": "SMS message"
+          }
+        },
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 2",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "9915"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "208"
+            },
+            "value": "facsimile/telefax"
+          }
+        }
+      ]
+    },
+    {
+      "_type": "EVALUATION",
+      "data": {
+        "_type": "ITEM_TREE",
+        "items": [
+          {
+            "_type": "CLUSTER",
+            "items": [
+              {
+                "_type": "ELEMENT",
+                "value": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #3.1.1 1"
+                },
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #3.1.1"
+                },
+                "archetype_node_id": "at0003"
+              },
+              {
+                "_type": "ELEMENT",
+                "value": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #3.1.2 1"
+                },
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #3.1.2"
+                },
+                "archetype_node_id": "at0004"
+              }
+            ],
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cluster #3.1"
+            },
+            "archetype_node_id": "at0002"
+          },
+          {
+            "_type": "CLUSTER",
+            "items": [
+              {
+                "_type": "ELEMENT",
+                "value": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #3.2.1 1"
+                },
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #3.2.1"
+                },
+                "archetype_node_id": "at0006"
+              }
+            ],
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Cluster #3.2"
+            },
+            "archetype_node_id": "at0005"
+          }
+        ],
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Tree"
+        },
+        "archetype_node_id": "at0001"
+      },
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Evaluation #3 test with tree structure"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "ru"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.validation_evaliation_test.v2"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.validation_evaliation_test.v2",
+      "other_participations": [
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 1",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "4213"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "203"
+            },
+            "value": "teleconference"
+          }
+        },
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 2",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "8141"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "216"
+            },
+            "value": "face-to-face communication"
+          }
+        }
+      ]
+    },
+    {
+      "_type": "EVALUATION",
+      "data": {
+        "_type": "ITEM_LIST",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "value": {
+              "_type": "DV_TEXT",
+              "value": "Element #4.1 1"
+            },
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Element #4.1"
+            },
+            "archetype_node_id": "at0004"
+          },
+          {
+            "_type": "ELEMENT",
+            "value": {
+              "_type": "DV_TEXT",
+              "value": "Element #4.2 1"
+            },
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Element #4.2"
+            },
+            "archetype_node_id": "at0006"
+          },
+          {
+            "_type": "ELEMENT",
+            "value": {
+              "_type": "DV_TEXT",
+              "value": "Element #4.3 1"
+            },
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Element #4.3"
+            },
+            "archetype_node_id": "at0007"
+          }
+        ],
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "List"
+        },
+        "archetype_node_id": "at0001"
+      },
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Evaluation #4 with list structure"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "ru"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.validation_evaliation_test.v1"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.validation_evaliation_test.v1",
+      "other_participations": [
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 1",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "1246"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "221"
+            },
+            "value": "translated text"
+          }
+        },
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 2",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "8834"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "194"
+            },
+            "value": "asynchronous audiovisual; recorded video"
+          }
+        }
+      ]
+    },
+    {
+      "_type": "EVALUATION",
+      "data": {
+        "_type": "ITEM_TABLE",
+        "rows": [
+          {
+            "_type": "CLUSTER",
+            "items": [
+              {
+                "_type": "ELEMENT",
+                "value": {
+                  "_type": "DV_CODED_TEXT",
+                  "defining_code": {
+                    "_type": "CODE_PHRASE",
+                    "terminology_id": {
+                      "_type": "TERMINOLOGY_ID",
+                      "value": "local"
+                    },
+                    "code_string": "at0007"
+                  },
+                  "value": "column"
+                },
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "Row_head #5.1"
+                },
+                "archetype_node_id": "at0008"
+              },
+              {
+                "_type": "ELEMENT",
+                "value": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #5.1 1"
+                },
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #5.1"
+                },
+                "archetype_node_id": "at0005"
+              },
+              {
+                "_type": "ELEMENT",
+                "value": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #5.2 1"
+                },
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #5.2"
+                },
+                "archetype_node_id": "at0006"
+              }
+            ],
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Row #5.1"
+            },
+            "archetype_node_id": "at0004"
+          }
+        ],
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Table"
+        },
+        "archetype_node_id": "at0001"
+      },
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Evaluation #5 test with table structure"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "ru"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-EVALUATION.validation_evaliation_test.v3"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-EVALUATION.validation_evaliation_test.v3",
+      "other_participations": [
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 1",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "7812"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "195"
+            },
+            "value": "live audiovisual; videoconference; videophone"
+          }
+        },
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 2",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "5230"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "223"
+            },
+            "value": "interpreted face-to-face communication"
+          }
+        }
+      ]
+    },
+    {
+      "_type": "INSTRUCTION",
+      "narrative": {
+        "_type": "DV_TEXT",
+        "value": "narrative"
+      },
+      "expiry_time": {
+        "_type": "DV_DATE_TIME",
+        "value": "2021-10-22T15:34:09.788+03:00"
+      },
+      "activities": [
+        {
+          "_type": "ACTIVITY",
+          "description": {
+            "_type": "ITEM_LIST",
+            "items": [
+              {
+                "_type": "ELEMENT",
+                "value": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #1 2"
+                },
+                "name": {
+                  "_type": "DV_TEXT",
+                  "value": "Element #1"
+                },
+                "archetype_node_id": "at0003"
+              }
+            ],
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "List"
+            },
+            "archetype_node_id": "at0002"
+          },
+          "timing": {
+            "_type": "DV_PARSABLE",
+            "value": "R5/2008-03-01T13:00:00Z/P1Y2M10DT2H30M",
+            "formalism": "timing"
+          },
+          "action_archetype_id": "/.*/",
+          "name": {
+            "_type": "DV_TEXT",
+            "value": "Activity #1"
+          },
+          "archetype_node_id": "at0001"
+        }
+      ],
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Instruction #1"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "ru"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-INSTRUCTION.instruction_test.v0"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-INSTRUCTION.instruction_test.v0",
+      "other_participations": [
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 1",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "1290"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "217"
+            },
+            "value": "signing (face-to-face)"
+          }
+        },
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 2",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "3169"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "211"
+            },
+            "value": "handwritten note"
+          }
+        }
+      ]
+    },
+    {
+      "_type": "ACTION",
+      "time": {
+        "_type": "DV_DATE_TIME",
+        "value": "2021-10-22T15:34:09.788+03:00"
+      },
+      "description": {
+        "_type": "ITEM_LIST",
+        "items": [
+          {
+            "_type": "ELEMENT",
+            "value": {
+              "_type": "DV_TEXT",
+              "value": "Element #1 3"
+            },
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Element #1"
+            },
+            "archetype_node_id": "at0002"
+          }
+        ],
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "List"
+        },
+        "archetype_node_id": "at0001"
+      },
+      "ism_transition": {
+        "_type": "ISM_TRANSITION",
+        "current_state": {
+          "value": "planned",
+          "defining_code": {
+            "terminology_id": {
+              "value": "openehr"
+            },
+            "code_string": "526"
+          }
+        }
+      },
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Action #1"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "ru"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-ACTION.action_test.v0"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-ACTION.action_test.v0",
+      "other_participations": [
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 1",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "5934"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "215"
+            },
+            "value": "interactive written note"
+          }
+        },
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 2",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "1086"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "205"
+            },
+            "value": "internet telephone"
+          }
+        }
+      ]
+    },
+    {
+      "_type": "OBSERVATION",
+      "data": {
+        "_type": "HISTORY",
+        "origin": {
+          "_type": "DV_DATE_TIME",
+          "value": "2021-10-22T15:34:09.788+03:00"
+        },
+        "events": [
+          {
+            "_type": "POINT_EVENT",
+            "name": {
+              "_type": "DV_TEXT",
+              "value": "Event #1"
+            },
+            "time": {
+              "_type": "DV_DATE_TIME",
+              "value": "2021-10-22T15:34:09.788+03:00"
+            },
+            "data": {
+              "_type": "ITEM_LIST",
+              "items": [
+                {
+                  "_type": "ELEMENT",
+                  "value": {
+                    "_type": "DV_TEXT",
+                    "value": "Element #1 4"
+                  },
+                  "name": {
+                    "_type": "DV_TEXT",
+                    "value": "Element #1"
+                  },
+                  "archetype_node_id": "at0004"
+                }
+              ],
+              "name": {
+                "_type": "DV_TEXT",
+                "value": "List"
+              },
+              "archetype_node_id": "at0003"
+            },
+            "archetype_node_id": "at0002"
+          }
+        ],
+        "name": {
+          "_type": "DV_TEXT",
+          "value": "Event Series"
+        },
+        "archetype_node_id": "at0001"
+      },
+      "name": {
+        "_type": "DV_TEXT",
+        "value": "Observation #1"
+      },
+      "language": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "ISO_639-1"
+        },
+        "code_string": "ru"
+      },
+      "encoding": {
+        "_type": "CODE_PHRASE",
+        "terminology_id": {
+          "_type": "TERMINOLOGY_ID",
+          "value": "IANA_character-sets"
+        },
+        "code_string": "UTF-8"
+      },
+      "subject": {
+        "_type": "PARTY_SELF"
+      },
+      "archetype_details": {
+        "_type": "ARCHETYPED",
+        "archetype_id": {
+          "_type": "ARCHETYPE_ID",
+          "value": "openEHR-EHR-OBSERVATION.observation_test.v0"
+        },
+        "rm_version": "1.0.1"
+      },
+      "archetype_node_id": "openEHR-EHR-OBSERVATION.observation_test.v0",
+      "other_participations": [
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 1",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "5895"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "210"
+            },
+            "value": "printed/typed letter"
+          }
+        },
+        {
+          "_type": "PARTICIPATION",
+          "function": {
+            "_type": "DV_TEXT",
+            "value": "unknown"
+          },
+          "performer": {
+            "_type": "PARTY_IDENTIFIED",
+            "name": "Firstname Lastname 2",
+            "external_ref": {
+              "_type": "PARTY_REF",
+              "id": {
+                "_type": "GENERIC_ID",
+                "scheme": "scheme",
+                "value": "5961"
+              },
+              "namespace": "namespace",
+              "type": "PERSON"
+            }
+          },
+          "mode": {
+            "_type": "DV_CODED_TEXT",
+            "defining_code": {
+              "_type": "CODE_PHRASE",
+              "terminology_id": {
+                "_type": "TERMINOLOGY_ID",
+                "value": "openehr"
+              },
+              "code_string": "199"
+            },
+            "value": "asynchronous audio-only; dictated; voice mail"
+          }
+        }
+      ]
+    }
+  ],
+  "name": {
+    "_type": "DV_TEXT",
+    "value": "Validation composition test"
+  },
+  "uid": {
+    "_type": "HIER_OBJECT_ID",
+    "value": "03047d3d-28f1-4e7a-a1c1-73f90dd3996a::ehrdb::1"
+  },
+  "links": [
+    {
+      "_type": "LINK",
+      "meaning": {
+        "_type": "DV_TEXT",
+        "value": "meaning"
+      },
+      "type": {
+        "_type": "DV_TEXT",
+        "value": "type"
+      },
+      "target": {
+        "_type": "DV_EHR_URI",
+        "value": "ehr:target1"
+      }
+    },
+    {
+      "_type": "LINK",
+      "meaning": {
+        "_type": "DV_TEXT",
+        "value": "meaning"
+      },
+      "type": {
+        "_type": "DV_TEXT",
+        "value": "type"
+      },
+      "target": {
+        "_type": "DV_EHR_URI",
+        "value": "ehr:target2"
+      }
+    }
+  ],
+  "archetype_details": {
+    "_type": "ARCHETYPED",
+    "archetype_id": {
+      "_type": "ARCHETYPE_ID",
+      "value": "openEHR-EHR-COMPOSITION.validation_composition_test.v0"
+    },
+    "template_id": {
+      "_type": "TEMPLATE_ID",
+      "value": "clinical_content_validation"
+    },
+    "rm_version": "1.0.1"
+  },
+  "archetype_node_id": "openEHR-EHR-COMPOSITION.validation_composition_test.v0"
+}

--- a/utils/src/main/java/com/nedap/archie/paths/PathSegment.java
+++ b/utils/src/main/java/com/nedap/archie/paths/PathSegment.java
@@ -20,6 +20,9 @@ public class PathSegment {
     private String archetypeRef = null;
     private Integer index;
 
+    public PathSegment() {
+    }
+
     public PathSegment(String nodeName, Integer index) {
         this(nodeName, null, index);
     }


### PR DESCRIPTION
Fix issue with Jackson when deserializing Composition serialized before using Javascript/default configuration.

The problem occurs on `path_segments` for `EventContext`, `IsmTransition` and probably `InstructionDetails` (not tested) classes that produce the following output:

```json
{
  "path_segments": [
    {
      "node_name": "content",
      "node_id": "openEHR-EHR-ACTION.action_test.v0"
    },
    {
      "node_name": "ism_transition"
    }
  ]
}
```

Classes that inherit from `Locatable` are not affected as the method is overridden and marked as `@JsonIgnore`. 

First, I fixed the issue using `@JsonIgnore` on the getter before I discovered that you are handling this property via `DontSerializePathMixin`.

Finally, I go with the option to create an empty contructor for `PathSegment`.

PS1: I tried to go with `@JsonIgnoreProperties(value="pathSegments", allowGetters= true)`, but it does not work as I expected.
PS2: An other approach may use `@JsonFilter` but I think the constructor option is easier/cleaner.
