### PR TITLE
Fix rules terminology id

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -163,19 +163,21 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
     public List<String> getValueSetExpanded() {
         List<String> result = new ArrayList<>();
         Archetype archetype = getArchetype();
-        if(archetype == null) {
+        ArchetypeTerminology terminology = null;
+        if(archetype != null) {
             //ideally this would not happen, but no reference to archetype exists in leaf constraints in rules so far
             //so for now fix it so it doesn't throw a NullPointerException
-            return result;
+            terminology = archetype.getTerminology(this);
         }
-        ArchetypeTerminology terminology = archetype.getTerminology(this);
         for(String constraint:getConstraint()) {
             if(constraint.startsWith("at")) {
                 result.add(constraint);
             } else if (constraint.startsWith("ac")) {
-                ValueSet acValueSet = terminology.getValueSets().get(constraint);
-                if(acValueSet != null) {
-                    result.addAll(AOMUtils.getExpandedValueSetMembers(terminology.getValueSets(), acValueSet));
+                if(terminology != null) {
+                    ValueSet acValueSet = terminology.getValueSets().get(constraint);
+                    if (acValueSet != null) {
+                        result.addAll(AOMUtils.getExpandedValueSetMembers(terminology.getValueSets(), acValueSet));
+                    }
                 }
             }
         }

--- a/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
+++ b/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
@@ -51,6 +51,7 @@ public class ArchetypeParsePostProcesser {
                 workList.addAll(attribute.getChildren());
             }
             if(cObject instanceof CComplexObject) {
+                //TODO: fix tuple so it has proper multiple references to the separate structures, instead of a complete duplication of data in json
                 CComplexObject cComplexObject = (CComplexObject) cObject;
                 for(CAttributeTuple tuple: cComplexObject.getAttributeTuples()) {
                     for(CAttribute attribute:tuple.getMembers()) {
@@ -58,6 +59,18 @@ public class ArchetypeParsePostProcesser {
                         attribute.setParent(cObject);
                         workList.addAll(attribute.getChildren());
                         cComplexObject.replaceAttribute(attribute);
+                    }
+                    for(CPrimitiveTuple primitiveTuple:tuple.getTuples()) {
+                        int index = 0;
+                        for(CPrimitiveObject object:primitiveTuple.getMembers()) {
+                            if(index < tuple.getMembers().size()) {
+                                CAttribute attribute = tuple.getMember(index);
+                                object.setSocParent(tuple);
+                                object.setParent(attribute);
+                                index++;
+                            }
+
+                        }
                     }
                 }
 

--- a/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
+++ b/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
@@ -55,6 +55,8 @@ public class ArchetypeParsePostProcesser {
                 for(CAttributeTuple tuple: cComplexObject.getAttributeTuples()) {
                     for(CAttribute attribute:tuple.getMembers()) {
                         attribute.setSocParent(tuple);
+                        attribute.setParent(cObject);
+                        workList.addAll(attribute.getChildren());
                         cComplexObject.replaceAttribute(attribute);
                     }
                 }

--- a/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
+++ b/aom/src/main/java/com/nedap/archie/aom/utils/ArchetypeParsePostProcesser.java
@@ -62,10 +62,10 @@ public class ArchetypeParsePostProcesser {
                     }
                     for(CPrimitiveTuple primitiveTuple:tuple.getTuples()) {
                         int index = 0;
-                        for(CPrimitiveObject object:primitiveTuple.getMembers()) {
+                        for(CPrimitiveObject<?, ?> object:primitiveTuple.getMembers()) {
                             if(index < tuple.getMembers().size()) {
                                 CAttribute attribute = tuple.getMember(index);
-                                object.setSocParent(tuple);
+                                object.setSocParent(primitiveTuple);
                                 object.setParent(attribute);
                                 index++;
                             }

--- a/base/src/main/java/com/nedap/archie/ValidationConfiguration.java
+++ b/base/src/main/java/com/nedap/archie/ValidationConfiguration.java
@@ -9,7 +9,7 @@ public class ValidationConfiguration {
     private static boolean failOnUnknownTerminologyId = false;
 
     /**
-     * Set whether to fail validation or not if in CTerminologyCode.isValidValue(), an uknown terminology is encountered
+     * Set whether to fail validation or not if in CTerminologyCode.isValidValue(), an unknown terminology is encountered
      * Since Archie does not validate external terminologies at all, this currently means all terminologies with id "local",
      * including "openehr" until that is implemented.
      * Sets this globally for the entire JVM!

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -288,7 +288,7 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
             Locatable locatable = (Locatable) createdObject;
             locatable.setArchetypeNodeId(constraint.getNodeId());
             locatable.setNameAsString(constraint.getMeaning());
-            if(constraint != null && constraint instanceof CArchetypeRoot) {
+            if(constraint instanceof CArchetypeRoot) {
                 CArchetypeRoot root = (CArchetypeRoot) constraint;
                 if(root.getArchetypeRef() != null) {
                     Archetyped details = new Archetyped();

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -79,6 +79,8 @@ import java.util.Map;
  */
 public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
 
+    public static final String RM_VERSION = "1.1.0";
+
     private static ArchieRMInfoLookup instance;
 
     private ArchieRMInfoLookup() {
@@ -291,7 +293,7 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
                 if(root.getArchetypeRef() != null) {
                     Archetyped details = new Archetyped();
                     details.setArchetypeId(new ArchetypeID(root.getArchetypeRef()));
-                    details.setRmVersion("1.1.0");
+                    details.setRmVersion(RM_VERSION);
                     locatable.setArchetypeDetails(details);
                 }
             }

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -1,12 +1,7 @@
 package com.nedap.archie.rminfo;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.ArchetypeHRID;
-import com.nedap.archie.aom.AuthoredResource;
-import com.nedap.archie.aom.CObject;
-import com.nedap.archie.aom.CPrimitiveObject;
-import com.nedap.archie.aom.TranslationDetails;
+import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.primitives.CBoolean;
 import com.nedap.archie.aom.primitives.CDate;
 import com.nedap.archie.aom.primitives.CDateTime;
@@ -291,6 +286,14 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
             Locatable locatable = (Locatable) createdObject;
             locatable.setArchetypeNodeId(constraint.getNodeId());
             locatable.setNameAsString(constraint.getMeaning());
+            if(constraint != null && constraint instanceof CArchetypeRoot) {
+                CArchetypeRoot root = (CArchetypeRoot) constraint;
+                if(root.getArchetypeRef() != null) {
+                    Archetyped details = new Archetyped();
+                    details.setArchetypeId(new ArchetypeID(root.getArchetypeRef()));
+                    locatable.setArchetypeDetails(details);
+                }
+            }
         }
     }
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/ArchieRMInfoLookup.java
@@ -291,6 +291,7 @@ public class ArchieRMInfoLookup extends ReflectionModelInfoLookup {
                 if(root.getArchetypeRef() != null) {
                     Archetyped details = new Archetyped();
                     details.setArchetypeId(new ArchetypeID(root.getArchetypeRef()));
+                    details.setRmVersion("1.1.0");
                     locatable.setArchetypeDetails(details);
                 }
             }

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rminfo;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.nedap.archie.ArchieLanguageConfiguration;
 import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
@@ -85,6 +86,10 @@ public class UpdatedValueHandler {
                 }
             }
         }
+        if(ordinal.getSymbol() != null && ordinal.getSymbol().getDefiningCode() != null) {
+            //also fix the DvCodedText inside the DvOrdinal
+            result.putAll(fixDvCodedText(rmObject, archetype, pathOfParent));
+        }
 
         return result;
     }
@@ -133,6 +138,12 @@ public class UpdatedValueHandler {
             codedText.setValue(value);
             result.put(path + "/value", value);
         }
+        if(codedText.getDefiningCode() != null &&  (codedText.getDefiningCode().getTerminologyId() == null || Strings.isNullOrEmpty(codedText.getDefiningCode().getTerminologyId().getValue()))) {
+            //TODO: only if at-code?
+            codedText.getDefiningCode().setTerminologyId(new TerminologyId("local"));
+            result.put(path + "/defining_code/terminology_id/value", "local");
+        }
+
         return result;
     }
 
@@ -145,8 +156,8 @@ public class UpdatedValueHandler {
                 if(child instanceof CTerminologyCode) {
                     String value = ((CTerminologyCode) child).getConstraint().get(0);
                     if(value.startsWith("ac")) {
-                        codedText.getDefiningCode().setTerminologyId(new TerminologyId(value));
-                        result.put(path + "/defining_code/terminology_id/value", value);
+                        codedText.getDefiningCode().setTerminologyId(new TerminologyId("local"));
+                        result.put(path + "/defining_code/terminology_id/value", "local");
                     }
                 }
             }

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
@@ -107,7 +107,7 @@ public class UpdatedValueHandler {
             OperationalTemplate template = (OperationalTemplate) archetype;
 
             String archetypePath = convertRMObjectPathToArchetypePath(pathOfParent);
-            result.putAll(setTerminologyFromArchetype(archetype, codedText, archetypePath, path));
+            //result.putAll(setTerminologyFromArchetype(archetype, codedText, archetypePath, path));
 
             ArchetypeTerm termDefinition = getTermDefinition(template, details, codedText);
             result.putAll(setDvCodedTextValue(codedText, termDefinition, path));

--- a/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rminfo/UpdatedValueHandler.java
@@ -7,6 +7,7 @@ import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.primitives.CTerminologyCode;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
+import com.nedap.archie.aom.utils.AOMUtils;
 import com.nedap.archie.base.Interval;
 import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.query.APathQuery;
@@ -138,10 +139,12 @@ public class UpdatedValueHandler {
             codedText.setValue(value);
             result.put(path + "/value", value);
         }
-        if(codedText.getDefiningCode() != null &&  (codedText.getDefiningCode().getTerminologyId() == null || Strings.isNullOrEmpty(codedText.getDefiningCode().getTerminologyId().getValue()))) {
-            //TODO: only if at-code?
-            codedText.getDefiningCode().setTerminologyId(new TerminologyId("local"));
-            result.put(path + "/defining_code/terminology_id/value", "local");
+        if(codedText.getDefiningCode() != null &&
+                (codedText.getDefiningCode().getTerminologyId() == null || Strings.isNullOrEmpty(codedText.getDefiningCode().getTerminologyId().getValue()))) {
+            if(AOMUtils.isValueCode(codedText.getDefiningCode().getCodeString())) {
+                codedText.getDefiningCode().setTerminologyId(new TerminologyId("local"));
+                result.put(path + "/defining_code/terminology_id/value", "local");
+            }
         }
 
         return result;

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
@@ -74,7 +74,7 @@ public class AssertionsFixer {
                     creator.set(parent, lastPathSegment, Lists.newArrayList(value.getValue()));
                 }
 
-                result = modelInfoLookup.pathHasBeenUpdated(ruleEvaluation.getRMRoot(), archetype, pathOfParent, parent);
+                result.putAll(modelInfoLookup.pathHasBeenUpdated(ruleEvaluation.getRMRoot(), archetype, pathOfParent, parent));
                 ruleEvaluation.refreshQueryContext();
             }
         }

--- a/tools/src/test/java/com/nedap/archie/creation/RMObjectCreatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/creation/RMObjectCreatorTest.java
@@ -1,11 +1,11 @@
 package com.nedap.archie.creation;
 
 import com.google.common.collect.Lists;
-import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.AuthoredArchetype;
-import com.nedap.archie.aom.CComplexObject;
+import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.terminology.ArchetypeTerm;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
+import com.nedap.archie.rm.archetyped.Archetyped;
+import com.nedap.archie.rm.composition.Observation;
 import com.nedap.archie.rm.datastructures.Cluster;
 import com.nedap.archie.rm.datastructures.Element;
 import com.nedap.archie.rm.datavalues.DvBoolean;
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.util.LinkedHashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Created by pieter.bos on 10/05/2017.
@@ -41,6 +42,32 @@ public class RMObjectCreatorTest {
         Element e = (Element) o;
         assertEquals("text", e.getName().getValue());
         assertEquals("id6", e.getArchetypeNodeId());
+    }
+
+    @Test
+    public void createdArchetypedObject() {
+        OperationalTemplate archetype = new OperationalTemplate();
+        archetype.setTerminology(new ArchetypeTerminology());
+        LinkedHashMap<String, ArchetypeTerm> termDefinitions = new LinkedHashMap<>();
+        termDefinitions.put("id6", new ArchetypeTerm("id6", "text", "description"));
+        archetype.getTerminology().getTermDefinitions().put("en", termDefinitions);
+
+        CArchetypeRoot elementConstraint = new CArchetypeRoot();
+        elementConstraint.setRmTypeName("OBSERVATION");
+        elementConstraint.setNodeId("id6");
+        elementConstraint.setArchetypeRef("openEHR-EHR-OBSERVATION.test.v1.0.0");
+
+        archetype.setDefinition(elementConstraint);
+
+        Object o = creator.create(elementConstraint);
+        assertEquals(Observation.class, o.getClass());
+        Observation e = (Observation) o;
+
+        assertEquals("id6", e.getArchetypeNodeId());
+        Archetyped archetypeDetails = e.getArchetypeDetails();
+        assertNotNull(archetypeDetails);
+        assertEquals("openEHR-EHR-OBSERVATION.test.v1.0.0", archetypeDetails.getArchetypeId().getValue());
+        assertEquals("1.1.0", archetypeDetails.getRmVersion());
     }
 
     @Test(expected=IllegalArgumentException.class)

--- a/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
@@ -1,0 +1,5 @@
+package com.nedap.archie.json.flat;
+
+public class ArchetypeParsePostProcessorTest
+{
+}

--- a/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
@@ -13,8 +13,7 @@ import static org.junit.Assert.assertNotNull;
 public class ArchetypeParsePostProcessorTest {
     @Test
     public void setTupleParents() throws Exception {
-        RMJacksonConfiguration config = RMJacksonConfiguration.createStandardsCompliant();
-        config.setTypePropertyName("@type");
+        RMJacksonConfiguration config = RMJacksonConfiguration.createConfigForJavascriptUsage();
         try(InputStream stream = getClass().getResourceAsStream("/com/nedap/archie/json/snaq_rc_opt.js")) {
             OperationalTemplate template = JacksonUtil.getObjectMapper(config).readValue(stream, OperationalTemplate.class);
             ArchetypeParsePostProcesser.fixArchetype(template);

--- a/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
@@ -1,5 +1,34 @@
 package com.nedap.archie.json.flat;
 
-public class ArchetypeParsePostProcessorTest
-{
+import com.nedap.archie.aom.*;
+import com.nedap.archie.aom.utils.ArchetypeParsePostProcesser;
+import com.nedap.archie.json.JacksonUtil;
+import com.nedap.archie.json.RMJacksonConfiguration;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ArchetypeParsePostProcessorTest {
+    @Test
+    public void optProcessorTest() throws Exception {
+        RMJacksonConfiguration config = RMJacksonConfiguration.createStandardsCompliant();
+        config.setTypePropertyName("@type");
+        try(InputStream stream = getClass().getResourceAsStream("/com/nedap/archie/json/snaq_rc_opt.js")) {
+            OperationalTemplate template = JacksonUtil.getObjectMapper(config).readValue(stream, OperationalTemplate.class);
+            ArchetypeParsePostProcesser.fixArchetype(template);
+            CComplexObject dvOrdinal = template.itemAtPath("/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]");
+            CAttributeTuple tuple = dvOrdinal.getAttributeTuples().get(0);
+            for(CAttribute tupleMember:tuple.getMembers()) {
+                assertNotNull(tupleMember.getArchetype());
+            }
+            for(CPrimitiveTuple primitiveTuple:tuple.getTuples()) {
+                for(CPrimitiveObject primitiveObject:primitiveTuple.getMembers()) {
+                    assertNotNull(primitiveObject.getArchetype());
+                }
+            }
+        }
+    }
+
 }

--- a/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/ArchetypeParsePostProcessorTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class ArchetypeParsePostProcessorTest {
     @Test
-    public void optProcessorTest() throws Exception {
+    public void setTupleParents() throws Exception {
         RMJacksonConfiguration config = RMJacksonConfiguration.createStandardsCompliant();
         config.setTypePropertyName("@type");
         try(InputStream stream = getClass().getResourceAsStream("/com/nedap/archie/json/snaq_rc_opt.js")) {

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -13,6 +13,7 @@ import com.nedap.archie.xml.JAXBUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -32,7 +33,7 @@ public class FixableAssertionsCheckerTest {
     public void setup() {
         testUtil = new TestUtil();
         rmObjectCreator = new RMObjectCreator(ArchieRMInfoLookup.getInstance());
-        parser = new ADLParser(new RMConstraintImposer());
+        parser = new ADLParser(BuiltinReferenceModels.getMetaModels());
         ArchieLanguageConfiguration.setThreadLocalLogicalPathLanguage("en");
         ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("en");
     }
@@ -44,30 +45,36 @@ public class FixableAssertionsCheckerTest {
     }
 
     @Test
-    public void fixableMatches() throws Exception {
+    public void fixableMatche   s() throws Exception {
         archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("fixable_matches.adls"));
         RuleEvaluation<Locatable> ruleEvaluation = getRuleEvaluation();
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("There are seven values that must be set", 7, evaluate.getSetPathValues().size());
+        assertEquals("There are ten values that must be set", 10, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
         assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string").getValue());
+        assertEquals("local", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/terminology_id/value").getValue());
         assertEquals("Option 1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/value").getValue());
         assertEquals("at6", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string").getValue());
+        assertEquals("local", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/terminology_id/value").getValue());
         assertEquals(0l, evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/value").getValue());
         assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/code_string").getValue());
+        assertEquals("local", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/terminology_id/value").getValue());
         assertEquals("Option 1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/value").getValue());
 
         //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
         assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
         assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string"));
+        assertEquals("local", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/terminology_id/value"));
         assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/value"));
         assertEquals("at6", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string"));
+        assertEquals("local", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/terminology_id/value"));
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
         assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/code_string"));
+        assertEquals("local", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/terminology_id/value"));
         assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/value"));
 
         //and of course the DV_ORDINAL and DV_CODED_TEXT should be constructed correctly, with the correct numeric respectively a textual value
@@ -90,19 +97,24 @@ public class FixableAssertionsCheckerTest {
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("There are four values that must be set", 4, evaluate.getSetPathValues().size());
+        assertEquals("There are five values that must be set", 7, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
         assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string").getValue());
+        assertEquals("Option 1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/value").getValue());
+        assertEquals("local", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/terminology_id/value").getValue());
         assertEquals("at6", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string").getValue());
+        assertEquals("local", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/terminology_id/value").getValue());
         assertEquals(0l, evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/value").getValue());
 
 
         //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
         assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
         assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code/code_string"));
+        assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id6]/value/value"));
         assertEquals("at6", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/code_string"));
+        assertEquals("local", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol/defining_code/terminology_id/value"));
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));
 
 

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -97,7 +97,7 @@ public class FixableAssertionsCheckerTest {
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("There are five values that must be set", 7, evaluate.getSetPathValues().size());
+        assertEquals("There are seven values that must be set", 7, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -45,7 +45,7 @@ public class FixableAssertionsCheckerTest {
     }
 
     @Test
-    public void fixableMatche   s() throws Exception {
+    public void fixableMatches() throws Exception {
         archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("fixable_matches.adls"));
         RuleEvaluation<Locatable> ruleEvaluation = getRuleEvaluation();
 

--- a/tools/src/test/resources/com/nedap/archie/json/snaq_rc_opt.js
+++ b/tools/src/test/resources/com/nedap/archie/json/snaq_rc_opt.js
@@ -1,0 +1,8497 @@
+{
+  "@type": "OPERATIONAL_TEMPLATE",
+  "adl_version": "2.0.5",
+  "archetype_id": {
+    "@type": "ARCHETYPE_HRID",
+    "build_count": "",
+    "concept_id": "snaq_rc_report",
+    "release_version": "1.0.0",
+    "rm_class": "COMPOSITION",
+    "rm_package": "EHR",
+    "version_status": "",
+    "full_id": "openEHR-EHR-COMPOSITION.snaq_rc_report.v1.0.0",
+    "id_up_to_concept": "openEHR-EHR-COMPOSITION.snaq_rc_report",
+    "major_version": "1",
+    "minor_version": "0",
+    "patch_version": "0",
+    "rm_publisher": "openEHR",
+    "semantic_id": "openEHR-EHR-COMPOSITION.snaq_rc_report.v1"
+  },
+  "component_terminologies": {
+    "openEHR-EHR-ELEMENT.weight.v1.0.0": {
+      "@type": "ARCHETYPE_TERMINOLOGY",
+      "concept_code": "id1",
+      "original_language": "nl",
+      "term_bindings": {
+
+      },
+      "term_definitions": {
+        "nl": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "code": "id1",
+            "description": "Gewicht",
+            "text": "Gewicht"
+          },
+          "openEHR-EHR-ELEMENT.weight.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "code": "id1",
+            "description": "Gewicht",
+            "text": "Gewicht"
+          }
+        }
+      },
+      "terminology_extracts": {
+
+      },
+      "value_sets": {
+
+      }
+    },
+    "openEHR-EHR-OBSERVATION.snaq_rc.v1.0.0": {
+      "@type": "ARCHETYPE_TERMINOLOGY",
+      "concept_code": "id1",
+      "original_language": "nl",
+      "term_bindings": {
+
+      },
+      "term_definitions": {
+        "nl": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
+            "text": "SNAQ RC"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Any event",
+            "text": "Any event"
+          },
+          "id10": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Bent u onbedoeld afgevallen?",
+            "text": "Bent u onbedoeld afgevallen?"
+          },
+          "id11": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Hebt u hulp van een ander nodig bij het eten?",
+            "text": "Hebt u hulp van een ander nodig bij het eten?"
+          },
+          "id12": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Had u de afgelopen maand een verminderde eetlust?",
+            "text": "Had u de afgelopen maand een verminderde eetlust?"
+          },
+          "id13": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Bereken de Body Mass Index (BMI)",
+            "text": "BMI"
+          },
+          "id14": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "De betekenis van de BMI-score",
+            "text": "Betekenis BMI"
+          },
+          "id15": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Totaalscore",
+            "text": "Totaalscore"
+          },
+          "id16": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Acties",
+            "text": "Acties"
+          },
+          "ac1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Bent u onbedoeld afgevallen?",
+            "text": "Bent u onbedoeld afgevallen?"
+          },
+          "ac2": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Risico op ondervoeding",
+            "text": "Risico op ondervoeding"
+          },
+          "ac3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Acties",
+            "text": "Acties"
+          },
+          "at1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "> 6 kg in de laatste 6 maanden",
+            "text": "> 6 kg in de laatste 6 maanden"
+          },
+          "at2": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "> 3 kg in de afgelopen maand",
+            "text": "> 3 kg in de afgelopen maand"
+          },
+          "at3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "nee",
+            "text": "nee"
+          },
+          "at4": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "ja",
+            "text": "ja"
+          },
+          "at5": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "nee",
+            "text": "nee"
+          },
+          "at6": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "BMI beneden 20",
+            "text": "< 20"
+          },
+          "at7": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "BMI van 20 tot 22",
+            "text": "20 - 22"
+          },
+          "at8": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "BMI van 22 tot 28",
+            "text": "22 - 28"
+          },
+          "at9": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "BMI boven 28 is overgewicht",
+            "text": "> 28 (overgewicht)"
+          },
+          "at10": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Niet ondervoed",
+            "text": "Niet ondervoed"
+          },
+          "at11": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Risico op ondervoeding",
+            "text": "Risico op ondervoeding"
+          },
+          "at12": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Ondervoed",
+            "text": "Ondervoed"
+          },
+          "at13": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Geen actie",
+            "text": "Geen actie"
+          },
+          "at14": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "- 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname",
+            "text": "• 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname"
+          },
+          "at15": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie",
+            "text": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie"
+          },
+          "id29": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Lengte",
+            "text": "Lengte"
+          },
+          "id33": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Lengte",
+            "text": "Lengte"
+          },
+          "id30": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Gewicht",
+            "text": "Gewicht"
+          },
+          "openEHR-EHR-OBSERVATION.snaq_rc.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
+            "text": "SNAQ RC"
+          }
+        }
+      },
+      "terminology_extracts": {
+
+      },
+      "value_sets": {
+        "ac1": {
+          "@type": "VALUE_SET",
+          "id": "ac1",
+          "members": [
+            "at1",
+            "at2",
+            "at3"
+          ]
+        },
+        "ac2": {
+          "@type": "VALUE_SET",
+          "id": "ac2",
+          "members": [
+            "at10",
+            "at11",
+            "at12"
+          ]
+        },
+        "ac3": {
+          "@type": "VALUE_SET",
+          "id": "ac3",
+          "members": [
+            "at13",
+            "at14",
+            "at15"
+          ]
+        }
+      }
+    },
+    "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+      "@type": "ARCHETYPE_TERMINOLOGY",
+      "concept_code": "id1.1",
+      "differential": false,
+      "original_language": "en",
+      "term_bindings": {
+
+      },
+      "term_definitions": {
+        "en": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Narrative summary or overview about a patient, specifically from the perspective of a healthcare provider, and with or without associated interpretations.",
+            "text": "Clinical Synopsis"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "The summary, assessment, conclusions or evaluation of the clinical findings.",
+            "text": "Synopsis"
+          },
+          "id3.1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Assessment or remarks about the clinical finding",
+            "text": "Assessment / remarks"
+          },
+          "id1.1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Describe an assessment or remarks for a clinical finding. This can for example be a more detailed interpretation of\n    \t\t\t\ta finding, or the meaning of a finding for a patiënt.",
+            "text": "Assessment / remarks"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Describe an assessment or remarks for a clinical finding. This can for example be a more detailed interpretation of\n    \t\t\t\ta finding, or the meaning of a finding for a patiënt.",
+            "text": "Assessment / remarks"
+          }
+        },
+        "fa": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "خلاصه یا مروری تشریحی دربازه بیمار بویژه از نظز ارایه کننده مراقبت بهداشتی با یا بدون تفسیرهای مربوطه ",
+            "text": "خلاصه بالینی"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "خلاصه ، ارزیابی ، نتیجه ، یا ارزشیابی یافته های بالینی",
+            "text": "خلاصه"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "خلاصه یا مروری تشریحی دربازه بیمار بویژه از نظز ارایه کننده مراقبت بهداشتی با یا بدون تفسیرهای مربوطه ",
+            "text": "خلاصه بالینی"
+          }
+        },
+        "ar-sy": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "ملخص بالرواية أو نظرة عامة عن المريض, خاصة من وجهة نظر مقدم الخدمة الصحية, مع إرفاق أو عدم إرفاق تفسيرات ",
+            "text": "المختصر السريري"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "الملخص, التقييم, الاستنتاجات أو التقييم للموجودات السريرية",
+            "text": "المختصر"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "ملخص بالرواية أو نظرة عامة عن المريض, خاصة من وجهة نظر مقدم الخدمة الصحية, مع إرفاق أو عدم إرفاق تفسيرات ",
+            "text": "المختصر السريري"
+          }
+        },
+        "de": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Zusammenfassung oder Übersicht einer Patientengeschichte, speziell aus der Sicht eines Gesundheitsdienstleisters, evtl. mit dazugehörigen Interpretationen.",
+            "text": "Klinische Synopsis"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Die Zusammenfassung, Beurteilung, Aussagen or Auswertung des klinischen Befunds.",
+            "text": "Synopsis"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Zusammenfassung oder Übersicht einer Patientengeschichte, speziell aus der Sicht eines Gesundheitsdienstleisters, evtl. mit dazugehörigen Interpretationen.",
+            "text": "Klinische Synopsis"
+          }
+        },
+        "es-ar": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Sumario narrativo o visión global acerca de un paciente, específicamente desde la perspectiva de un profesional del cuidado de la salud, con o sin interpretaciones asociadas.",
+            "text": "Sinopsis Clínica"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "El sumario, la impresión diagnóstica y las conclusiones sobre los hallazgos clínicos.",
+            "text": "Sinopsis"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Sumario narrativo o visión global acerca de un paciente, específicamente desde la perspectiva de un profesional del cuidado de la salud, con o sin interpretaciones asociadas.",
+            "text": "Sinopsis Clínica"
+          }
+        },
+        "pt-br": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Resumo narrativo ou visão geral sobre um paciente, especificamente a partir da perspectiva de um profissional de saúde, e com ou sem interpretações associadas.",
+            "text": "Sinopse Clínica"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": " O sumário, a avaliação, conclusões ou avaliação dos achados clínicos.",
+            "text": "Sinopse"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Resumo narrativo ou visão geral sobre um paciente, especificamente a partir da perspectiva de um profissional de saúde, e com ou sem interpretações associadas.",
+            "text": "Sinopse Clínica"
+          }
+        },
+        "zh-cn": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "从医疗保健服务提供着的角度，手工综合并记录关于患者的叙述型摘要或概述，且带有或没有相关联的解释。",
+            "text": "临床提要"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "对于临床所见（临床发现）进行的概括、评估、总结或评价。",
+            "text": "提要"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "从医疗保健服务提供着的角度，手工综合并记录关于患者的叙述型摘要或概述，且带有或没有相关联的解释。",
+            "text": "临床提要"
+          }
+        },
+        "nl": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Samenvatting, beoordeling, conclusies of evaluaties bij de meting.",
+            "text": "Klinische Synopsis"
+          },
+          "id3": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "De samenvatting, beoordeling, conclusies of evaluaties van de bevindingen.",
+            "text": "Synopsis"
+          },
+          "id3.1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Beoordeling van de meting of opmerkingen over de meting",
+            "text": "Beoordeling / opmerkingen"
+          },
+          "id1.1": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
+            "text": "Beoordeling / opmerkingen"
+          },
+          "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
+            "text": "Beoordeling / opmerkingen"
+          }
+        }
+      },
+      "terminology_extracts": {
+
+      },
+      "value_sets": {
+
+      }
+    },
+    "openEHR-EHR-ELEMENT.height.v1.0.0": {
+      "@type": "ARCHETYPE_TERMINOLOGY",
+      "concept_code": "id1",
+      "original_language": "nl",
+      "term_bindings": {
+
+      },
+      "term_definitions": {
+        "nl": {
+          "id1": {
+            "@type": "ARCHETYPE_TERM",
+            "code": "id1",
+            "description": "Lengte",
+            "text": "Lengte"
+          },
+          "openEHR-EHR-ELEMENT.height.v1.0.0": {
+            "@type": "ARCHETYPE_TERM",
+            "code": "id1",
+            "description": "Lengte",
+            "text": "Lengte"
+          }
+        }
+      },
+      "terminology_extracts": {
+
+      },
+      "value_sets": {
+
+      }
+    }
+  },
+  "definition": {
+    "@type": "C_COMPLEX_OBJECT",
+    "rm_type_name": "COMPOSITION",
+    "node_id": "id1.1.1.1",
+    "path": "/",
+    "logical_path": "/",
+    "term": {
+      "@type": "ARCHETYPE_TERM",
+      "description": "SNAQ RC",
+      "text": "SNAQ RC"
+    },
+    "required": false,
+    "allowed": true,
+    "any_allowed": false,
+    "attributes": [
+      {
+        "@type": "C_ATTRIBUTE",
+        "rm_attribute_name": "category",
+        "path": "/category",
+        "logical_path": "/category",
+        "multiple": false,
+        "mandatory": true,
+        "existence": {
+          "@type": "MULTIPLICITY_INTERVAL",
+          "lower": 1,
+          "lower_included": true,
+          "lower_unbounded": false,
+          "mandatory": true,
+          "open": false,
+          "optional": false,
+          "prohibited": false,
+          "upper": 1,
+          "upper_included": true,
+          "upper_unbounded": false
+        },
+        "children": [
+          {
+            "@type": "C_COMPLEX_OBJECT",
+            "rm_type_name": "DV_CODED_TEXT",
+            "node_id": "id8",
+            "path": "/category[id8]",
+            "logical_path": "/category[id8]",
+            "required": false,
+            "allowed": true,
+            "any_allowed": false,
+            "attributes": [
+              {
+                "@type": "C_ATTRIBUTE",
+                "rm_attribute_name": "defining_code",
+                "path": "/category[id8]/defining_code",
+                "logical_path": "/category[id8]/defining_code",
+                "multiple": false,
+                "mandatory": true,
+                "existence": {
+                  "@type": "MULTIPLICITY_INTERVAL",
+                  "lower": 1,
+                  "lower_included": true,
+                  "lower_unbounded": false,
+                  "mandatory": true,
+                  "open": false,
+                  "optional": false,
+                  "prohibited": false,
+                  "upper": 1,
+                  "upper_included": true,
+                  "upper_unbounded": false
+                },
+                "children": [
+                  {
+                    "@type": "C_TERMINOLOGY_CODE",
+                    "allowed": true,
+                    "attributes": [
+
+                    ],
+                    "constraint": [
+                      "at1"
+                    ],
+                    "logical_path": "/category[id8]/defining_code",
+                    "node_id": "id9999",
+                    "path": "/category[id8]/defining_code",
+                    "prohibited": false,
+                    "required": false,
+                    "rm_type_name": "terminology_code",
+                    "terms": [
+                      {
+                        "code": "at1",
+                        "term": {
+                          "@type": "ARCHETYPE_TERM",
+                          "description": "event",
+                          "text": "event"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "prohibited": false
+              }
+            ],
+            "attribute_tuples": [
+
+            ],
+            "prohibited": false
+          }
+        ],
+        "prohibited": false
+      },
+      {
+        "@type": "C_ATTRIBUTE",
+        "rm_attribute_name": "context",
+        "path": "/context",
+        "logical_path": "/context",
+        "multiple": false,
+        "mandatory": false,
+        "existence": {
+          "@type": "MULTIPLICITY_INTERVAL",
+          "lower": 0,
+          "lower_included": true,
+          "lower_unbounded": false,
+          "mandatory": false,
+          "open": false,
+          "optional": true,
+          "prohibited": false,
+          "upper": 1,
+          "upper_included": true,
+          "upper_unbounded": false
+        },
+        "children": [
+          {
+            "@type": "C_COMPLEX_OBJECT",
+            "rm_type_name": "EVENT_CONTEXT",
+            "node_id": "id9",
+            "path": "/context[id9]",
+            "logical_path": "/context[id9]",
+            "required": false,
+            "allowed": true,
+            "any_allowed": false,
+            "attributes": [
+              {
+                "@type": "C_ATTRIBUTE",
+                "rm_attribute_name": "other_context",
+                "path": "/context[id9]/other_context",
+                "logical_path": "/context[id9]/other_context",
+                "multiple": false,
+                "mandatory": false,
+                "existence": {
+                  "@type": "MULTIPLICITY_INTERVAL",
+                  "lower": 0,
+                  "lower_included": true,
+                  "lower_unbounded": false,
+                  "mandatory": false,
+                  "open": false,
+                  "optional": true,
+                  "prohibited": false,
+                  "upper": 1,
+                  "upper_included": true,
+                  "upper_unbounded": false
+                },
+                "children": [
+                  {
+                    "@type": "C_COMPLEX_OBJECT",
+                    "rm_type_name": "ITEM_TREE",
+                    "node_id": "id2",
+                    "path": "/context[id9]/other_context[id2]",
+                    "logical_path": "/context[id9]/other_context[id2]",
+                    "required": false,
+                    "allowed": true,
+                    "any_allowed": false,
+                    "attributes": [
+                      {
+                        "@type": "C_ATTRIBUTE",
+                        "rm_attribute_name": "items",
+                        "path": "/context[id9]/other_context[id2]/items",
+                        "logical_path": "/context[id9]/other_context[id2]/items",
+                        "multiple": true,
+                        "mandatory": false,
+                        "existence": {
+                          "@type": "MULTIPLICITY_INTERVAL",
+                          "lower": 0,
+                          "lower_included": true,
+                          "lower_unbounded": false,
+                          "mandatory": false,
+                          "open": false,
+                          "optional": true,
+                          "prohibited": false,
+                          "upper": 1,
+                          "upper_included": true,
+                          "upper_unbounded": false
+                        },
+                        "cardinality": {
+                          "@type": "CARDINALITY",
+                          "interval": {
+                            "@type": "MULTIPLICITY_INTERVAL",
+                            "lower": 0,
+                            "lower_included": true,
+                            "lower_unbounded": false,
+                            "mandatory": false,
+                            "open": true,
+                            "optional": false,
+                            "prohibited": false,
+                            "upper_included": true,
+                            "upper_unbounded": true
+                          },
+                          "ordered": true,
+                          "unique": false
+                        },
+                        "children": [
+                          {
+                            "@type": "C_COMPLEX_OBJECT",
+                            "rm_type_name": "ELEMENT",
+                            "node_id": "id3",
+                            "path": "/context[id9]/other_context[id2]/items[id3]",
+                            "logical_path": "/context[id9]/other_context[id2]/items[Report ID]",
+                            "term": {
+                              "@type": "ARCHETYPE_TERM",
+                              "description": "Identificerende informatie over deze rapportage",
+                              "text": "Rapportage ID"
+                            },
+                            "required": false,
+                            "allowed": true,
+                            "any_allowed": false,
+                            "occurrences": {
+                              "@type": "MULTIPLICITY_INTERVAL",
+                              "lower": 0,
+                              "lower_included": true,
+                              "lower_unbounded": false,
+                              "mandatory": false,
+                              "open": false,
+                              "optional": true,
+                              "prohibited": false,
+                              "upper": 1,
+                              "upper_included": true,
+                              "upper_unbounded": false
+                            },
+                            "attributes": [
+                              {
+                                "@type": "C_ATTRIBUTE",
+                                "rm_attribute_name": "value",
+                                "path": "/context[id9]/other_context[id2]/items[id3]/value",
+                                "logical_path": "/context[id9]/other_context[id2]/items[Report ID]/value",
+                                "multiple": false,
+                                "mandatory": false,
+                                "existence": {
+                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "lower": 0,
+                                  "lower_included": true,
+                                  "lower_unbounded": false,
+                                  "mandatory": false,
+                                  "open": false,
+                                  "optional": true,
+                                  "prohibited": false,
+                                  "upper": 1,
+                                  "upper_included": true,
+                                  "upper_unbounded": false
+                                },
+                                "children": [
+                                  {
+                                    "@type": "C_COMPLEX_OBJECT",
+                                    "rm_type_name": "DV_TEXT",
+                                    "node_id": "id10",
+                                    "path": "/context[id9]/other_context[id2]/items[id3]/value[id10]",
+                                    "logical_path": "/context[id9]/other_context[id2]/items[Report ID]/value[id10]",
+                                    "required": false,
+                                    "allowed": true,
+                                    "any_allowed": true,
+                                    "attributes": [
+
+                                    ],
+                                    "attribute_tuples": [
+
+                                    ],
+                                    "prohibited": false
+                                  }
+                                ],
+                                "prohibited": false
+                              }
+                            ],
+                            "attribute_tuples": [
+
+                            ],
+                            "prohibited": false
+                          },
+                          {
+                            "@type": "C_COMPLEX_OBJECT",
+                            "rm_type_name": "ELEMENT",
+                            "node_id": "id6",
+                            "path": "/context[id9]/other_context[id2]/items[id6]",
+                            "logical_path": "/context[id9]/other_context[id2]/items[Status]",
+                            "term": {
+                              "@type": "ARCHETYPE_TERM",
+                              "description": "De status van de rapportage. Let op, dit is niet de status van een van de onderdelen van de rappotage",
+                              "text": "Status"
+                            },
+                            "required": false,
+                            "allowed": true,
+                            "any_allowed": false,
+                            "occurrences": {
+                              "@type": "MULTIPLICITY_INTERVAL",
+                              "lower": 0,
+                              "lower_included": true,
+                              "lower_unbounded": false,
+                              "mandatory": false,
+                              "open": false,
+                              "optional": true,
+                              "prohibited": false,
+                              "upper": 1,
+                              "upper_included": true,
+                              "upper_unbounded": false
+                            },
+                            "attributes": [
+                              {
+                                "@type": "C_ATTRIBUTE",
+                                "rm_attribute_name": "value",
+                                "path": "/context[id9]/other_context[id2]/items[id6]/value",
+                                "logical_path": "/context[id9]/other_context[id2]/items[Status]/value",
+                                "multiple": false,
+                                "mandatory": false,
+                                "existence": {
+                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "lower": 0,
+                                  "lower_included": true,
+                                  "lower_unbounded": false,
+                                  "mandatory": false,
+                                  "open": false,
+                                  "optional": true,
+                                  "prohibited": false,
+                                  "upper": 1,
+                                  "upper_included": true,
+                                  "upper_unbounded": false
+                                },
+                                "children": [
+                                  {
+                                    "@type": "C_COMPLEX_OBJECT",
+                                    "rm_type_name": "DV_TEXT",
+                                    "node_id": "id11",
+                                    "path": "/context[id9]/other_context[id2]/items[id6]/value[id11]",
+                                    "logical_path": "/context[id9]/other_context[id2]/items[Status]/value[id11]",
+                                    "required": false,
+                                    "allowed": true,
+                                    "any_allowed": true,
+                                    "attributes": [
+
+                                    ],
+                                    "attribute_tuples": [
+
+                                    ],
+                                    "prohibited": false
+                                  }
+                                ],
+                                "prohibited": false
+                              }
+                            ],
+                            "attribute_tuples": [
+
+                            ],
+                            "prohibited": false
+                          },
+                          {
+                            "@type": "ARCHETYPE_SLOT",
+                            "allowed": true,
+                            "attributes": [
+
+                            ],
+                            "closed": false,
+                            "excludes": [
+
+                            ],
+                            "includes": [
+                              {
+                                "@type": "ASSERTION",
+                                "expression": {
+                                  "@type": "BINARY_OPERATOR",
+                                  "left_operand": {
+                                    "@type": "MODEL_REFERENCE",
+                                    "path": "archetype_id/value",
+                                    "precedence_overridden": false
+                                  },
+                                  "operator": "matches",
+                                  "precedence_overridden": false,
+                                  "right_operand": {
+                                    "@type": "CONSTRAINT",
+                                    "item": {
+                                      "@type": "C_STRING",
+                                      "allowed": true,
+                                      "attributes": [
+
+                                      ],
+                                      "constraint": [
+                                        "/.*/"
+                                      ],
+                                      "logical_path": "/",
+                                      "node_id": "id9999",
+                                      "path": "/",
+                                      "prohibited": false,
+                                      "required": false,
+                                      "rm_type_name": "string"
+                                    },
+                                    "precedence_overridden": false
+                                  },
+                                  "type": "BOOLEAN",
+                                  "unary": false
+                                },
+                                "string_expression": "archetype_id/valuematches{/.*/}",
+                                "variables": [
+
+                                ]
+                              }
+                            ],
+                            "logical_path": "/context[id9]/other_context[id2]/items[Extension]",
+                            "node_id": "id7",
+                            "occurrences": {
+                              "@type": "MULTIPLICITY_INTERVAL",
+                              "lower": 0,
+                              "lower_included": true,
+                              "lower_unbounded": false,
+                              "mandatory": false,
+                              "open": true,
+                              "optional": false,
+                              "prohibited": false,
+                              "upper_included": false,
+                              "upper_unbounded": true
+                            },
+                            "path": "/context[id9]/other_context[id2]/items[id7]",
+                            "prohibited": false,
+                            "required": false,
+                            "rm_type_name": "CLUSTER",
+                            "term": {
+                              "@type": "ARCHETYPE_TERM",
+                              "description": "Extra informatie nodig om de context te beschrijven of te voldoen met andere modellen of formalismes.",
+                              "text": "Uitbreiding"
+                            }
+                          }
+                        ],
+                        "prohibited": false
+                      }
+                    ],
+                    "attribute_tuples": [
+
+                    ],
+                    "prohibited": false
+                  }
+                ],
+                "prohibited": false
+              }
+            ],
+            "attribute_tuples": [
+
+            ],
+            "prohibited": false
+          }
+        ],
+        "prohibited": false
+      },
+      {
+        "@type": "C_ATTRIBUTE",
+        "rm_attribute_name": "content",
+        "path": "/content",
+        "logical_path": "/content",
+        "multiple": true,
+        "mandatory": false,
+        "existence": {
+          "@type": "MULTIPLICITY_INTERVAL",
+          "lower": 0,
+          "lower_included": true,
+          "lower_unbounded": false,
+          "mandatory": false,
+          "open": false,
+          "optional": true,
+          "prohibited": false,
+          "upper": 1,
+          "upper_included": true,
+          "upper_unbounded": false
+        },
+        "cardinality": {
+          "@type": "CARDINALITY",
+          "interval": {
+            "@type": "MULTIPLICITY_INTERVAL",
+            "lower": 0,
+            "lower_included": true,
+            "lower_unbounded": false,
+            "mandatory": false,
+            "open": true,
+            "optional": false,
+            "prohibited": false,
+            "upper_included": true,
+            "upper_unbounded": true
+          },
+          "ordered": true,
+          "unique": false
+        },
+        "children": [
+          {
+            "@type": "C_ARCHETYPE_ROOT",
+            "rm_type_name": "OBSERVATION",
+            "node_id": "id0.0.100.1",
+            "path": "/content[id0.0.100.1]",
+            "logical_path": "/content[id0.0.100.1]",
+            "term": {
+              "@type": "ARCHETYPE_TERM",
+              "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
+              "text": "SNAQ RC"
+            },
+            "required": true,
+            "allowed": true,
+            "any_allowed": false,
+            "occurrences": {
+              "@type": "MULTIPLICITY_INTERVAL",
+              "lower": 1,
+              "lower_included": true,
+              "lower_unbounded": false,
+              "mandatory": true,
+              "open": false,
+              "optional": false,
+              "prohibited": false,
+              "upper": 1,
+              "upper_included": true,
+              "upper_unbounded": false
+            },
+            "attributes": [
+              {
+                "@type": "C_ATTRIBUTE",
+                "rm_attribute_name": "data",
+                "path": "/content[id0.0.100.1]/data",
+                "logical_path": "/content[id0.0.100.1]/data",
+                "multiple": false,
+                "mandatory": true,
+                "existence": {
+                  "@type": "MULTIPLICITY_INTERVAL",
+                  "lower": 1,
+                  "lower_included": true,
+                  "lower_unbounded": false,
+                  "mandatory": true,
+                  "open": false,
+                  "optional": false,
+                  "prohibited": false,
+                  "upper": 1,
+                  "upper_included": true,
+                  "upper_unbounded": false
+                },
+                "children": [
+                  {
+                    "@type": "C_COMPLEX_OBJECT",
+                    "rm_type_name": "HISTORY",
+                    "node_id": "id2",
+                    "path": "/content[id0.0.100.1]/data[id2]",
+                    "logical_path": "/content[id0.0.100.1]/data[id2]",
+                    "required": false,
+                    "allowed": true,
+                    "any_allowed": false,
+                    "attributes": [
+                      {
+                        "@type": "C_ATTRIBUTE",
+                        "rm_attribute_name": "events",
+                        "path": "/content[id0.0.100.1]/data[id2]/events",
+                        "logical_path": "/content[id0.0.100.1]/data[id2]/events",
+                        "multiple": true,
+                        "mandatory": false,
+                        "existence": {
+                          "@type": "MULTIPLICITY_INTERVAL",
+                          "lower": 0,
+                          "lower_included": true,
+                          "lower_unbounded": false,
+                          "mandatory": false,
+                          "open": false,
+                          "optional": true,
+                          "prohibited": false,
+                          "upper": 1,
+                          "upper_included": true,
+                          "upper_unbounded": false
+                        },
+                        "cardinality": {
+                          "@type": "CARDINALITY",
+                          "interval": {
+                            "@type": "MULTIPLICITY_INTERVAL",
+                            "lower": 1,
+                            "lower_included": true,
+                            "lower_unbounded": false,
+                            "mandatory": true,
+                            "open": false,
+                            "optional": false,
+                            "prohibited": false,
+                            "upper_included": false,
+                            "upper_unbounded": true
+                          },
+                          "ordered": false,
+                          "unique": false
+                        },
+                        "children": [
+                          {
+                            "@type": "C_COMPLEX_OBJECT",
+                            "rm_type_name": "EVENT",
+                            "node_id": "id3",
+                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]",
+                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]",
+                            "term": {
+                              "@type": "ARCHETYPE_TERM",
+                              "description": "Any event",
+                              "text": "Any event"
+                            },
+                            "required": false,
+                            "allowed": true,
+                            "any_allowed": false,
+                            "attributes": [
+                              {
+                                "@type": "C_ATTRIBUTE",
+                                "rm_attribute_name": "data",
+                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data",
+                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data",
+                                "multiple": false,
+                                "mandatory": true,
+                                "existence": {
+                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "lower": 1,
+                                  "lower_included": true,
+                                  "lower_unbounded": false,
+                                  "mandatory": true,
+                                  "open": false,
+                                  "optional": false,
+                                  "prohibited": false,
+                                  "upper": 1,
+                                  "upper_included": true,
+                                  "upper_unbounded": false
+                                },
+                                "children": [
+                                  {
+                                    "@type": "C_COMPLEX_OBJECT",
+                                    "rm_type_name": "ITEM_TREE",
+                                    "node_id": "id4",
+                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]",
+                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]",
+                                    "required": true,
+                                    "allowed": true,
+                                    "any_allowed": false,
+                                    "occurrences": {
+                                      "@type": "MULTIPLICITY_INTERVAL",
+                                      "lower": 1,
+                                      "lower_included": true,
+                                      "lower_unbounded": false,
+                                      "mandatory": true,
+                                      "open": false,
+                                      "optional": false,
+                                      "prohibited": false,
+                                      "upper": 1,
+                                      "upper_included": true,
+                                      "upper_unbounded": false
+                                    },
+                                    "attributes": [
+                                      {
+                                        "@type": "C_ATTRIBUTE",
+                                        "rm_attribute_name": "items",
+                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items",
+                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items",
+                                        "multiple": true,
+                                        "mandatory": false,
+                                        "existence": {
+                                          "@type": "MULTIPLICITY_INTERVAL",
+                                          "lower": 0,
+                                          "lower_included": true,
+                                          "lower_unbounded": false,
+                                          "mandatory": false,
+                                          "open": false,
+                                          "optional": true,
+                                          "prohibited": false,
+                                          "upper": 1,
+                                          "upper_included": true,
+                                          "upper_unbounded": false
+                                        },
+                                        "cardinality": {
+                                          "@type": "CARDINALITY",
+                                          "interval": {
+                                            "@type": "MULTIPLICITY_INTERVAL",
+                                            "lower": 0,
+                                            "lower_included": true,
+                                            "lower_unbounded": false,
+                                            "mandatory": false,
+                                            "open": true,
+                                            "optional": false,
+                                            "prohibited": false,
+                                            "upper_included": true,
+                                            "upper_unbounded": true
+                                          },
+                                          "ordered": true,
+                                          "unique": false
+                                        },
+                                        "children": [
+                                          {
+                                            "@type": "C_COMPLEX_OBJECT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id10",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Bent u onbedoeld afgevallen?",
+                                              "text": "Bent u onbedoeld afgevallen?"
+                                            },
+                                            "required": true,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "occurrences": {
+                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "lower": 1,
+                                              "lower_included": true,
+                                              "lower_unbounded": false,
+                                              "mandatory": true,
+                                              "open": false,
+                                              "optional": false,
+                                              "prohibited": false,
+                                              "upper": 1,
+                                              "upper_included": true,
+                                              "upper_unbounded": false
+                                            },
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_ORDINAL",
+                                                    "node_id": "id20",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "value",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 2,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 2,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 2,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 2,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 2,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 2,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 0,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "symbol",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at1"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at1",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "> 6 kg in de laatste 6 maanden",
+                                                                  "text": "> 6 kg in de laatste 6 maanden"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at2"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at2",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "> 3 kg in de afgelopen maand",
+                                                                  "text": "> 3 kg in de afgelopen maand"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at3"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at3",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "nee",
+                                                                  "text": "nee"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "value",
+                                                          "symbol"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "value",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "symbol",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at1"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at1",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "> 6 kg in de laatste 6 maanden",
+                                                                      "text": "> 6 kg in de laatste 6 maanden"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at2"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at2",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "> 3 kg in de afgelopen maand",
+                                                                      "text": "> 3 kg in de afgelopen maand"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at3"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at3",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "nee",
+                                                                      "text": "nee"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at1"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at1",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "> 6 kg in de laatste 6 maanden",
+                                                                      "text": "> 6 kg in de laatste 6 maanden"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at2"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at2",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "> 3 kg in de afgelopen maand",
+                                                                      "text": "> 3 kg in de afgelopen maand"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at3"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at3",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "nee",
+                                                                      "text": "nee"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_COMPLEX_OBJECT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id11",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Hebt u hulp van een ander nodig bij het eten?",
+                                              "text": "Hebt u hulp van een ander nodig bij het eten?"
+                                            },
+                                            "required": true,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "occurrences": {
+                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "lower": 1,
+                                              "lower_included": true,
+                                              "lower_unbounded": false,
+                                              "mandatory": true,
+                                              "open": false,
+                                              "optional": false,
+                                              "prohibited": false,
+                                              "upper": 1,
+                                              "upper_included": true,
+                                              "upper_unbounded": false
+                                            },
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_ORDINAL",
+                                                    "node_id": "id21",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "value",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 1,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 1,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 0,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "symbol",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at4"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at4",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "ja",
+                                                                  "text": "ja"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at5"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at5",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "nee",
+                                                                  "text": "nee"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "value",
+                                                          "symbol"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "value",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "symbol",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at4"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at4",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "ja",
+                                                                      "text": "ja"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at5"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at5",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "nee",
+                                                                      "text": "nee"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at4"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at4",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "ja",
+                                                                      "text": "ja"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at5"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at5",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "nee",
+                                                                      "text": "nee"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_COMPLEX_OBJECT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id12",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Had u de afgelopen maand een verminderde eetlust?",
+                                              "text": "Had u de afgelopen maand een verminderde eetlust?"
+                                            },
+                                            "required": true,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "occurrences": {
+                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "lower": 1,
+                                              "lower_included": true,
+                                              "lower_unbounded": false,
+                                              "mandatory": true,
+                                              "open": false,
+                                              "optional": false,
+                                              "prohibited": false,
+                                              "upper": 1,
+                                              "upper_included": true,
+                                              "upper_unbounded": false
+                                            },
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_ORDINAL",
+                                                    "node_id": "id22",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "value",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 1,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 1,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 0,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "symbol",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at4"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at4",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "ja",
+                                                                  "text": "ja"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at5"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at5",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "nee",
+                                                                  "text": "nee"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "value",
+                                                          "symbol"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "value",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "symbol",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at4"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at4",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "ja",
+                                                                      "text": "ja"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at5"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at5",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "nee",
+                                                                      "text": "nee"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at4"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at4",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "ja",
+                                                                      "text": "ja"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at5"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at5",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "nee",
+                                                                      "text": "nee"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_ARCHETYPE_ROOT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id29",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Lengte",
+                                              "text": "Lengte"
+                                            },
+                                            "required": false,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_QUANTITY",
+                                                    "node_id": "id2",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "magnitude",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_REAL",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0.0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1000.0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "real"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "units",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_STRING",
+                                                            "allowed": true,
+                                                            "assumed_value": "cm",
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "cm"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "string"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "precision",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                        "multiple": false,
+                                                        "mandatory": false,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 0,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": false,
+                                                          "open": false,
+                                                          "optional": true,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 0,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "magnitude",
+                                                          "units",
+                                                          "precision"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "magnitude",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_REAL",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0.0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1000.0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "real"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "units",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_STRING",
+                                                                "allowed": true,
+                                                                "assumed_value": "cm",
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "cm"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "string"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "precision",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                            "multiple": false,
+                                                            "mandatory": false,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 0,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": false,
+                                                              "open": false,
+                                                              "optional": true,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_REAL",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0.0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1000.0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "real"
+                                                              },
+                                                              {
+                                                                "@type": "C_STRING",
+                                                                "allowed": true,
+                                                                "assumed_value": "cm",
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "cm"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "string"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "archetype_ref": "openEHR-EHR-ELEMENT.height.v1.0.0",
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_ARCHETYPE_ROOT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id30",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Gewicht",
+                                              "text": "Gewicht"
+                                            },
+                                            "required": false,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_QUANTITY",
+                                                    "node_id": "id2",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "magnitude",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_REAL",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0.0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1000.0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "real"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "units",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_STRING",
+                                                            "allowed": true,
+                                                            "assumed_value": "kg",
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "kg"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "string"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "precision",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                        "multiple": false,
+                                                        "mandatory": false,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 0,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": false,
+                                                          "open": false,
+                                                          "optional": true,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 1,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 1,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "magnitude",
+                                                          "units",
+                                                          "precision"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "magnitude",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_REAL",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0.0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1000.0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "real"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "units",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_STRING",
+                                                                "allowed": true,
+                                                                "assumed_value": "kg",
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "kg"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "string"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "precision",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                            "multiple": false,
+                                                            "mandatory": false,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 0,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": false,
+                                                              "open": false,
+                                                              "optional": true,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_REAL",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0.0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1000.0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "real"
+                                                              },
+                                                              {
+                                                                "@type": "C_STRING",
+                                                                "allowed": true,
+                                                                "assumed_value": "kg",
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "kg"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "string"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "archetype_ref": "openEHR-EHR-ELEMENT.weight.v1.0.0",
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_COMPLEX_OBJECT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id13",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Bereken de Body Mass Index (BMI)",
+                                              "text": "BMI"
+                                            },
+                                            "required": true,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "occurrences": {
+                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "lower": 1,
+                                              "lower_included": true,
+                                              "lower_unbounded": false,
+                                              "mandatory": true,
+                                              "open": false,
+                                              "optional": false,
+                                              "prohibited": false,
+                                              "upper": 1,
+                                              "upper_included": true,
+                                              "upper_unbounded": false
+                                            },
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_QUANTITY",
+                                                    "node_id": "id23",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "magnitude",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_REAL",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0.0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1000.0,
+                                                                "upper_included": false,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "real"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "units",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_STRING",
+                                                            "allowed": true,
+                                                            "assumed_value": "kg/m2",
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "kg/m2"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "string"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "precision",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                        "multiple": false,
+                                                        "mandatory": false,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 0,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": false,
+                                                          "open": false,
+                                                          "optional": true,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 1,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 1,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "magnitude",
+                                                          "units",
+                                                          "precision"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "magnitude",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_REAL",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0.0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1000.0,
+                                                                    "upper_included": false,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "real"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "units",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_STRING",
+                                                                "allowed": true,
+                                                                "assumed_value": "kg/m2",
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "kg/m2"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "string"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "precision",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                            "multiple": false,
+                                                            "mandatory": false,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 0,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": false,
+                                                              "open": false,
+                                                              "optional": true,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_REAL",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0.0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1000.0,
+                                                                    "upper_included": false,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "real"
+                                                              },
+                                                              {
+                                                                "@type": "C_STRING",
+                                                                "allowed": true,
+                                                                "assumed_value": "kg/m2",
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "kg/m2"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "string"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_COMPLEX_OBJECT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id14",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "De betekenis van de BMI-score",
+                                              "text": "Betekenis BMI"
+                                            },
+                                            "required": true,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "occurrences": {
+                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "lower": 1,
+                                              "lower_included": true,
+                                              "lower_unbounded": false,
+                                              "mandatory": true,
+                                              "open": false,
+                                              "optional": false,
+                                              "prohibited": false,
+                                              "upper": 1,
+                                              "upper_included": true,
+                                              "upper_unbounded": false
+                                            },
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_ORDINAL",
+                                                    "node_id": "id24",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "value",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 2,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 2,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 2,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 1,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 1,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 0,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 0,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "symbol",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at6"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at6",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "BMI beneden 20",
+                                                                  "text": "< 20"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at7"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at7",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "BMI van 20 tot 22",
+                                                                  "text": "20 - 22"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at8"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at8",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "BMI van 22 tot 28",
+                                                                  "text": "22 - 28"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at9"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at9",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "BMI boven 28 is overgewicht",
+                                                                  "text": "> 28 (overgewicht)"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "value",
+                                                          "symbol"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "value",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "symbol",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at6"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at6",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI beneden 20",
+                                                                      "text": "< 20"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at7"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at7",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI van 20 tot 22",
+                                                                      "text": "20 - 22"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at8"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at8",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI van 22 tot 28",
+                                                                      "text": "22 - 28"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at9"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at9",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI boven 28 is overgewicht",
+                                                                      "text": "> 28 (overgewicht)"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at6"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at6",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI beneden 20",
+                                                                      "text": "< 20"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at7"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at7",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI van 20 tot 22",
+                                                                      "text": "20 - 22"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at8"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at8",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI van 22 tot 28",
+                                                                      "text": "22 - 28"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at9"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at9",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "BMI boven 28 is overgewicht",
+                                                                      "text": "> 28 (overgewicht)"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_COMPLEX_OBJECT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id15",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Totaalscore",
+                                              "text": "Totaalscore"
+                                            },
+                                            "required": true,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "occurrences": {
+                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "lower": 1,
+                                              "lower_included": true,
+                                              "lower_unbounded": false,
+                                              "mandatory": true,
+                                              "open": false,
+                                              "optional": false,
+                                              "prohibited": false,
+                                              "upper": 1,
+                                              "upper_included": true,
+                                              "upper_unbounded": false
+                                            },
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_ORDINAL",
+                                                    "node_id": "id25",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "value",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 0,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 0,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 0,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 1,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 1,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 1,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          },
+                                                          {
+                                                            "@type": "C_INTEGER",
+                                                            "allowed": true,
+                                                            "assumed_value": 2,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              {
+                                                                "@type": "INTERVAL",
+                                                                "lower": 2,
+                                                                "lower_included": true,
+                                                                "lower_unbounded": false,
+                                                                "upper": 2,
+                                                                "upper_included": true,
+                                                                "upper_unbounded": false
+                                                              }
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "integer"
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      },
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "symbol",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at10"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at10",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "Niet ondervoed",
+                                                                  "text": "Niet ondervoed"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at11"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at11",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "Risico op ondervoeding",
+                                                                  "text": "Risico op ondervoeding"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "at12"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at12",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "Ondervoed",
+                                                                  "text": "Ondervoed"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "member_names": [
+                                                          "value",
+                                                          "symbol"
+                                                        ],
+                                                        "members": [
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "value",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          },
+                                                          {
+                                                            "@type": "C_ATTRIBUTE",
+                                                            "rm_attribute_name": "symbol",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                            "multiple": false,
+                                                            "mandatory": true,
+                                                            "existence": {
+                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "lower": 1,
+                                                              "lower_included": true,
+                                                              "lower_unbounded": false,
+                                                              "mandatory": true,
+                                                              "open": false,
+                                                              "optional": false,
+                                                              "prohibited": false,
+                                                              "upper": 1,
+                                                              "upper_included": true,
+                                                              "upper_unbounded": false
+                                                            },
+                                                            "children": [
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at10"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at10",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "Niet ondervoed",
+                                                                      "text": "Niet ondervoed"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at11"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at11",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "Risico op ondervoeding",
+                                                                      "text": "Risico op ondervoeding"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at12"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at12",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "Ondervoed",
+                                                                      "text": "Ondervoed"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ],
+                                                            "prohibited": false
+                                                          }
+                                                        ],
+                                                        "tuples": [
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 0,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 0,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 0,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at10"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at10",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "Niet ondervoed",
+                                                                      "text": "Niet ondervoed"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 1,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 1,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 1,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at11"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at11",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "Risico op ondervoeding",
+                                                                      "text": "Risico op ondervoeding"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "members": [
+                                                              {
+                                                                "@type": "C_INTEGER",
+                                                                "allowed": true,
+                                                                "assumed_value": 2,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  {
+                                                                    "@type": "INTERVAL",
+                                                                    "lower": 2,
+                                                                    "lower_included": true,
+                                                                    "lower_unbounded": false,
+                                                                    "upper": 2,
+                                                                    "upper_included": true,
+                                                                    "upper_unbounded": false
+                                                                  }
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "integer"
+                                                              },
+                                                              {
+                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "allowed": true,
+                                                                "attributes": [
+
+                                                                ],
+                                                                "constraint": [
+                                                                  "at12"
+                                                                ],
+                                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "node_id": "id9999",
+                                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
+                                                                "prohibited": false,
+                                                                "required": false,
+                                                                "rm_type_name": "terminology_code",
+                                                                "terms": [
+                                                                  {
+                                                                    "code": "at12",
+                                                                    "term": {
+                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "description": "Ondervoed",
+                                                                      "text": "Ondervoed"
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "prohibited": false
+                                          },
+                                          {
+                                            "@type": "C_COMPLEX_OBJECT",
+                                            "rm_type_name": "ELEMENT",
+                                            "node_id": "id16",
+                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]",
+                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]",
+                                            "term": {
+                                              "@type": "ARCHETYPE_TERM",
+                                              "description": "Acties",
+                                              "text": "Acties"
+                                            },
+                                            "required": false,
+                                            "allowed": true,
+                                            "any_allowed": false,
+                                            "occurrences": {
+                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "lower": 0,
+                                              "lower_included": true,
+                                              "lower_unbounded": false,
+                                              "mandatory": false,
+                                              "open": false,
+                                              "optional": true,
+                                              "prohibited": false,
+                                              "upper": 1,
+                                              "upper_included": true,
+                                              "upper_unbounded": false
+                                            },
+                                            "attributes": [
+                                              {
+                                                "@type": "C_ATTRIBUTE",
+                                                "rm_attribute_name": "value",
+                                                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value",
+                                                "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value",
+                                                "multiple": false,
+                                                "mandatory": false,
+                                                "existence": {
+                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "lower": 0,
+                                                  "lower_included": true,
+                                                  "lower_unbounded": false,
+                                                  "mandatory": false,
+                                                  "open": false,
+                                                  "optional": true,
+                                                  "prohibited": false,
+                                                  "upper": 1,
+                                                  "upper_included": true,
+                                                  "upper_unbounded": false
+                                                },
+                                                "children": [
+                                                  {
+                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "rm_type_name": "DV_CODED_TEXT",
+                                                    "node_id": "id26",
+                                                    "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]",
+                                                    "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]",
+                                                    "required": false,
+                                                    "allowed": true,
+                                                    "any_allowed": false,
+                                                    "attributes": [
+                                                      {
+                                                        "@type": "C_ATTRIBUTE",
+                                                        "rm_attribute_name": "defining_code",
+                                                        "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]/defining_code",
+                                                        "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]/defining_code",
+                                                        "multiple": false,
+                                                        "mandatory": true,
+                                                        "existence": {
+                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "lower": 1,
+                                                          "lower_included": true,
+                                                          "lower_unbounded": false,
+                                                          "mandatory": true,
+                                                          "open": false,
+                                                          "optional": false,
+                                                          "prohibited": false,
+                                                          "upper": 1,
+                                                          "upper_included": true,
+                                                          "upper_unbounded": false
+                                                        },
+                                                        "children": [
+                                                          {
+                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "allowed": true,
+                                                            "attributes": [
+
+                                                            ],
+                                                            "constraint": [
+                                                              "ac3"
+                                                            ],
+                                                            "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]/defining_code",
+                                                            "node_id": "id9999",
+                                                            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]/defining_code",
+                                                            "prohibited": false,
+                                                            "required": false,
+                                                            "rm_type_name": "terminology_code",
+                                                            "terms": [
+                                                              {
+                                                                "code": "at13",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "Geen actie",
+                                                                  "text": "Geen actie"
+                                                                }
+                                                              },
+                                                              {
+                                                                "code": "at14",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "- 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname",
+                                                                  "text": "• 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname"
+                                                                }
+                                                              },
+                                                              {
+                                                                "code": "at15",
+                                                                "term": {
+                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "description": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie",
+                                                                  "text": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ],
+                                                        "prohibited": false
+                                                      }
+                                                    ],
+                                                    "attribute_tuples": [
+
+                                                    ],
+                                                    "prohibited": false
+                                                  }
+                                                ],
+                                                "prohibited": false
+                                              }
+                                            ],
+                                            "attribute_tuples": [
+
+                                            ],
+                                            "prohibited": false
+                                          }
+                                        ],
+                                        "prohibited": false
+                                      }
+                                    ],
+                                    "attribute_tuples": [
+
+                                    ],
+                                    "prohibited": false
+                                  }
+                                ],
+                                "prohibited": false
+                              }
+                            ],
+                            "attribute_tuples": [
+
+                            ],
+                            "prohibited": false
+                          }
+                        ],
+                        "prohibited": false
+                      }
+                    ],
+                    "attribute_tuples": [
+
+                    ],
+                    "prohibited": false
+                  }
+                ],
+                "prohibited": false
+              }
+            ],
+            "attribute_tuples": [
+
+            ],
+            "archetype_ref": "openEHR-EHR-OBSERVATION.snaq_rc.v1.0.0",
+            "prohibited": false
+          },
+          {
+            "@type": "C_ARCHETYPE_ROOT",
+            "rm_type_name": "EVALUATION",
+            "node_id": "id0.0.101",
+            "path": "/content[id0.0.101]",
+            "logical_path": "/content[Assessment / remarks]",
+            "term": {
+              "@type": "ARCHETYPE_TERM",
+              "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
+              "text": "Beoordeling / opmerkingen"
+            },
+            "required": false,
+            "allowed": true,
+            "any_allowed": false,
+            "occurrences": {
+              "@type": "MULTIPLICITY_INTERVAL",
+              "lower": 0,
+              "lower_included": true,
+              "lower_unbounded": false,
+              "mandatory": false,
+              "open": false,
+              "optional": true,
+              "prohibited": false,
+              "upper": 1,
+              "upper_included": true,
+              "upper_unbounded": false
+            },
+            "attributes": [
+              {
+                "@type": "C_ATTRIBUTE",
+                "rm_attribute_name": "data",
+                "path": "/content[id0.0.101]/data",
+                "logical_path": "/content[Assessment / remarks]/data",
+                "multiple": false,
+                "mandatory": true,
+                "existence": {
+                  "@type": "MULTIPLICITY_INTERVAL",
+                  "lower": 1,
+                  "lower_included": true,
+                  "lower_unbounded": false,
+                  "mandatory": true,
+                  "open": false,
+                  "optional": false,
+                  "prohibited": false,
+                  "upper": 1,
+                  "upper_included": true,
+                  "upper_unbounded": false
+                },
+                "children": [
+                  {
+                    "@type": "C_COMPLEX_OBJECT",
+                    "rm_type_name": "ITEM_TREE",
+                    "node_id": "id2",
+                    "path": "/content[id0.0.101]/data[id2]",
+                    "logical_path": "/content[Assessment / remarks]/data[id2]",
+                    "required": false,
+                    "allowed": true,
+                    "any_allowed": false,
+                    "attributes": [
+                      {
+                        "@type": "C_ATTRIBUTE",
+                        "rm_attribute_name": "items",
+                        "path": "/content[id0.0.101]/data[id2]/items",
+                        "logical_path": "/content[Assessment / remarks]/data[id2]/items",
+                        "multiple": true,
+                        "mandatory": false,
+                        "existence": {
+                          "@type": "MULTIPLICITY_INTERVAL",
+                          "lower": 0,
+                          "lower_included": true,
+                          "lower_unbounded": false,
+                          "mandatory": false,
+                          "open": false,
+                          "optional": true,
+                          "prohibited": false,
+                          "upper": 1,
+                          "upper_included": true,
+                          "upper_unbounded": false
+                        },
+                        "cardinality": {
+                          "@type": "CARDINALITY",
+                          "interval": {
+                            "@type": "MULTIPLICITY_INTERVAL",
+                            "lower": 1,
+                            "lower_included": true,
+                            "lower_unbounded": false,
+                            "mandatory": true,
+                            "open": false,
+                            "optional": false,
+                            "prohibited": false,
+                            "upper_included": false,
+                            "upper_unbounded": true
+                          },
+                          "ordered": true,
+                          "unique": false
+                        },
+                        "children": [
+                          {
+                            "@type": "C_COMPLEX_OBJECT",
+                            "rm_type_name": "ELEMENT",
+                            "node_id": "id3.1",
+                            "path": "/content[id0.0.101]/data[id2]/items[id3.1]",
+                            "logical_path": "/content[Assessment / remarks]/data[id2]/items[Assessment / remarks]",
+                            "term": {
+                              "@type": "ARCHETYPE_TERM",
+                              "description": "Beoordeling van de meting of opmerkingen over de meting",
+                              "text": "Beoordeling / opmerkingen"
+                            },
+                            "required": false,
+                            "allowed": true,
+                            "any_allowed": false,
+                            "attributes": [
+                              {
+                                "@type": "C_ATTRIBUTE",
+                                "rm_attribute_name": "value",
+                                "path": "/content[id0.0.101]/data[id2]/items[id3.1]/value",
+                                "logical_path": "/content[Assessment / remarks]/data[id2]/items[Assessment / remarks]/value",
+                                "multiple": false,
+                                "mandatory": false,
+                                "existence": {
+                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "lower": 0,
+                                  "lower_included": true,
+                                  "lower_unbounded": false,
+                                  "mandatory": false,
+                                  "open": false,
+                                  "optional": true,
+                                  "prohibited": false,
+                                  "upper": 1,
+                                  "upper_included": true,
+                                  "upper_unbounded": false
+                                },
+                                "children": [
+                                  {
+                                    "@type": "C_COMPLEX_OBJECT",
+                                    "rm_type_name": "DV_TEXT",
+                                    "node_id": "id4",
+                                    "path": "/content[id0.0.101]/data[id2]/items[id3.1]/value[id4]",
+                                    "logical_path": "/content[Assessment / remarks]/data[id2]/items[Assessment / remarks]/value[id4]",
+                                    "required": false,
+                                    "allowed": true,
+                                    "any_allowed": true,
+                                    "attributes": [
+
+                                    ],
+                                    "attribute_tuples": [
+
+                                    ],
+                                    "prohibited": false
+                                  }
+                                ],
+                                "prohibited": false
+                              }
+                            ],
+                            "attribute_tuples": [
+
+                            ],
+                            "prohibited": false
+                          }
+                        ],
+                        "prohibited": false
+                      }
+                    ],
+                    "attribute_tuples": [
+
+                    ],
+                    "prohibited": false
+                  }
+                ],
+                "prohibited": false
+              }
+            ],
+            "attribute_tuples": [
+
+            ],
+            "archetype_ref": "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0",
+            "prohibited": false
+          }
+        ],
+        "prohibited": false
+      }
+    ],
+    "attribute_tuples": [
+
+    ],
+    "prohibited": false
+  },
+  "description": {
+    "@type": "RESOURCE_DESCRIPTION",
+    "conversion_details": {
+
+    },
+    "copyright": "www.stuurgroepondervoeding.nl",
+    "details": {
+      "nl": {
+        "@type": "RESOURCE_DESCRIPTION_ITEM",
+        "language": {
+          "@type": "TerminologyCode",
+          "code_string": "nl",
+          "terminology_id": "ISO_639-1",
+          "terminology_id_string": "ISO_639-1"
+        },
+        "misuse": "",
+        "purpose": "De SNAQRC (Short Nutritional Assessment Questionnaire for Residential Care) is ontwikkeld en\n                            gevalideerd door de Vrije Universiteit in Amsterdam. Dit instrument is bedoeld om ondervoeding in\n                            verzorgings- en verpleeghuizen op te sporen. De methode werkt met een stoplicht score.",
+        "use": ""
+      }
+    },
+    "ip_acknowledgements": {
+
+    },
+    "lifecycle_state": {
+      "@type": "TerminologyCode",
+      "code_string": "unmanaged"
+    },
+    "original_author": {
+
+    },
+    "other_contributors": [
+
+    ],
+    "other_details": {
+
+    },
+    "references": {
+
+    }
+  },
+  "differential": false,
+  "generated": true,
+  "original_language": {
+    "@type": "TerminologyCode",
+    "code_string": "nl",
+    "terminology_id": "ISO_639-1",
+    "terminology_id_string": "ISO_639-1"
+  },
+  "other_meta_data": {
+
+  },
+  "parent_archetype_id": "openEHR-EHR-COMPOSITION.report-result-with-synopsis.v1",
+  "rm_release": "1.0.2",
+  "rules": {
+    "@type": "RULES_SECTION",
+    "rules": [
+      {
+        "@type": "EXPRESSION_VARIABLE",
+        "expression": {
+          "@type": "MODEL_REFERENCE",
+          "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
+          "precedence_overridden": false
+        },
+        "name": "snaq_rc_weight",
+        "type": "REAL"
+      },
+      {
+        "@type": "EXPRESSION_VARIABLE",
+        "expression": {
+          "@type": "BINARY_OPERATOR",
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
+            "precedence_overridden": false
+          },
+          "operator": "divide",
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "CONSTANT",
+            "precedence_overridden": false,
+            "type": "INTEGER",
+            "value": 100
+          },
+          "type": "INTEGER",
+          "unary": false
+        },
+        "name": "snaq_rc_height",
+        "type": "REAL"
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "BINARY_OPERATOR",
+                  "left_operand": {
+                    "@type": "MODEL_REFERENCE",
+                    "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/magnitude",
+                    "precedence_overridden": false,
+                    "variable_reference_prefix": "snaq_rc_item"
+                  },
+                  "operator": "eq",
+                  "precedence_overridden": false,
+                  "right_operand": {
+                    "@type": "BINARY_OPERATOR",
+                    "left_operand": {
+                      "@type": "VARIABLE_REFERENCE",
+                      "declaration": {
+                        "@type": "VARIABLE_DECLARATION",
+                        "name": "snaq_rc_weight"
+                      },
+                      "precedence_overridden": false
+                    },
+                    "operator": "divide",
+                    "precedence_overridden": false,
+                    "right_operand": {
+                      "@type": "BINARY_OPERATOR",
+                      "left_operand": {
+                        "@type": "VARIABLE_REFERENCE",
+                        "declaration": {
+                          "@type": "VARIABLE_DECLARATION",
+                          "name": "snaq_rc_height"
+                        },
+                        "precedence_overridden": false
+                      },
+                      "operator": "multiply",
+                      "precedence_overridden": true,
+                      "right_operand": {
+                        "@type": "VARIABLE_REFERENCE",
+                        "declaration": {
+                          "@type": "VARIABLE_DECLARATION",
+                          "name": "snaq_rc_height"
+                        },
+                        "precedence_overridden": false
+                      },
+                      "unary": false
+                    },
+                    "unary": false
+                  },
+                  "unary": false
+                },
+                "operator": "and",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "BINARY_OPERATOR",
+                  "left_operand": {
+                    "@type": "MODEL_REFERENCE",
+                    "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/units",
+                    "precedence_overridden": false,
+                    "variable_reference_prefix": "snaq_rc_item"
+                  },
+                  "operator": "eq",
+                  "precedence_overridden": false,
+                  "right_operand": {
+                    "@type": "CONSTANT",
+                    "precedence_overridden": false,
+                    "type": "STRING",
+                    "value": "kg/m2"
+                  },
+                  "unary": false
+                },
+                "type": "BOOLEAN",
+                "unary": false
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/precision",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "eq",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 1
+                },
+                "unary": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "BINARY_OPERATOR",
+                  "left_operand": {
+                    "@type": "MODEL_REFERENCE",
+                    "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/magnitude",
+                    "precedence_overridden": false,
+                    "variable_reference_prefix": "snaq_rc_item"
+                  },
+                  "operator": "eq",
+                  "precedence_overridden": false,
+                  "right_operand": {
+                    "@type": "BINARY_OPERATOR",
+                    "left_operand": {
+                      "@type": "VARIABLE_REFERENCE",
+                      "declaration": {
+                        "@type": "VARIABLE_DECLARATION",
+                        "name": "snaq_rc_weight"
+                      },
+                      "precedence_overridden": false
+                    },
+                    "operator": "divide",
+                    "precedence_overridden": false,
+                    "right_operand": {
+                      "@type": "BINARY_OPERATOR",
+                      "left_operand": {
+                        "@type": "VARIABLE_REFERENCE",
+                        "declaration": {
+                          "@type": "VARIABLE_DECLARATION",
+                          "name": "snaq_rc_height"
+                        },
+                        "precedence_overridden": false
+                      },
+                      "operator": "multiply",
+                      "precedence_overridden": true,
+                      "right_operand": {
+                        "@type": "VARIABLE_REFERENCE",
+                        "declaration": {
+                          "@type": "VARIABLE_DECLARATION",
+                          "name": "snaq_rc_height"
+                        },
+                        "precedence_overridden": false
+                      },
+                      "unary": false
+                    },
+                    "unary": false
+                  },
+                  "unary": false
+                },
+                "operator": "and",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "BINARY_OPERATOR",
+                  "left_operand": {
+                    "@type": "MODEL_REFERENCE",
+                    "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/units",
+                    "precedence_overridden": false,
+                    "variable_reference_prefix": "snaq_rc_item"
+                  },
+                  "operator": "eq",
+                  "precedence_overridden": false,
+                  "right_operand": {
+                    "@type": "CONSTANT",
+                    "precedence_overridden": false,
+                    "type": "STRING",
+                    "value": "kg/m2"
+                  },
+                  "unary": false
+                },
+                "type": "BOOLEAN",
+                "unary": false
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/precision",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "eq",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 1
+                },
+                "unary": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "computed_bmi:exists/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitudeandexists/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitudeimplies/data[id2]/events[id3]/data[id4]/items[id13]/value/magnitude=$weight/($height*$height)and/data[id2]/events[id3]/data[id4]/items[id13]/value/units=\"kg/m2\"and/data[id2]/events[id3]/data[id4]/items[id13]/value/precision=1",
+        "tag": "snaq_rc_computed_bmi",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "EXPRESSION_VARIABLE",
+        "expression": {
+          "@type": "MODEL_REFERENCE",
+          "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value/magnitude",
+          "precedence_overridden": false
+        },
+        "name": "snaq_rc_bmi",
+        "type": "REAL"
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_bmi"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "lt",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 20
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at6"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_bmi"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "lt",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 20
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at6"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "bmi_score:$bmi<20implies/data[id2]/events[id3]/data[id4]/items[id14]/value/symbolmatches{[at6]}",
+        "tag": "snaq_rc_bmi_score",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "ge",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 20
+                },
+                "unary": false
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "lt",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 22
+                },
+                "unary": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at7"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "ge",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 20
+                },
+                "unary": false
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "lt",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 22
+                },
+                "unary": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at7"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "$bmi>=20and$bmi<22implies/data[id2]/events[id3]/data[id4]/items[id14]/value/symbolmatches{[at7]}",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "ge",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 22
+                },
+                "unary": false
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "lt",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 28
+                },
+                "unary": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at8"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "ge",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 22
+                },
+                "unary": false
+              },
+              "operator": "and",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "BINARY_OPERATOR",
+                "left_operand": {
+                  "@type": "VARIABLE_REFERENCE",
+                  "declaration": {
+                    "@type": "VARIABLE_DECLARATION",
+                    "name": "snaq_rc_bmi"
+                  },
+                  "precedence_overridden": false
+                },
+                "operator": "lt",
+                "precedence_overridden": false,
+                "right_operand": {
+                  "@type": "CONSTANT",
+                  "precedence_overridden": false,
+                  "type": "INTEGER",
+                  "value": 28
+                },
+                "unary": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at8"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "$bmi>=22and$bmi<28implies/data[id2]/events[id3]/data[id4]/items[id14]/value/symbolmatches{[at8]}",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_bmi"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "ge",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 28
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at9"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_bmi"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "ge",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 28
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at9"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "$bmi>=28implies/data[id2]/events[id3]/data[id4]/items[id14]/value/symbolmatches{[at9]}",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "EXPRESSION_VARIABLE",
+        "expression": {
+          "@type": "BINARY_OPERATOR",
+          "left_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value/value",
+                "precedence_overridden": false
+              },
+              "operator": "plus",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value/value",
+                "precedence_overridden": false
+              },
+              "unary": false
+            },
+            "operator": "plus",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "MODEL_REFERENCE",
+              "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value/value",
+              "precedence_overridden": false
+            },
+            "unary": false
+          },
+          "operator": "plus",
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value/value",
+            "precedence_overridden": false
+          },
+          "unary": false
+        },
+        "name": "snaq_rc_snaq_score",
+        "type": "INTEGER"
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_snaq_score"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 0
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at10"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_snaq_score"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 0
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at10"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "$snaq_score=0implies/data[id2]/events[id3]/data[id4]/items[id15]/value/symbolmatches{[at10]}",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_snaq_score"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 1
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at11"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_snaq_score"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 1
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at11"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "$snaq_score=1implies/data[id2]/events[id3]/data[id4]/items[id15]/value/symbolmatches{[at11]}",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_snaq_score"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "ge",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 2
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at12"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "VARIABLE_REFERENCE",
+                "declaration": {
+                  "@type": "VARIABLE_DECLARATION",
+                  "name": "snaq_rc_snaq_score"
+                },
+                "precedence_overridden": false
+              },
+              "operator": "ge",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 2
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at12"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "$snaq_score>=2implies/data[id2]/events[id3]/data[id4]/items[id15]/value/symbolmatches{[at12]}",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operator": "not",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operator": "not",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operator": "not",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operand": {
+                "@type": "UNARY_OPERATOR",
+                "left_operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operand": {
+                  "@type": "MODEL_REFERENCE",
+                  "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                  "precedence_overridden": false,
+                  "variable_reference_prefix": "snaq_rc_item"
+                },
+                "operator": "exists",
+                "precedence_overridden": false,
+                "type": "BOOLEAN",
+                "unary": true
+              },
+              "operator": "not",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "hide_actions:notexists/data[id2]/events[id3]/data[id4]/items[id15]/value/valueimpliesnotexists/data[id2]/events[id3]/data[id4]/items[id16]",
+        "tag": "snaq_rc_hide_actions",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "exists",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "exists",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "exists",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "UNARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "exists",
+              "precedence_overridden": false,
+              "type": "BOOLEAN",
+              "unary": true
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "show_actions:exists/data[id2]/events[id3]/data[id4]/items[id15]/value/valueimpliesexists/data[id2]/events[id3]/data[id4]/items[id16]",
+        "tag": "snaq_rc_show_actions",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 0
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at13"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 0
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at13"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "actions_niet_ondervoed:/data[id2]/events[id3]/data[id4]/items[id15]/value/value=0implies/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_codematches{[at13]}",
+        "tag": "snaq_rc_actions_niet_ondervoed",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 1
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at14"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 1
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at14"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "actions_risico:/data[id2]/events[id3]/data[id4]/items[id15]/value/value=1implies/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_codematches{[at14]}",
+        "tag": "snaq_rc_actions_risico",
+        "variables": [
+
+        ]
+      },
+      {
+        "@type": "ASSERTION",
+        "expression": {
+          "@type": "FOR_ALL_STATEMENT",
+          "assertion": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 2
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at15"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "left_operand": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "operator": "for_all",
+          "path_expression": {
+            "@type": "MODEL_REFERENCE",
+            "path": "/content[id0.0.100.1]",
+            "precedence_overridden": false
+          },
+          "precedence_overridden": false,
+          "right_operand": {
+            "@type": "BINARY_OPERATOR",
+            "left_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "eq",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTANT",
+                "precedence_overridden": false,
+                "type": "INTEGER",
+                "value": 2
+              },
+              "unary": false
+            },
+            "operator": "implies",
+            "precedence_overridden": false,
+            "right_operand": {
+              "@type": "BINARY_OPERATOR",
+              "left_operand": {
+                "@type": "MODEL_REFERENCE",
+                "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
+                "precedence_overridden": false,
+                "variable_reference_prefix": "snaq_rc_item"
+              },
+              "operator": "matches",
+              "precedence_overridden": false,
+              "right_operand": {
+                "@type": "CONSTRAINT",
+                "item": {
+                  "@type": "C_TERMINOLOGY_CODE",
+                  "allowed": true,
+                  "attributes": [
+
+                  ],
+                  "constraint": [
+                    "at15"
+                  ],
+                  "logical_path": "/",
+                  "node_id": "id9999",
+                  "path": "/",
+                  "prohibited": false,
+                  "required": false,
+                  "rm_type_name": "terminology_code",
+                  "terms": [
+
+                  ]
+                },
+                "precedence_overridden": false
+              },
+              "type": "BOOLEAN",
+              "unary": false
+            },
+            "type": "BOOLEAN",
+            "unary": false
+          },
+          "type": "BOOLEAN",
+          "unary": false,
+          "variable_name": "snaq_rc_item"
+        },
+        "string_expression": "actions_ondervoed:/data[id2]/events[id3]/data[id4]/items[id15]/value/value=2implies/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_codematches{[at15]}",
+        "tag": "snaq_rc_actions_ondervoed",
+        "variables": [
+
+        ]
+      }
+    ]
+  },
+  "specialized": true,
+  "terminology": {
+    "@type": "ARCHETYPE_TERMINOLOGY",
+    "concept_code": "id1.1.1.1",
+    "differential": false,
+    "original_language": "nl",
+    "term_bindings": {
+      "openehr": {
+        "at1": "http://openehr.org/id/433"
+      }
+    },
+    "term_definitions": {
+      "ar-sy": {
+        "id1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "وثيقة لتوصيل المعلومات للآخرين, عادة كاستجابة لطلب من طرف آخر.",
+          "text": "تقرير"
+        },
+        "id3": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "معلومات التعريف حول التقرير",
+          "text": "العنصر التعريفي الفريد للتقرير"
+        },
+        "id6": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "حالة التقرير بشكل كلي. و لا تمثل هذه الحالة جزءا من التقرير و إنما جميعه ككل.",
+          "text": "الحالة"
+        },
+        "id7": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*Additional information required to capture local context or to align with other reference models/formalisms.(en)",
+          "text": "*Extension(en)"
+        },
+        "at1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*event (en)",
+          "text": "*event (en)"
+        },
+        "id1.1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*Document to communicate information to others about the result of a test  or assessment.(en)",
+          "text": "*Result Report(en)"
+        }
+      },
+      "sl": {
+        "id1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*Document to communicate information to others, commonly in response to a request from another party.(en)",
+          "text": "Poročilo"
+        },
+        "id3": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*Identification information about the report.(en)",
+          "text": "ID Poročila"
+        },
+        "id6": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*The status of the entire report. Note: This is not the status of any of the report components.(en)",
+          "text": "Status"
+        },
+        "id7": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*Additional information required to capture local context or to align with other reference models/formalisms.(en)",
+          "text": "*Extension(en)"
+        },
+        "at1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*event (en)",
+          "text": "*event (en)"
+        }
+      },
+      "en": {
+        "id1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Document to communicate information to others, commonly in response to a request from another party.",
+          "text": "Report"
+        },
+        "id3": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Identification information about the report.",
+          "text": "Report ID"
+        },
+        "id6": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "The status of the entire report. Note: This is not the status of any of the report components.",
+          "text": "Status"
+        },
+        "id7": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Additional information required to capture local context or to align with other reference models/formalisms.",
+          "text": "Extension"
+        },
+        "at1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "event",
+          "text": "event"
+        },
+        "id1.1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Document to communicate information to others about the result of a test  or assessment.",
+          "text": "Result Report"
+        }
+      },
+      "es-ar": {
+        "id1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Documento para comunicar información a otros, comunmente en respuesta a la solicitud de un tercero.",
+          "text": "Informe"
+        },
+        "id3": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Información para la identificación del informe.",
+          "text": "ID del informe"
+        },
+        "id6": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "El estado del informe como un todo. Nota: no se refiere al estado de alguno de los componentes del informe.",
+          "text": "Estado"
+        },
+        "id7": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*Additional information required to capture local context or to align with other reference models/formalisms.(en)",
+          "text": "*Extension(en)"
+        },
+        "at1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "*event (en)",
+          "text": "*event (en)"
+        }
+      },
+      "nl": {
+        "id1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Document om informatie met anderen te communiceren, vaak op verzoek van een andere partij.",
+          "text": "Rapportage"
+        },
+        "id3": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Identificerende informatie over deze rapportage",
+          "text": "Rapportage ID"
+        },
+        "id6": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "De status van de rapportage. Let op, dit is niet de status van een van de onderdelen van de rappotage",
+          "text": "Status"
+        },
+        "id7": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Extra informatie nodig om de context te beschrijven of te voldoen met andere modellen of formalismes.",
+          "text": "Uitbreiding"
+        },
+        "at1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "event",
+          "text": "event"
+        },
+        "id1.1.1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Rapportage met resultaat van een meting en beoordeling",
+          "text": "Rapportage met resultaat van een meting en beoordeling"
+        },
+        "id0.0.100": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Een observatie",
+          "text": "Een observatie"
+        },
+        "id0.0.101": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
+          "text": "Beoordeling / opmerkingen"
+        },
+        "id1.1.1.1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "SNAQ RC",
+          "text": "SNAQ RC"
+        },
+        "id0.0.100.1": {
+          "@type": "ARCHETYPE_TERM",
+          "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
+          "text": "SNAQ RC"
+        }
+      }
+    },
+    "terminology_extracts": {
+
+    },
+    "value_sets": {
+
+    }
+  },
+  "terminology_extracts": {
+
+  },
+  "translations": {
+
+  }
+}

--- a/tools/src/test/resources/com/nedap/archie/json/snaq_rc_opt.js
+++ b/tools/src/test/resources/com/nedap/archie/json/snaq_rc_opt.js
@@ -1,8 +1,8 @@
 {
-  "@type": "OPERATIONAL_TEMPLATE",
+  "_type": "OPERATIONAL_TEMPLATE",
   "adl_version": "2.0.5",
   "archetype_id": {
-    "@type": "ARCHETYPE_HRID",
+    "_type": "ARCHETYPE_HRID",
     "build_count": "",
     "concept_id": "snaq_rc_report",
     "release_version": "1.0.0",
@@ -19,7 +19,7 @@
   },
   "component_terminologies": {
     "openEHR-EHR-ELEMENT.weight.v1.0.0": {
-      "@type": "ARCHETYPE_TERMINOLOGY",
+      "_type": "ARCHETYPE_TERMINOLOGY",
       "concept_code": "id1",
       "original_language": "nl",
       "term_bindings": {
@@ -28,13 +28,13 @@
       "term_definitions": {
         "nl": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "code": "id1",
             "description": "Gewicht",
             "text": "Gewicht"
           },
           "openEHR-EHR-ELEMENT.weight.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "code": "id1",
             "description": "Gewicht",
             "text": "Gewicht"
@@ -49,7 +49,7 @@
       }
     },
     "openEHR-EHR-OBSERVATION.snaq_rc.v1.0.0": {
-      "@type": "ARCHETYPE_TERMINOLOGY",
+      "_type": "ARCHETYPE_TERMINOLOGY",
       "concept_code": "id1",
       "original_language": "nl",
       "term_bindings": {
@@ -58,157 +58,157 @@
       "term_definitions": {
         "nl": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
             "text": "SNAQ RC"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Any event",
             "text": "Any event"
           },
           "id10": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Bent u onbedoeld afgevallen?",
             "text": "Bent u onbedoeld afgevallen?"
           },
           "id11": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Hebt u hulp van een ander nodig bij het eten?",
             "text": "Hebt u hulp van een ander nodig bij het eten?"
           },
           "id12": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Had u de afgelopen maand een verminderde eetlust?",
             "text": "Had u de afgelopen maand een verminderde eetlust?"
           },
           "id13": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Bereken de Body Mass Index (BMI)",
             "text": "BMI"
           },
           "id14": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "De betekenis van de BMI-score",
             "text": "Betekenis BMI"
           },
           "id15": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Totaalscore",
             "text": "Totaalscore"
           },
           "id16": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Acties",
             "text": "Acties"
           },
           "ac1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Bent u onbedoeld afgevallen?",
             "text": "Bent u onbedoeld afgevallen?"
           },
           "ac2": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Risico op ondervoeding",
             "text": "Risico op ondervoeding"
           },
           "ac3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Acties",
             "text": "Acties"
           },
           "at1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "> 6 kg in de laatste 6 maanden",
             "text": "> 6 kg in de laatste 6 maanden"
           },
           "at2": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "> 3 kg in de afgelopen maand",
             "text": "> 3 kg in de afgelopen maand"
           },
           "at3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "nee",
             "text": "nee"
           },
           "at4": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "ja",
             "text": "ja"
           },
           "at5": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "nee",
             "text": "nee"
           },
           "at6": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "BMI beneden 20",
             "text": "< 20"
           },
           "at7": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "BMI van 20 tot 22",
             "text": "20 - 22"
           },
           "at8": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "BMI van 22 tot 28",
             "text": "22 - 28"
           },
           "at9": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "BMI boven 28 is overgewicht",
             "text": "> 28 (overgewicht)"
           },
           "at10": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Niet ondervoed",
             "text": "Niet ondervoed"
           },
           "at11": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Risico op ondervoeding",
             "text": "Risico op ondervoeding"
           },
           "at12": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Ondervoed",
             "text": "Ondervoed"
           },
           "at13": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Geen actie",
             "text": "Geen actie"
           },
           "at14": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "- 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname",
             "text": "• 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname"
           },
           "at15": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie",
             "text": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie"
           },
           "id29": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Lengte",
             "text": "Lengte"
           },
           "id33": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Lengte",
             "text": "Lengte"
           },
           "id30": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Gewicht",
             "text": "Gewicht"
           },
           "openEHR-EHR-OBSERVATION.snaq_rc.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
             "text": "SNAQ RC"
           }
@@ -219,7 +219,7 @@
       },
       "value_sets": {
         "ac1": {
-          "@type": "VALUE_SET",
+          "_type": "VALUE_SET",
           "id": "ac1",
           "members": [
             "at1",
@@ -228,7 +228,7 @@
           ]
         },
         "ac2": {
-          "@type": "VALUE_SET",
+          "_type": "VALUE_SET",
           "id": "ac2",
           "members": [
             "at10",
@@ -237,7 +237,7 @@
           ]
         },
         "ac3": {
-          "@type": "VALUE_SET",
+          "_type": "VALUE_SET",
           "id": "ac3",
           "members": [
             "at13",
@@ -248,7 +248,7 @@
       }
     },
     "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-      "@type": "ARCHETYPE_TERMINOLOGY",
+      "_type": "ARCHETYPE_TERMINOLOGY",
       "concept_code": "id1.1",
       "differential": false,
       "original_language": "en",
@@ -258,156 +258,156 @@
       "term_definitions": {
         "en": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Narrative summary or overview about a patient, specifically from the perspective of a healthcare provider, and with or without associated interpretations.",
             "text": "Clinical Synopsis"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "The summary, assessment, conclusions or evaluation of the clinical findings.",
             "text": "Synopsis"
           },
           "id3.1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Assessment or remarks about the clinical finding",
             "text": "Assessment / remarks"
           },
           "id1.1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Describe an assessment or remarks for a clinical finding. This can for example be a more detailed interpretation of\n    \t\t\t\ta finding, or the meaning of a finding for a patiënt.",
             "text": "Assessment / remarks"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Describe an assessment or remarks for a clinical finding. This can for example be a more detailed interpretation of\n    \t\t\t\ta finding, or the meaning of a finding for a patiënt.",
             "text": "Assessment / remarks"
           }
         },
         "fa": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "خلاصه یا مروری تشریحی دربازه بیمار بویژه از نظز ارایه کننده مراقبت بهداشتی با یا بدون تفسیرهای مربوطه ",
             "text": "خلاصه بالینی"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "خلاصه ، ارزیابی ، نتیجه ، یا ارزشیابی یافته های بالینی",
             "text": "خلاصه"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "خلاصه یا مروری تشریحی دربازه بیمار بویژه از نظز ارایه کننده مراقبت بهداشتی با یا بدون تفسیرهای مربوطه ",
             "text": "خلاصه بالینی"
           }
         },
         "ar-sy": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "ملخص بالرواية أو نظرة عامة عن المريض, خاصة من وجهة نظر مقدم الخدمة الصحية, مع إرفاق أو عدم إرفاق تفسيرات ",
             "text": "المختصر السريري"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "الملخص, التقييم, الاستنتاجات أو التقييم للموجودات السريرية",
             "text": "المختصر"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "ملخص بالرواية أو نظرة عامة عن المريض, خاصة من وجهة نظر مقدم الخدمة الصحية, مع إرفاق أو عدم إرفاق تفسيرات ",
             "text": "المختصر السريري"
           }
         },
         "de": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Zusammenfassung oder Übersicht einer Patientengeschichte, speziell aus der Sicht eines Gesundheitsdienstleisters, evtl. mit dazugehörigen Interpretationen.",
             "text": "Klinische Synopsis"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Die Zusammenfassung, Beurteilung, Aussagen or Auswertung des klinischen Befunds.",
             "text": "Synopsis"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Zusammenfassung oder Übersicht einer Patientengeschichte, speziell aus der Sicht eines Gesundheitsdienstleisters, evtl. mit dazugehörigen Interpretationen.",
             "text": "Klinische Synopsis"
           }
         },
         "es-ar": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Sumario narrativo o visión global acerca de un paciente, específicamente desde la perspectiva de un profesional del cuidado de la salud, con o sin interpretaciones asociadas.",
             "text": "Sinopsis Clínica"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "El sumario, la impresión diagnóstica y las conclusiones sobre los hallazgos clínicos.",
             "text": "Sinopsis"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Sumario narrativo o visión global acerca de un paciente, específicamente desde la perspectiva de un profesional del cuidado de la salud, con o sin interpretaciones asociadas.",
             "text": "Sinopsis Clínica"
           }
         },
         "pt-br": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Resumo narrativo ou visão geral sobre um paciente, especificamente a partir da perspectiva de um profissional de saúde, e com ou sem interpretações associadas.",
             "text": "Sinopse Clínica"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": " O sumário, a avaliação, conclusões ou avaliação dos achados clínicos.",
             "text": "Sinopse"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Resumo narrativo ou visão geral sobre um paciente, especificamente a partir da perspectiva de um profissional de saúde, e com ou sem interpretações associadas.",
             "text": "Sinopse Clínica"
           }
         },
         "zh-cn": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "从医疗保健服务提供着的角度，手工综合并记录关于患者的叙述型摘要或概述，且带有或没有相关联的解释。",
             "text": "临床提要"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "对于临床所见（临床发现）进行的概括、评估、总结或评价。",
             "text": "提要"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "从医疗保健服务提供着的角度，手工综合并记录关于患者的叙述型摘要或概述，且带有或没有相关联的解释。",
             "text": "临床提要"
           }
         },
         "nl": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Samenvatting, beoordeling, conclusies of evaluaties bij de meting.",
             "text": "Klinische Synopsis"
           },
           "id3": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "De samenvatting, beoordeling, conclusies of evaluaties van de bevindingen.",
             "text": "Synopsis"
           },
           "id3.1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Beoordeling van de meting of opmerkingen over de meting",
             "text": "Beoordeling / opmerkingen"
           },
           "id1.1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
             "text": "Beoordeling / opmerkingen"
           },
           "openEHR-EHR-EVALUATION.clinical_assessment_or_remarks.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
             "text": "Beoordeling / opmerkingen"
           }
@@ -421,7 +421,7 @@
       }
     },
     "openEHR-EHR-ELEMENT.height.v1.0.0": {
-      "@type": "ARCHETYPE_TERMINOLOGY",
+      "_type": "ARCHETYPE_TERMINOLOGY",
       "concept_code": "id1",
       "original_language": "nl",
       "term_bindings": {
@@ -430,13 +430,13 @@
       "term_definitions": {
         "nl": {
           "id1": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "code": "id1",
             "description": "Lengte",
             "text": "Lengte"
           },
           "openEHR-EHR-ELEMENT.height.v1.0.0": {
-            "@type": "ARCHETYPE_TERM",
+            "_type": "ARCHETYPE_TERM",
             "code": "id1",
             "description": "Lengte",
             "text": "Lengte"
@@ -452,13 +452,13 @@
     }
   },
   "definition": {
-    "@type": "C_COMPLEX_OBJECT",
+    "_type": "C_COMPLEX_OBJECT",
     "rm_type_name": "COMPOSITION",
     "node_id": "id1.1.1.1",
     "path": "/",
     "logical_path": "/",
     "term": {
-      "@type": "ARCHETYPE_TERM",
+      "_type": "ARCHETYPE_TERM",
       "description": "SNAQ RC",
       "text": "SNAQ RC"
     },
@@ -467,14 +467,14 @@
     "any_allowed": false,
     "attributes": [
       {
-        "@type": "C_ATTRIBUTE",
+        "_type": "C_ATTRIBUTE",
         "rm_attribute_name": "category",
         "path": "/category",
         "logical_path": "/category",
         "multiple": false,
         "mandatory": true,
         "existence": {
-          "@type": "MULTIPLICITY_INTERVAL",
+          "_type": "MULTIPLICITY_INTERVAL",
           "lower": 1,
           "lower_included": true,
           "lower_unbounded": false,
@@ -488,7 +488,7 @@
         },
         "children": [
           {
-            "@type": "C_COMPLEX_OBJECT",
+            "_type": "C_COMPLEX_OBJECT",
             "rm_type_name": "DV_CODED_TEXT",
             "node_id": "id8",
             "path": "/category[id8]",
@@ -498,14 +498,14 @@
             "any_allowed": false,
             "attributes": [
               {
-                "@type": "C_ATTRIBUTE",
+                "_type": "C_ATTRIBUTE",
                 "rm_attribute_name": "defining_code",
                 "path": "/category[id8]/defining_code",
                 "logical_path": "/category[id8]/defining_code",
                 "multiple": false,
                 "mandatory": true,
                 "existence": {
-                  "@type": "MULTIPLICITY_INTERVAL",
+                  "_type": "MULTIPLICITY_INTERVAL",
                   "lower": 1,
                   "lower_included": true,
                   "lower_unbounded": false,
@@ -519,7 +519,7 @@
                 },
                 "children": [
                   {
-                    "@type": "C_TERMINOLOGY_CODE",
+                    "_type": "C_TERMINOLOGY_CODE",
                     "allowed": true,
                     "attributes": [
 
@@ -537,7 +537,7 @@
                       {
                         "code": "at1",
                         "term": {
-                          "@type": "ARCHETYPE_TERM",
+                          "_type": "ARCHETYPE_TERM",
                           "description": "event",
                           "text": "event"
                         }
@@ -557,14 +557,14 @@
         "prohibited": false
       },
       {
-        "@type": "C_ATTRIBUTE",
+        "_type": "C_ATTRIBUTE",
         "rm_attribute_name": "context",
         "path": "/context",
         "logical_path": "/context",
         "multiple": false,
         "mandatory": false,
         "existence": {
-          "@type": "MULTIPLICITY_INTERVAL",
+          "_type": "MULTIPLICITY_INTERVAL",
           "lower": 0,
           "lower_included": true,
           "lower_unbounded": false,
@@ -578,7 +578,7 @@
         },
         "children": [
           {
-            "@type": "C_COMPLEX_OBJECT",
+            "_type": "C_COMPLEX_OBJECT",
             "rm_type_name": "EVENT_CONTEXT",
             "node_id": "id9",
             "path": "/context[id9]",
@@ -588,14 +588,14 @@
             "any_allowed": false,
             "attributes": [
               {
-                "@type": "C_ATTRIBUTE",
+                "_type": "C_ATTRIBUTE",
                 "rm_attribute_name": "other_context",
                 "path": "/context[id9]/other_context",
                 "logical_path": "/context[id9]/other_context",
                 "multiple": false,
                 "mandatory": false,
                 "existence": {
-                  "@type": "MULTIPLICITY_INTERVAL",
+                  "_type": "MULTIPLICITY_INTERVAL",
                   "lower": 0,
                   "lower_included": true,
                   "lower_unbounded": false,
@@ -609,7 +609,7 @@
                 },
                 "children": [
                   {
-                    "@type": "C_COMPLEX_OBJECT",
+                    "_type": "C_COMPLEX_OBJECT",
                     "rm_type_name": "ITEM_TREE",
                     "node_id": "id2",
                     "path": "/context[id9]/other_context[id2]",
@@ -619,14 +619,14 @@
                     "any_allowed": false,
                     "attributes": [
                       {
-                        "@type": "C_ATTRIBUTE",
+                        "_type": "C_ATTRIBUTE",
                         "rm_attribute_name": "items",
                         "path": "/context[id9]/other_context[id2]/items",
                         "logical_path": "/context[id9]/other_context[id2]/items",
                         "multiple": true,
                         "mandatory": false,
                         "existence": {
-                          "@type": "MULTIPLICITY_INTERVAL",
+                          "_type": "MULTIPLICITY_INTERVAL",
                           "lower": 0,
                           "lower_included": true,
                           "lower_unbounded": false,
@@ -639,9 +639,9 @@
                           "upper_unbounded": false
                         },
                         "cardinality": {
-                          "@type": "CARDINALITY",
+                          "_type": "CARDINALITY",
                           "interval": {
-                            "@type": "MULTIPLICITY_INTERVAL",
+                            "_type": "MULTIPLICITY_INTERVAL",
                             "lower": 0,
                             "lower_included": true,
                             "lower_unbounded": false,
@@ -657,13 +657,13 @@
                         },
                         "children": [
                           {
-                            "@type": "C_COMPLEX_OBJECT",
+                            "_type": "C_COMPLEX_OBJECT",
                             "rm_type_name": "ELEMENT",
                             "node_id": "id3",
                             "path": "/context[id9]/other_context[id2]/items[id3]",
                             "logical_path": "/context[id9]/other_context[id2]/items[Report ID]",
                             "term": {
-                              "@type": "ARCHETYPE_TERM",
+                              "_type": "ARCHETYPE_TERM",
                               "description": "Identificerende informatie over deze rapportage",
                               "text": "Rapportage ID"
                             },
@@ -671,7 +671,7 @@
                             "allowed": true,
                             "any_allowed": false,
                             "occurrences": {
-                              "@type": "MULTIPLICITY_INTERVAL",
+                              "_type": "MULTIPLICITY_INTERVAL",
                               "lower": 0,
                               "lower_included": true,
                               "lower_unbounded": false,
@@ -685,14 +685,14 @@
                             },
                             "attributes": [
                               {
-                                "@type": "C_ATTRIBUTE",
+                                "_type": "C_ATTRIBUTE",
                                 "rm_attribute_name": "value",
                                 "path": "/context[id9]/other_context[id2]/items[id3]/value",
                                 "logical_path": "/context[id9]/other_context[id2]/items[Report ID]/value",
                                 "multiple": false,
                                 "mandatory": false,
                                 "existence": {
-                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "_type": "MULTIPLICITY_INTERVAL",
                                   "lower": 0,
                                   "lower_included": true,
                                   "lower_unbounded": false,
@@ -706,7 +706,7 @@
                                 },
                                 "children": [
                                   {
-                                    "@type": "C_COMPLEX_OBJECT",
+                                    "_type": "C_COMPLEX_OBJECT",
                                     "rm_type_name": "DV_TEXT",
                                     "node_id": "id10",
                                     "path": "/context[id9]/other_context[id2]/items[id3]/value[id10]",
@@ -732,13 +732,13 @@
                             "prohibited": false
                           },
                           {
-                            "@type": "C_COMPLEX_OBJECT",
+                            "_type": "C_COMPLEX_OBJECT",
                             "rm_type_name": "ELEMENT",
                             "node_id": "id6",
                             "path": "/context[id9]/other_context[id2]/items[id6]",
                             "logical_path": "/context[id9]/other_context[id2]/items[Status]",
                             "term": {
-                              "@type": "ARCHETYPE_TERM",
+                              "_type": "ARCHETYPE_TERM",
                               "description": "De status van de rapportage. Let op, dit is niet de status van een van de onderdelen van de rappotage",
                               "text": "Status"
                             },
@@ -746,7 +746,7 @@
                             "allowed": true,
                             "any_allowed": false,
                             "occurrences": {
-                              "@type": "MULTIPLICITY_INTERVAL",
+                              "_type": "MULTIPLICITY_INTERVAL",
                               "lower": 0,
                               "lower_included": true,
                               "lower_unbounded": false,
@@ -760,14 +760,14 @@
                             },
                             "attributes": [
                               {
-                                "@type": "C_ATTRIBUTE",
+                                "_type": "C_ATTRIBUTE",
                                 "rm_attribute_name": "value",
                                 "path": "/context[id9]/other_context[id2]/items[id6]/value",
                                 "logical_path": "/context[id9]/other_context[id2]/items[Status]/value",
                                 "multiple": false,
                                 "mandatory": false,
                                 "existence": {
-                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "_type": "MULTIPLICITY_INTERVAL",
                                   "lower": 0,
                                   "lower_included": true,
                                   "lower_unbounded": false,
@@ -781,7 +781,7 @@
                                 },
                                 "children": [
                                   {
-                                    "@type": "C_COMPLEX_OBJECT",
+                                    "_type": "C_COMPLEX_OBJECT",
                                     "rm_type_name": "DV_TEXT",
                                     "node_id": "id11",
                                     "path": "/context[id9]/other_context[id2]/items[id6]/value[id11]",
@@ -807,7 +807,7 @@
                             "prohibited": false
                           },
                           {
-                            "@type": "ARCHETYPE_SLOT",
+                            "_type": "ARCHETYPE_SLOT",
                             "allowed": true,
                             "attributes": [
 
@@ -818,20 +818,20 @@
                             ],
                             "includes": [
                               {
-                                "@type": "ASSERTION",
+                                "_type": "ASSERTION",
                                 "expression": {
-                                  "@type": "BINARY_OPERATOR",
+                                  "_type": "BINARY_OPERATOR",
                                   "left_operand": {
-                                    "@type": "MODEL_REFERENCE",
+                                    "_type": "MODEL_REFERENCE",
                                     "path": "archetype_id/value",
                                     "precedence_overridden": false
                                   },
                                   "operator": "matches",
                                   "precedence_overridden": false,
                                   "right_operand": {
-                                    "@type": "CONSTRAINT",
+                                    "_type": "CONSTRAINT",
                                     "item": {
-                                      "@type": "C_STRING",
+                                      "_type": "C_STRING",
                                       "allowed": true,
                                       "attributes": [
 
@@ -860,7 +860,7 @@
                             "logical_path": "/context[id9]/other_context[id2]/items[Extension]",
                             "node_id": "id7",
                             "occurrences": {
-                              "@type": "MULTIPLICITY_INTERVAL",
+                              "_type": "MULTIPLICITY_INTERVAL",
                               "lower": 0,
                               "lower_included": true,
                               "lower_unbounded": false,
@@ -876,7 +876,7 @@
                             "required": false,
                             "rm_type_name": "CLUSTER",
                             "term": {
-                              "@type": "ARCHETYPE_TERM",
+                              "_type": "ARCHETYPE_TERM",
                               "description": "Extra informatie nodig om de context te beschrijven of te voldoen met andere modellen of formalismes.",
                               "text": "Uitbreiding"
                             }
@@ -903,14 +903,14 @@
         "prohibited": false
       },
       {
-        "@type": "C_ATTRIBUTE",
+        "_type": "C_ATTRIBUTE",
         "rm_attribute_name": "content",
         "path": "/content",
         "logical_path": "/content",
         "multiple": true,
         "mandatory": false,
         "existence": {
-          "@type": "MULTIPLICITY_INTERVAL",
+          "_type": "MULTIPLICITY_INTERVAL",
           "lower": 0,
           "lower_included": true,
           "lower_unbounded": false,
@@ -923,9 +923,9 @@
           "upper_unbounded": false
         },
         "cardinality": {
-          "@type": "CARDINALITY",
+          "_type": "CARDINALITY",
           "interval": {
-            "@type": "MULTIPLICITY_INTERVAL",
+            "_type": "MULTIPLICITY_INTERVAL",
             "lower": 0,
             "lower_included": true,
             "lower_unbounded": false,
@@ -941,13 +941,13 @@
         },
         "children": [
           {
-            "@type": "C_ARCHETYPE_ROOT",
+            "_type": "C_ARCHETYPE_ROOT",
             "rm_type_name": "OBSERVATION",
             "node_id": "id0.0.100.1",
             "path": "/content[id0.0.100.1]",
             "logical_path": "/content[id0.0.100.1]",
             "term": {
-              "@type": "ARCHETYPE_TERM",
+              "_type": "ARCHETYPE_TERM",
               "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
               "text": "SNAQ RC"
             },
@@ -955,7 +955,7 @@
             "allowed": true,
             "any_allowed": false,
             "occurrences": {
-              "@type": "MULTIPLICITY_INTERVAL",
+              "_type": "MULTIPLICITY_INTERVAL",
               "lower": 1,
               "lower_included": true,
               "lower_unbounded": false,
@@ -969,14 +969,14 @@
             },
             "attributes": [
               {
-                "@type": "C_ATTRIBUTE",
+                "_type": "C_ATTRIBUTE",
                 "rm_attribute_name": "data",
                 "path": "/content[id0.0.100.1]/data",
                 "logical_path": "/content[id0.0.100.1]/data",
                 "multiple": false,
                 "mandatory": true,
                 "existence": {
-                  "@type": "MULTIPLICITY_INTERVAL",
+                  "_type": "MULTIPLICITY_INTERVAL",
                   "lower": 1,
                   "lower_included": true,
                   "lower_unbounded": false,
@@ -990,7 +990,7 @@
                 },
                 "children": [
                   {
-                    "@type": "C_COMPLEX_OBJECT",
+                    "_type": "C_COMPLEX_OBJECT",
                     "rm_type_name": "HISTORY",
                     "node_id": "id2",
                     "path": "/content[id0.0.100.1]/data[id2]",
@@ -1000,14 +1000,14 @@
                     "any_allowed": false,
                     "attributes": [
                       {
-                        "@type": "C_ATTRIBUTE",
+                        "_type": "C_ATTRIBUTE",
                         "rm_attribute_name": "events",
                         "path": "/content[id0.0.100.1]/data[id2]/events",
                         "logical_path": "/content[id0.0.100.1]/data[id2]/events",
                         "multiple": true,
                         "mandatory": false,
                         "existence": {
-                          "@type": "MULTIPLICITY_INTERVAL",
+                          "_type": "MULTIPLICITY_INTERVAL",
                           "lower": 0,
                           "lower_included": true,
                           "lower_unbounded": false,
@@ -1020,9 +1020,9 @@
                           "upper_unbounded": false
                         },
                         "cardinality": {
-                          "@type": "CARDINALITY",
+                          "_type": "CARDINALITY",
                           "interval": {
-                            "@type": "MULTIPLICITY_INTERVAL",
+                            "_type": "MULTIPLICITY_INTERVAL",
                             "lower": 1,
                             "lower_included": true,
                             "lower_unbounded": false,
@@ -1038,13 +1038,13 @@
                         },
                         "children": [
                           {
-                            "@type": "C_COMPLEX_OBJECT",
+                            "_type": "C_COMPLEX_OBJECT",
                             "rm_type_name": "EVENT",
                             "node_id": "id3",
                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]",
                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]",
                             "term": {
-                              "@type": "ARCHETYPE_TERM",
+                              "_type": "ARCHETYPE_TERM",
                               "description": "Any event",
                               "text": "Any event"
                             },
@@ -1053,14 +1053,14 @@
                             "any_allowed": false,
                             "attributes": [
                               {
-                                "@type": "C_ATTRIBUTE",
+                                "_type": "C_ATTRIBUTE",
                                 "rm_attribute_name": "data",
                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data",
                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data",
                                 "multiple": false,
                                 "mandatory": true,
                                 "existence": {
-                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "_type": "MULTIPLICITY_INTERVAL",
                                   "lower": 1,
                                   "lower_included": true,
                                   "lower_unbounded": false,
@@ -1074,7 +1074,7 @@
                                 },
                                 "children": [
                                   {
-                                    "@type": "C_COMPLEX_OBJECT",
+                                    "_type": "C_COMPLEX_OBJECT",
                                     "rm_type_name": "ITEM_TREE",
                                     "node_id": "id4",
                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]",
@@ -1083,7 +1083,7 @@
                                     "allowed": true,
                                     "any_allowed": false,
                                     "occurrences": {
-                                      "@type": "MULTIPLICITY_INTERVAL",
+                                      "_type": "MULTIPLICITY_INTERVAL",
                                       "lower": 1,
                                       "lower_included": true,
                                       "lower_unbounded": false,
@@ -1097,14 +1097,14 @@
                                     },
                                     "attributes": [
                                       {
-                                        "@type": "C_ATTRIBUTE",
+                                        "_type": "C_ATTRIBUTE",
                                         "rm_attribute_name": "items",
                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items",
                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items",
                                         "multiple": true,
                                         "mandatory": false,
                                         "existence": {
-                                          "@type": "MULTIPLICITY_INTERVAL",
+                                          "_type": "MULTIPLICITY_INTERVAL",
                                           "lower": 0,
                                           "lower_included": true,
                                           "lower_unbounded": false,
@@ -1117,9 +1117,9 @@
                                           "upper_unbounded": false
                                         },
                                         "cardinality": {
-                                          "@type": "CARDINALITY",
+                                          "_type": "CARDINALITY",
                                           "interval": {
-                                            "@type": "MULTIPLICITY_INTERVAL",
+                                            "_type": "MULTIPLICITY_INTERVAL",
                                             "lower": 0,
                                             "lower_included": true,
                                             "lower_unbounded": false,
@@ -1135,13 +1135,13 @@
                                         },
                                         "children": [
                                           {
-                                            "@type": "C_COMPLEX_OBJECT",
+                                            "_type": "C_COMPLEX_OBJECT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id10",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Bent u onbedoeld afgevallen?",
                                               "text": "Bent u onbedoeld afgevallen?"
                                             },
@@ -1149,7 +1149,7 @@
                                             "allowed": true,
                                             "any_allowed": false,
                                             "occurrences": {
-                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "_type": "MULTIPLICITY_INTERVAL",
                                               "lower": 1,
                                               "lower_included": true,
                                               "lower_unbounded": false,
@@ -1163,14 +1163,14 @@
                                             },
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -1184,7 +1184,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_ORDINAL",
                                                     "node_id": "id20",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]",
@@ -1194,14 +1194,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "value",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -1215,7 +1215,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 2,
                                                             "attributes": [
@@ -1223,7 +1223,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 2,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -1240,7 +1240,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 2,
                                                             "attributes": [
@@ -1248,7 +1248,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 2,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -1265,7 +1265,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 0,
                                                             "attributes": [
@@ -1273,7 +1273,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -1293,14 +1293,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "symbol",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -1314,7 +1314,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -1332,7 +1332,7 @@
                                                               {
                                                                 "code": "at1",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "> 6 kg in de laatste 6 maanden",
                                                                   "text": "> 6 kg in de laatste 6 maanden"
                                                                 }
@@ -1340,7 +1340,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -1358,7 +1358,7 @@
                                                               {
                                                                 "code": "at2",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "> 3 kg in de afgelopen maand",
                                                                   "text": "> 3 kg in de afgelopen maand"
                                                                 }
@@ -1366,7 +1366,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -1384,7 +1384,7 @@
                                                               {
                                                                 "code": "at3",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "nee",
                                                                   "text": "nee"
                                                                 }
@@ -1397,21 +1397,21 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "value",
                                                           "symbol"
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "value",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/value",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -1425,7 +1425,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -1433,7 +1433,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -1450,7 +1450,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -1458,7 +1458,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -1475,7 +1475,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -1483,7 +1483,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -1503,14 +1503,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "symbol",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value[id20]/symbol",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -1524,7 +1524,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -1542,7 +1542,7 @@
                                                                   {
                                                                     "code": "at1",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "> 6 kg in de laatste 6 maanden",
                                                                       "text": "> 6 kg in de laatste 6 maanden"
                                                                     }
@@ -1550,7 +1550,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -1568,7 +1568,7 @@
                                                                   {
                                                                     "code": "at2",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "> 3 kg in de afgelopen maand",
                                                                       "text": "> 3 kg in de afgelopen maand"
                                                                     }
@@ -1576,7 +1576,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -1594,7 +1594,7 @@
                                                                   {
                                                                     "code": "at3",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "nee",
                                                                       "text": "nee"
                                                                     }
@@ -1607,10 +1607,10 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -1618,7 +1618,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -1635,7 +1635,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -1653,7 +1653,7 @@
                                                                   {
                                                                     "code": "at1",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "> 6 kg in de laatste 6 maanden",
                                                                       "text": "> 6 kg in de laatste 6 maanden"
                                                                     }
@@ -1663,10 +1663,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -1674,7 +1674,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -1691,7 +1691,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -1709,7 +1709,7 @@
                                                                   {
                                                                     "code": "at2",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "> 3 kg in de afgelopen maand",
                                                                       "text": "> 3 kg in de afgelopen maand"
                                                                     }
@@ -1719,10 +1719,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -1730,7 +1730,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -1747,7 +1747,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -1765,7 +1765,7 @@
                                                                   {
                                                                     "code": "at3",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "nee",
                                                                       "text": "nee"
                                                                     }
@@ -1789,13 +1789,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_COMPLEX_OBJECT",
+                                            "_type": "C_COMPLEX_OBJECT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id11",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Hebt u hulp van een ander nodig bij het eten?",
                                               "text": "Hebt u hulp van een ander nodig bij het eten?"
                                             },
@@ -1803,7 +1803,7 @@
                                             "allowed": true,
                                             "any_allowed": false,
                                             "occurrences": {
-                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "_type": "MULTIPLICITY_INTERVAL",
                                               "lower": 1,
                                               "lower_included": true,
                                               "lower_unbounded": false,
@@ -1817,14 +1817,14 @@
                                             },
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -1838,7 +1838,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_ORDINAL",
                                                     "node_id": "id21",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]",
@@ -1848,14 +1848,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "value",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -1869,7 +1869,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 1,
                                                             "attributes": [
@@ -1877,7 +1877,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 1,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -1894,7 +1894,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 0,
                                                             "attributes": [
@@ -1902,7 +1902,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -1922,14 +1922,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "symbol",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -1943,7 +1943,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -1961,7 +1961,7 @@
                                                               {
                                                                 "code": "at4",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "ja",
                                                                   "text": "ja"
                                                                 }
@@ -1969,7 +1969,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -1987,7 +1987,7 @@
                                                               {
                                                                 "code": "at5",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "nee",
                                                                   "text": "nee"
                                                                 }
@@ -2000,21 +2000,21 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "value",
                                                           "symbol"
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "value",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/value",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -2028,7 +2028,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -2036,7 +2036,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2053,7 +2053,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -2061,7 +2061,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2081,14 +2081,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "symbol",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value[id21]/symbol",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -2102,7 +2102,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2120,7 +2120,7 @@
                                                                   {
                                                                     "code": "at4",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "ja",
                                                                       "text": "ja"
                                                                     }
@@ -2128,7 +2128,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2146,7 +2146,7 @@
                                                                   {
                                                                     "code": "at5",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "nee",
                                                                       "text": "nee"
                                                                     }
@@ -2159,10 +2159,10 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -2170,7 +2170,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2187,7 +2187,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2205,7 +2205,7 @@
                                                                   {
                                                                     "code": "at4",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "ja",
                                                                       "text": "ja"
                                                                     }
@@ -2215,10 +2215,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -2226,7 +2226,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2243,7 +2243,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2261,7 +2261,7 @@
                                                                   {
                                                                     "code": "at5",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "nee",
                                                                       "text": "nee"
                                                                     }
@@ -2285,13 +2285,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_COMPLEX_OBJECT",
+                                            "_type": "C_COMPLEX_OBJECT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id12",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Had u de afgelopen maand een verminderde eetlust?",
                                               "text": "Had u de afgelopen maand een verminderde eetlust?"
                                             },
@@ -2299,7 +2299,7 @@
                                             "allowed": true,
                                             "any_allowed": false,
                                             "occurrences": {
-                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "_type": "MULTIPLICITY_INTERVAL",
                                               "lower": 1,
                                               "lower_included": true,
                                               "lower_unbounded": false,
@@ -2313,14 +2313,14 @@
                                             },
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -2334,7 +2334,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_ORDINAL",
                                                     "node_id": "id22",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]",
@@ -2344,14 +2344,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "value",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -2365,7 +2365,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 1,
                                                             "attributes": [
@@ -2373,7 +2373,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 1,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -2390,7 +2390,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 0,
                                                             "attributes": [
@@ -2398,7 +2398,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -2418,14 +2418,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "symbol",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -2439,7 +2439,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -2457,7 +2457,7 @@
                                                               {
                                                                 "code": "at4",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "ja",
                                                                   "text": "ja"
                                                                 }
@@ -2465,7 +2465,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -2483,7 +2483,7 @@
                                                               {
                                                                 "code": "at5",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "nee",
                                                                   "text": "nee"
                                                                 }
@@ -2496,21 +2496,21 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "value",
                                                           "symbol"
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "value",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/value",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -2524,7 +2524,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -2532,7 +2532,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2549,7 +2549,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -2557,7 +2557,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2577,14 +2577,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "symbol",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value[id22]/symbol",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -2598,7 +2598,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2616,7 +2616,7 @@
                                                                   {
                                                                     "code": "at4",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "ja",
                                                                       "text": "ja"
                                                                     }
@@ -2624,7 +2624,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2642,7 +2642,7 @@
                                                                   {
                                                                     "code": "at5",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "nee",
                                                                       "text": "nee"
                                                                     }
@@ -2655,10 +2655,10 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -2666,7 +2666,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2683,7 +2683,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2701,7 +2701,7 @@
                                                                   {
                                                                     "code": "at4",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "ja",
                                                                       "text": "ja"
                                                                     }
@@ -2711,10 +2711,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -2722,7 +2722,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -2739,7 +2739,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -2757,7 +2757,7 @@
                                                                   {
                                                                     "code": "at5",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "nee",
                                                                       "text": "nee"
                                                                     }
@@ -2781,13 +2781,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_ARCHETYPE_ROOT",
+                                            "_type": "C_ARCHETYPE_ROOT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id29",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Lengte",
                                               "text": "Lengte"
                                             },
@@ -2796,14 +2796,14 @@
                                             "any_allowed": false,
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -2817,7 +2817,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_QUANTITY",
                                                     "node_id": "id2",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]",
@@ -2827,14 +2827,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "magnitude",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -2848,14 +2848,14 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_REAL",
+                                                            "_type": "C_REAL",
                                                             "allowed": true,
                                                             "attributes": [
 
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0.0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -2875,14 +2875,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "units",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -2896,7 +2896,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_STRING",
+                                                            "_type": "C_STRING",
                                                             "allowed": true,
                                                             "assumed_value": "cm",
                                                             "attributes": [
@@ -2916,14 +2916,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "precision",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
                                                         "multiple": false,
                                                         "mandatory": false,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 0,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -2937,7 +2937,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 0,
                                                             "attributes": [
@@ -2945,7 +2945,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -2967,7 +2967,7 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "magnitude",
                                                           "units",
@@ -2975,14 +2975,14 @@
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "magnitude",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/magnitude",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -2996,14 +2996,14 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_REAL",
+                                                                "_type": "C_REAL",
                                                                 "allowed": true,
                                                                 "attributes": [
 
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0.0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3023,14 +3023,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "units",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/units",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3044,7 +3044,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_STRING",
+                                                                "_type": "C_STRING",
                                                                 "allowed": true,
                                                                 "assumed_value": "cm",
                                                                 "attributes": [
@@ -3064,14 +3064,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "precision",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value[id2]/precision",
                                                             "multiple": false,
                                                             "mandatory": false,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 0,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3085,7 +3085,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -3093,7 +3093,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3115,17 +3115,17 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_REAL",
+                                                                "_type": "C_REAL",
                                                                 "allowed": true,
                                                                 "attributes": [
 
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0.0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3142,7 +3142,7 @@
                                                                 "rm_type_name": "real"
                                                               },
                                                               {
-                                                                "@type": "C_STRING",
+                                                                "_type": "C_STRING",
                                                                 "allowed": true,
                                                                 "assumed_value": "cm",
                                                                 "attributes": [
@@ -3159,7 +3159,7 @@
                                                                 "rm_type_name": "string"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -3167,7 +3167,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3201,13 +3201,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_ARCHETYPE_ROOT",
+                                            "_type": "C_ARCHETYPE_ROOT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id30",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Gewicht",
                                               "text": "Gewicht"
                                             },
@@ -3216,14 +3216,14 @@
                                             "any_allowed": false,
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -3237,7 +3237,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_QUANTITY",
                                                     "node_id": "id2",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]",
@@ -3247,14 +3247,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "magnitude",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -3268,14 +3268,14 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_REAL",
+                                                            "_type": "C_REAL",
                                                             "allowed": true,
                                                             "attributes": [
 
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0.0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -3295,14 +3295,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "units",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -3316,7 +3316,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_STRING",
+                                                            "_type": "C_STRING",
                                                             "allowed": true,
                                                             "assumed_value": "kg",
                                                             "attributes": [
@@ -3336,14 +3336,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "precision",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
                                                         "multiple": false,
                                                         "mandatory": false,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 0,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -3357,7 +3357,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 1,
                                                             "attributes": [
@@ -3365,7 +3365,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 1,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -3387,7 +3387,7 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "magnitude",
                                                           "units",
@@ -3395,14 +3395,14 @@
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "magnitude",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/magnitude",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3416,14 +3416,14 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_REAL",
+                                                                "_type": "C_REAL",
                                                                 "allowed": true,
                                                                 "attributes": [
 
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0.0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3443,14 +3443,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "units",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/units",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3464,7 +3464,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_STRING",
+                                                                "_type": "C_STRING",
                                                                 "allowed": true,
                                                                 "assumed_value": "kg",
                                                                 "attributes": [
@@ -3484,14 +3484,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "precision",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value[id2]/precision",
                                                             "multiple": false,
                                                             "mandatory": false,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 0,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3505,7 +3505,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -3513,7 +3513,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3535,17 +3535,17 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_REAL",
+                                                                "_type": "C_REAL",
                                                                 "allowed": true,
                                                                 "attributes": [
 
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0.0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3562,7 +3562,7 @@
                                                                 "rm_type_name": "real"
                                                               },
                                                               {
-                                                                "@type": "C_STRING",
+                                                                "_type": "C_STRING",
                                                                 "allowed": true,
                                                                 "assumed_value": "kg",
                                                                 "attributes": [
@@ -3579,7 +3579,7 @@
                                                                 "rm_type_name": "string"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -3587,7 +3587,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3621,13 +3621,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_COMPLEX_OBJECT",
+                                            "_type": "C_COMPLEX_OBJECT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id13",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Bereken de Body Mass Index (BMI)",
                                               "text": "BMI"
                                             },
@@ -3635,7 +3635,7 @@
                                             "allowed": true,
                                             "any_allowed": false,
                                             "occurrences": {
-                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "_type": "MULTIPLICITY_INTERVAL",
                                               "lower": 1,
                                               "lower_included": true,
                                               "lower_unbounded": false,
@@ -3649,14 +3649,14 @@
                                             },
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -3670,7 +3670,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_QUANTITY",
                                                     "node_id": "id23",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]",
@@ -3680,14 +3680,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "magnitude",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -3701,14 +3701,14 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_REAL",
+                                                            "_type": "C_REAL",
                                                             "allowed": true,
                                                             "attributes": [
 
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0.0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -3728,14 +3728,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "units",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -3749,7 +3749,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_STRING",
+                                                            "_type": "C_STRING",
                                                             "allowed": true,
                                                             "assumed_value": "kg/m2",
                                                             "attributes": [
@@ -3769,14 +3769,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "precision",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
                                                         "multiple": false,
                                                         "mandatory": false,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 0,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -3790,7 +3790,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 1,
                                                             "attributes": [
@@ -3798,7 +3798,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 1,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -3820,7 +3820,7 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "magnitude",
                                                           "units",
@@ -3828,14 +3828,14 @@
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "magnitude",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/magnitude",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3849,14 +3849,14 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_REAL",
+                                                                "_type": "C_REAL",
                                                                 "allowed": true,
                                                                 "attributes": [
 
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0.0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3876,14 +3876,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "units",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/units",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3897,7 +3897,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_STRING",
+                                                                "_type": "C_STRING",
                                                                 "allowed": true,
                                                                 "assumed_value": "kg/m2",
                                                                 "attributes": [
@@ -3917,14 +3917,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "precision",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value[id23]/precision",
                                                             "multiple": false,
                                                             "mandatory": false,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 0,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -3938,7 +3938,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -3946,7 +3946,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3968,17 +3968,17 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_REAL",
+                                                                "_type": "C_REAL",
                                                                 "allowed": true,
                                                                 "attributes": [
 
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0.0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -3995,7 +3995,7 @@
                                                                 "rm_type_name": "real"
                                                               },
                                                               {
-                                                                "@type": "C_STRING",
+                                                                "_type": "C_STRING",
                                                                 "allowed": true,
                                                                 "assumed_value": "kg/m2",
                                                                 "attributes": [
@@ -4012,7 +4012,7 @@
                                                                 "rm_type_name": "string"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -4020,7 +4020,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4053,13 +4053,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_COMPLEX_OBJECT",
+                                            "_type": "C_COMPLEX_OBJECT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id14",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "De betekenis van de BMI-score",
                                               "text": "Betekenis BMI"
                                             },
@@ -4067,7 +4067,7 @@
                                             "allowed": true,
                                             "any_allowed": false,
                                             "occurrences": {
-                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "_type": "MULTIPLICITY_INTERVAL",
                                               "lower": 1,
                                               "lower_included": true,
                                               "lower_unbounded": false,
@@ -4081,14 +4081,14 @@
                                             },
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -4102,7 +4102,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_ORDINAL",
                                                     "node_id": "id24",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]",
@@ -4112,14 +4112,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "value",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -4133,7 +4133,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 2,
                                                             "attributes": [
@@ -4141,7 +4141,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 2,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -4158,7 +4158,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 1,
                                                             "attributes": [
@@ -4166,7 +4166,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 1,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -4183,7 +4183,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 0,
                                                             "attributes": [
@@ -4191,7 +4191,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -4208,7 +4208,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 0,
                                                             "attributes": [
@@ -4216,7 +4216,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -4236,14 +4236,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "symbol",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -4257,7 +4257,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -4275,7 +4275,7 @@
                                                               {
                                                                 "code": "at6",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "BMI beneden 20",
                                                                   "text": "< 20"
                                                                 }
@@ -4283,7 +4283,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -4301,7 +4301,7 @@
                                                               {
                                                                 "code": "at7",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "BMI van 20 tot 22",
                                                                   "text": "20 - 22"
                                                                 }
@@ -4309,7 +4309,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -4327,7 +4327,7 @@
                                                               {
                                                                 "code": "at8",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "BMI van 22 tot 28",
                                                                   "text": "22 - 28"
                                                                 }
@@ -4335,7 +4335,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -4353,7 +4353,7 @@
                                                               {
                                                                 "code": "at9",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "BMI boven 28 is overgewicht",
                                                                   "text": "> 28 (overgewicht)"
                                                                 }
@@ -4366,21 +4366,21 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "value",
                                                           "symbol"
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "value",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/value",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -4394,7 +4394,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -4402,7 +4402,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4419,7 +4419,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -4427,7 +4427,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4444,7 +4444,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -4452,7 +4452,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4469,7 +4469,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -4477,7 +4477,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4497,14 +4497,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "symbol",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value[id24]/symbol",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -4518,7 +4518,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4536,7 +4536,7 @@
                                                                   {
                                                                     "code": "at6",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI beneden 20",
                                                                       "text": "< 20"
                                                                     }
@@ -4544,7 +4544,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4562,7 +4562,7 @@
                                                                   {
                                                                     "code": "at7",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI van 20 tot 22",
                                                                       "text": "20 - 22"
                                                                     }
@@ -4570,7 +4570,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4588,7 +4588,7 @@
                                                                   {
                                                                     "code": "at8",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI van 22 tot 28",
                                                                       "text": "22 - 28"
                                                                     }
@@ -4596,7 +4596,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4614,7 +4614,7 @@
                                                                   {
                                                                     "code": "at9",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI boven 28 is overgewicht",
                                                                       "text": "> 28 (overgewicht)"
                                                                     }
@@ -4627,10 +4627,10 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -4638,7 +4638,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4655,7 +4655,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4673,7 +4673,7 @@
                                                                   {
                                                                     "code": "at6",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI beneden 20",
                                                                       "text": "< 20"
                                                                     }
@@ -4683,10 +4683,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -4694,7 +4694,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4711,7 +4711,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4729,7 +4729,7 @@
                                                                   {
                                                                     "code": "at7",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI van 20 tot 22",
                                                                       "text": "20 - 22"
                                                                     }
@@ -4739,10 +4739,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -4750,7 +4750,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4767,7 +4767,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4785,7 +4785,7 @@
                                                                   {
                                                                     "code": "at8",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI van 22 tot 28",
                                                                       "text": "22 - 28"
                                                                     }
@@ -4795,10 +4795,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -4806,7 +4806,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -4823,7 +4823,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -4841,7 +4841,7 @@
                                                                   {
                                                                     "code": "at9",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "BMI boven 28 is overgewicht",
                                                                       "text": "> 28 (overgewicht)"
                                                                     }
@@ -4865,13 +4865,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_COMPLEX_OBJECT",
+                                            "_type": "C_COMPLEX_OBJECT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id15",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Totaalscore",
                                               "text": "Totaalscore"
                                             },
@@ -4879,7 +4879,7 @@
                                             "allowed": true,
                                             "any_allowed": false,
                                             "occurrences": {
-                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "_type": "MULTIPLICITY_INTERVAL",
                                               "lower": 1,
                                               "lower_included": true,
                                               "lower_unbounded": false,
@@ -4893,14 +4893,14 @@
                                             },
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -4914,7 +4914,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_ORDINAL",
                                                     "node_id": "id25",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]",
@@ -4924,14 +4924,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "value",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -4945,7 +4945,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 0,
                                                             "attributes": [
@@ -4953,7 +4953,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 0,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -4970,7 +4970,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 1,
                                                             "attributes": [
@@ -4978,7 +4978,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 1,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -4995,7 +4995,7 @@
                                                             "rm_type_name": "integer"
                                                           },
                                                           {
-                                                            "@type": "C_INTEGER",
+                                                            "_type": "C_INTEGER",
                                                             "allowed": true,
                                                             "assumed_value": 2,
                                                             "attributes": [
@@ -5003,7 +5003,7 @@
                                                             ],
                                                             "constraint": [
                                                               {
-                                                                "@type": "INTERVAL",
+                                                                "_type": "INTERVAL",
                                                                 "lower": 2,
                                                                 "lower_included": true,
                                                                 "lower_unbounded": false,
@@ -5023,14 +5023,14 @@
                                                         "prohibited": false
                                                       },
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "symbol",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -5044,7 +5044,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -5062,7 +5062,7 @@
                                                               {
                                                                 "code": "at10",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "Niet ondervoed",
                                                                   "text": "Niet ondervoed"
                                                                 }
@@ -5070,7 +5070,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -5088,7 +5088,7 @@
                                                               {
                                                                 "code": "at11",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "Risico op ondervoeding",
                                                                   "text": "Risico op ondervoeding"
                                                                 }
@@ -5096,7 +5096,7 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -5114,7 +5114,7 @@
                                                               {
                                                                 "code": "at12",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "Ondervoed",
                                                                   "text": "Ondervoed"
                                                                 }
@@ -5127,21 +5127,21 @@
                                                     ],
                                                     "attribute_tuples": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE_TUPLE",
+                                                        "_type": "C_ATTRIBUTE_TUPLE",
                                                         "member_names": [
                                                           "value",
                                                           "symbol"
                                                         ],
                                                         "members": [
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "value",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/value",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -5155,7 +5155,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -5163,7 +5163,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -5180,7 +5180,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -5188,7 +5188,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -5205,7 +5205,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -5213,7 +5213,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -5233,14 +5233,14 @@
                                                             "prohibited": false
                                                           },
                                                           {
-                                                            "@type": "C_ATTRIBUTE",
+                                                            "_type": "C_ATTRIBUTE",
                                                             "rm_attribute_name": "symbol",
                                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
                                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id15]/value[id25]/symbol",
                                                             "multiple": false,
                                                             "mandatory": true,
                                                             "existence": {
-                                                              "@type": "MULTIPLICITY_INTERVAL",
+                                                              "_type": "MULTIPLICITY_INTERVAL",
                                                               "lower": 1,
                                                               "lower_included": true,
                                                               "lower_unbounded": false,
@@ -5254,7 +5254,7 @@
                                                             },
                                                             "children": [
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -5272,7 +5272,7 @@
                                                                   {
                                                                     "code": "at10",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "Niet ondervoed",
                                                                       "text": "Niet ondervoed"
                                                                     }
@@ -5280,7 +5280,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -5298,7 +5298,7 @@
                                                                   {
                                                                     "code": "at11",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "Risico op ondervoeding",
                                                                       "text": "Risico op ondervoeding"
                                                                     }
@@ -5306,7 +5306,7 @@
                                                                 ]
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -5324,7 +5324,7 @@
                                                                   {
                                                                     "code": "at12",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "Ondervoed",
                                                                       "text": "Ondervoed"
                                                                     }
@@ -5337,10 +5337,10 @@
                                                         ],
                                                         "tuples": [
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 0,
                                                                 "attributes": [
@@ -5348,7 +5348,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 0,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -5365,7 +5365,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -5383,7 +5383,7 @@
                                                                   {
                                                                     "code": "at10",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "Niet ondervoed",
                                                                       "text": "Niet ondervoed"
                                                                     }
@@ -5393,10 +5393,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 1,
                                                                 "attributes": [
@@ -5404,7 +5404,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 1,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -5421,7 +5421,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -5439,7 +5439,7 @@
                                                                   {
                                                                     "code": "at11",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "Risico op ondervoeding",
                                                                       "text": "Risico op ondervoeding"
                                                                     }
@@ -5449,10 +5449,10 @@
                                                             ]
                                                           },
                                                           {
-                                                            "@type": "C_PRIMITIVE_TUPLE",
+                                                            "_type": "C_PRIMITIVE_TUPLE",
                                                             "members": [
                                                               {
-                                                                "@type": "C_INTEGER",
+                                                                "_type": "C_INTEGER",
                                                                 "allowed": true,
                                                                 "assumed_value": 2,
                                                                 "attributes": [
@@ -5460,7 +5460,7 @@
                                                                 ],
                                                                 "constraint": [
                                                                   {
-                                                                    "@type": "INTERVAL",
+                                                                    "_type": "INTERVAL",
                                                                     "lower": 2,
                                                                     "lower_included": true,
                                                                     "lower_unbounded": false,
@@ -5477,7 +5477,7 @@
                                                                 "rm_type_name": "integer"
                                                               },
                                                               {
-                                                                "@type": "C_TERMINOLOGY_CODE",
+                                                                "_type": "C_TERMINOLOGY_CODE",
                                                                 "allowed": true,
                                                                 "attributes": [
 
@@ -5495,7 +5495,7 @@
                                                                   {
                                                                     "code": "at12",
                                                                     "term": {
-                                                                      "@type": "ARCHETYPE_TERM",
+                                                                      "_type": "ARCHETYPE_TERM",
                                                                       "description": "Ondervoed",
                                                                       "text": "Ondervoed"
                                                                     }
@@ -5519,13 +5519,13 @@
                                             "prohibited": false
                                           },
                                           {
-                                            "@type": "C_COMPLEX_OBJECT",
+                                            "_type": "C_COMPLEX_OBJECT",
                                             "rm_type_name": "ELEMENT",
                                             "node_id": "id16",
                                             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]",
                                             "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]",
                                             "term": {
-                                              "@type": "ARCHETYPE_TERM",
+                                              "_type": "ARCHETYPE_TERM",
                                               "description": "Acties",
                                               "text": "Acties"
                                             },
@@ -5533,7 +5533,7 @@
                                             "allowed": true,
                                             "any_allowed": false,
                                             "occurrences": {
-                                              "@type": "MULTIPLICITY_INTERVAL",
+                                              "_type": "MULTIPLICITY_INTERVAL",
                                               "lower": 0,
                                               "lower_included": true,
                                               "lower_unbounded": false,
@@ -5547,14 +5547,14 @@
                                             },
                                             "attributes": [
                                               {
-                                                "@type": "C_ATTRIBUTE",
+                                                "_type": "C_ATTRIBUTE",
                                                 "rm_attribute_name": "value",
                                                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value",
                                                 "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value",
                                                 "multiple": false,
                                                 "mandatory": false,
                                                 "existence": {
-                                                  "@type": "MULTIPLICITY_INTERVAL",
+                                                  "_type": "MULTIPLICITY_INTERVAL",
                                                   "lower": 0,
                                                   "lower_included": true,
                                                   "lower_unbounded": false,
@@ -5568,7 +5568,7 @@
                                                 },
                                                 "children": [
                                                   {
-                                                    "@type": "C_COMPLEX_OBJECT",
+                                                    "_type": "C_COMPLEX_OBJECT",
                                                     "rm_type_name": "DV_CODED_TEXT",
                                                     "node_id": "id26",
                                                     "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]",
@@ -5578,14 +5578,14 @@
                                                     "any_allowed": false,
                                                     "attributes": [
                                                       {
-                                                        "@type": "C_ATTRIBUTE",
+                                                        "_type": "C_ATTRIBUTE",
                                                         "rm_attribute_name": "defining_code",
                                                         "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]/defining_code",
                                                         "logical_path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id16]/value[id26]/defining_code",
                                                         "multiple": false,
                                                         "mandatory": true,
                                                         "existence": {
-                                                          "@type": "MULTIPLICITY_INTERVAL",
+                                                          "_type": "MULTIPLICITY_INTERVAL",
                                                           "lower": 1,
                                                           "lower_included": true,
                                                           "lower_unbounded": false,
@@ -5599,7 +5599,7 @@
                                                         },
                                                         "children": [
                                                           {
-                                                            "@type": "C_TERMINOLOGY_CODE",
+                                                            "_type": "C_TERMINOLOGY_CODE",
                                                             "allowed": true,
                                                             "attributes": [
 
@@ -5617,7 +5617,7 @@
                                                               {
                                                                 "code": "at13",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "Geen actie",
                                                                   "text": "Geen actie"
                                                                 }
@@ -5625,7 +5625,7 @@
                                                               {
                                                                 "code": "at14",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "- 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname",
                                                                   "text": "• 2 - 3 x per dag tussentijdse verstrekking\n                        • Motiveren, evt. brochure\n                        • Globale monitoring van de inname"
                                                                 }
@@ -5633,7 +5633,7 @@
                                                               {
                                                                 "code": "at15",
                                                                 "term": {
-                                                                  "@type": "ARCHETYPE_TERM",
+                                                                  "_type": "ARCHETYPE_TERM",
                                                                   "description": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie",
                                                                   "text": "• 2 - 3 x per dag tussentijdse verstrekking + verrijken hoofdmaaltijden + globale monitoring van de inname\n                        • Melden bij arts voor inschakelen diëtetiek\n                        • <= 3 werkdagen na screening diëtist in consult\n                        • <= 8 werkdagen na screening start behandeling\n                        • 5 werkdagen na start van de behandeling evaluatie"
                                                                 }
@@ -5696,13 +5696,13 @@
             "prohibited": false
           },
           {
-            "@type": "C_ARCHETYPE_ROOT",
+            "_type": "C_ARCHETYPE_ROOT",
             "rm_type_name": "EVALUATION",
             "node_id": "id0.0.101",
             "path": "/content[id0.0.101]",
             "logical_path": "/content[Assessment / remarks]",
             "term": {
-              "@type": "ARCHETYPE_TERM",
+              "_type": "ARCHETYPE_TERM",
               "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
               "text": "Beoordeling / opmerkingen"
             },
@@ -5710,7 +5710,7 @@
             "allowed": true,
             "any_allowed": false,
             "occurrences": {
-              "@type": "MULTIPLICITY_INTERVAL",
+              "_type": "MULTIPLICITY_INTERVAL",
               "lower": 0,
               "lower_included": true,
               "lower_unbounded": false,
@@ -5724,14 +5724,14 @@
             },
             "attributes": [
               {
-                "@type": "C_ATTRIBUTE",
+                "_type": "C_ATTRIBUTE",
                 "rm_attribute_name": "data",
                 "path": "/content[id0.0.101]/data",
                 "logical_path": "/content[Assessment / remarks]/data",
                 "multiple": false,
                 "mandatory": true,
                 "existence": {
-                  "@type": "MULTIPLICITY_INTERVAL",
+                  "_type": "MULTIPLICITY_INTERVAL",
                   "lower": 1,
                   "lower_included": true,
                   "lower_unbounded": false,
@@ -5745,7 +5745,7 @@
                 },
                 "children": [
                   {
-                    "@type": "C_COMPLEX_OBJECT",
+                    "_type": "C_COMPLEX_OBJECT",
                     "rm_type_name": "ITEM_TREE",
                     "node_id": "id2",
                     "path": "/content[id0.0.101]/data[id2]",
@@ -5755,14 +5755,14 @@
                     "any_allowed": false,
                     "attributes": [
                       {
-                        "@type": "C_ATTRIBUTE",
+                        "_type": "C_ATTRIBUTE",
                         "rm_attribute_name": "items",
                         "path": "/content[id0.0.101]/data[id2]/items",
                         "logical_path": "/content[Assessment / remarks]/data[id2]/items",
                         "multiple": true,
                         "mandatory": false,
                         "existence": {
-                          "@type": "MULTIPLICITY_INTERVAL",
+                          "_type": "MULTIPLICITY_INTERVAL",
                           "lower": 0,
                           "lower_included": true,
                           "lower_unbounded": false,
@@ -5775,9 +5775,9 @@
                           "upper_unbounded": false
                         },
                         "cardinality": {
-                          "@type": "CARDINALITY",
+                          "_type": "CARDINALITY",
                           "interval": {
-                            "@type": "MULTIPLICITY_INTERVAL",
+                            "_type": "MULTIPLICITY_INTERVAL",
                             "lower": 1,
                             "lower_included": true,
                             "lower_unbounded": false,
@@ -5793,13 +5793,13 @@
                         },
                         "children": [
                           {
-                            "@type": "C_COMPLEX_OBJECT",
+                            "_type": "C_COMPLEX_OBJECT",
                             "rm_type_name": "ELEMENT",
                             "node_id": "id3.1",
                             "path": "/content[id0.0.101]/data[id2]/items[id3.1]",
                             "logical_path": "/content[Assessment / remarks]/data[id2]/items[Assessment / remarks]",
                             "term": {
-                              "@type": "ARCHETYPE_TERM",
+                              "_type": "ARCHETYPE_TERM",
                               "description": "Beoordeling van de meting of opmerkingen over de meting",
                               "text": "Beoordeling / opmerkingen"
                             },
@@ -5808,14 +5808,14 @@
                             "any_allowed": false,
                             "attributes": [
                               {
-                                "@type": "C_ATTRIBUTE",
+                                "_type": "C_ATTRIBUTE",
                                 "rm_attribute_name": "value",
                                 "path": "/content[id0.0.101]/data[id2]/items[id3.1]/value",
                                 "logical_path": "/content[Assessment / remarks]/data[id2]/items[Assessment / remarks]/value",
                                 "multiple": false,
                                 "mandatory": false,
                                 "existence": {
-                                  "@type": "MULTIPLICITY_INTERVAL",
+                                  "_type": "MULTIPLICITY_INTERVAL",
                                   "lower": 0,
                                   "lower_included": true,
                                   "lower_unbounded": false,
@@ -5829,7 +5829,7 @@
                                 },
                                 "children": [
                                   {
-                                    "@type": "C_COMPLEX_OBJECT",
+                                    "_type": "C_COMPLEX_OBJECT",
                                     "rm_type_name": "DV_TEXT",
                                     "node_id": "id4",
                                     "path": "/content[id0.0.101]/data[id2]/items[id3.1]/value[id4]",
@@ -5883,16 +5883,16 @@
     "prohibited": false
   },
   "description": {
-    "@type": "RESOURCE_DESCRIPTION",
+    "_type": "RESOURCE_DESCRIPTION",
     "conversion_details": {
 
     },
     "copyright": "www.stuurgroepondervoeding.nl",
     "details": {
       "nl": {
-        "@type": "RESOURCE_DESCRIPTION_ITEM",
+        "_type": "RESOURCE_DESCRIPTION_ITEM",
         "language": {
-          "@type": "TerminologyCode",
+          "_type": "TerminologyCode",
           "code_string": "nl",
           "terminology_id": "ISO_639-1",
           "terminology_id_string": "ISO_639-1"
@@ -5906,7 +5906,7 @@
 
     },
     "lifecycle_state": {
-      "@type": "TerminologyCode",
+      "_type": "TerminologyCode",
       "code_string": "unmanaged"
     },
     "original_author": {
@@ -5925,7 +5925,7 @@
   "differential": false,
   "generated": true,
   "original_language": {
-    "@type": "TerminologyCode",
+    "_type": "TerminologyCode",
     "code_string": "nl",
     "terminology_id": "ISO_639-1",
     "terminology_id_string": "ISO_639-1"
@@ -5936,12 +5936,12 @@
   "parent_archetype_id": "openEHR-EHR-COMPOSITION.report-result-with-synopsis.v1",
   "rm_release": "1.0.2",
   "rules": {
-    "@type": "RULES_SECTION",
+    "_type": "RULES_SECTION",
     "rules": [
       {
-        "@type": "EXPRESSION_VARIABLE",
+        "_type": "EXPRESSION_VARIABLE",
         "expression": {
-          "@type": "MODEL_REFERENCE",
+          "_type": "MODEL_REFERENCE",
           "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
           "precedence_overridden": false
         },
@@ -5949,18 +5949,18 @@
         "type": "REAL"
       },
       {
-        "@type": "EXPRESSION_VARIABLE",
+        "_type": "EXPRESSION_VARIABLE",
         "expression": {
-          "@type": "BINARY_OPERATOR",
+          "_type": "BINARY_OPERATOR",
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
             "precedence_overridden": false
           },
           "operator": "divide",
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "CONSTANT",
+            "_type": "CONSTANT",
             "precedence_overridden": false,
             "type": "INTEGER",
             "value": 100
@@ -5972,23 +5972,23 @@
         "type": "REAL"
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -6001,15 +6001,15 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -6025,13 +6025,13 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "BINARY_OPERATOR",
+                  "_type": "BINARY_OPERATOR",
                   "left_operand": {
-                    "@type": "MODEL_REFERENCE",
+                    "_type": "MODEL_REFERENCE",
                     "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/magnitude",
                     "precedence_overridden": false,
                     "variable_reference_prefix": "snaq_rc_item"
@@ -6039,11 +6039,11 @@
                   "operator": "eq",
                   "precedence_overridden": false,
                   "right_operand": {
-                    "@type": "BINARY_OPERATOR",
+                    "_type": "BINARY_OPERATOR",
                     "left_operand": {
-                      "@type": "VARIABLE_REFERENCE",
+                      "_type": "VARIABLE_REFERENCE",
                       "declaration": {
-                        "@type": "VARIABLE_DECLARATION",
+                        "_type": "VARIABLE_DECLARATION",
                         "name": "snaq_rc_weight"
                       },
                       "precedence_overridden": false
@@ -6051,11 +6051,11 @@
                     "operator": "divide",
                     "precedence_overridden": false,
                     "right_operand": {
-                      "@type": "BINARY_OPERATOR",
+                      "_type": "BINARY_OPERATOR",
                       "left_operand": {
-                        "@type": "VARIABLE_REFERENCE",
+                        "_type": "VARIABLE_REFERENCE",
                         "declaration": {
-                          "@type": "VARIABLE_DECLARATION",
+                          "_type": "VARIABLE_DECLARATION",
                           "name": "snaq_rc_height"
                         },
                         "precedence_overridden": false
@@ -6063,9 +6063,9 @@
                       "operator": "multiply",
                       "precedence_overridden": true,
                       "right_operand": {
-                        "@type": "VARIABLE_REFERENCE",
+                        "_type": "VARIABLE_REFERENCE",
                         "declaration": {
-                          "@type": "VARIABLE_DECLARATION",
+                          "_type": "VARIABLE_DECLARATION",
                           "name": "snaq_rc_height"
                         },
                         "precedence_overridden": false
@@ -6079,9 +6079,9 @@
                 "operator": "and",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "BINARY_OPERATOR",
+                  "_type": "BINARY_OPERATOR",
                   "left_operand": {
-                    "@type": "MODEL_REFERENCE",
+                    "_type": "MODEL_REFERENCE",
                     "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/units",
                     "precedence_overridden": false,
                     "variable_reference_prefix": "snaq_rc_item"
@@ -6089,7 +6089,7 @@
                   "operator": "eq",
                   "precedence_overridden": false,
                   "right_operand": {
-                    "@type": "CONSTANT",
+                    "_type": "CONSTANT",
                     "precedence_overridden": false,
                     "type": "STRING",
                     "value": "kg/m2"
@@ -6102,9 +6102,9 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/precision",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -6112,7 +6112,7 @@
                 "operator": "eq",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 1
@@ -6126,31 +6126,31 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id30]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -6163,15 +6163,15 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id29]/value/magnitude",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -6187,13 +6187,13 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "BINARY_OPERATOR",
+                  "_type": "BINARY_OPERATOR",
                   "left_operand": {
-                    "@type": "MODEL_REFERENCE",
+                    "_type": "MODEL_REFERENCE",
                     "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/magnitude",
                     "precedence_overridden": false,
                     "variable_reference_prefix": "snaq_rc_item"
@@ -6201,11 +6201,11 @@
                   "operator": "eq",
                   "precedence_overridden": false,
                   "right_operand": {
-                    "@type": "BINARY_OPERATOR",
+                    "_type": "BINARY_OPERATOR",
                     "left_operand": {
-                      "@type": "VARIABLE_REFERENCE",
+                      "_type": "VARIABLE_REFERENCE",
                       "declaration": {
-                        "@type": "VARIABLE_DECLARATION",
+                        "_type": "VARIABLE_DECLARATION",
                         "name": "snaq_rc_weight"
                       },
                       "precedence_overridden": false
@@ -6213,11 +6213,11 @@
                     "operator": "divide",
                     "precedence_overridden": false,
                     "right_operand": {
-                      "@type": "BINARY_OPERATOR",
+                      "_type": "BINARY_OPERATOR",
                       "left_operand": {
-                        "@type": "VARIABLE_REFERENCE",
+                        "_type": "VARIABLE_REFERENCE",
                         "declaration": {
-                          "@type": "VARIABLE_DECLARATION",
+                          "_type": "VARIABLE_DECLARATION",
                           "name": "snaq_rc_height"
                         },
                         "precedence_overridden": false
@@ -6225,9 +6225,9 @@
                       "operator": "multiply",
                       "precedence_overridden": true,
                       "right_operand": {
-                        "@type": "VARIABLE_REFERENCE",
+                        "_type": "VARIABLE_REFERENCE",
                         "declaration": {
-                          "@type": "VARIABLE_DECLARATION",
+                          "_type": "VARIABLE_DECLARATION",
                           "name": "snaq_rc_height"
                         },
                         "precedence_overridden": false
@@ -6241,9 +6241,9 @@
                 "operator": "and",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "BINARY_OPERATOR",
+                  "_type": "BINARY_OPERATOR",
                   "left_operand": {
-                    "@type": "MODEL_REFERENCE",
+                    "_type": "MODEL_REFERENCE",
                     "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/units",
                     "precedence_overridden": false,
                     "variable_reference_prefix": "snaq_rc_item"
@@ -6251,7 +6251,7 @@
                   "operator": "eq",
                   "precedence_overridden": false,
                   "right_operand": {
-                    "@type": "CONSTANT",
+                    "_type": "CONSTANT",
                     "precedence_overridden": false,
                     "type": "STRING",
                     "value": "kg/m2"
@@ -6264,9 +6264,9 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id13]/value/precision",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -6274,7 +6274,7 @@
                 "operator": "eq",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 1
@@ -6298,9 +6298,9 @@
         ]
       },
       {
-        "@type": "EXPRESSION_VARIABLE",
+        "_type": "EXPRESSION_VARIABLE",
         "expression": {
-          "@type": "MODEL_REFERENCE",
+          "_type": "MODEL_REFERENCE",
           "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id13]/value/magnitude",
           "precedence_overridden": false
         },
@@ -6308,17 +6308,17 @@
         "type": "REAL"
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_bmi"
                 },
                 "precedence_overridden": false
@@ -6326,7 +6326,7 @@
               "operator": "lt",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 20
@@ -6336,9 +6336,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6346,9 +6346,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -6375,25 +6375,25 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_bmi"
                 },
                 "precedence_overridden": false
@@ -6401,7 +6401,7 @@
               "operator": "lt",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 20
@@ -6411,9 +6411,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6421,9 +6421,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -6460,19 +6460,19 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6480,7 +6480,7 @@
                 "operator": "ge",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 20
@@ -6490,11 +6490,11 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6502,7 +6502,7 @@
                 "operator": "lt",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 22
@@ -6515,9 +6515,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6525,9 +6525,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -6554,27 +6554,27 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6582,7 +6582,7 @@
                 "operator": "ge",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 20
@@ -6592,11 +6592,11 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6604,7 +6604,7 @@
                 "operator": "lt",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 22
@@ -6617,9 +6617,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6627,9 +6627,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -6665,19 +6665,19 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6685,7 +6685,7 @@
                 "operator": "ge",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 22
@@ -6695,11 +6695,11 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6707,7 +6707,7 @@
                 "operator": "lt",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 28
@@ -6720,9 +6720,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6730,9 +6730,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -6759,27 +6759,27 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6787,7 +6787,7 @@
                 "operator": "ge",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 22
@@ -6797,11 +6797,11 @@
               "operator": "and",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "BINARY_OPERATOR",
+                "_type": "BINARY_OPERATOR",
                 "left_operand": {
-                  "@type": "VARIABLE_REFERENCE",
+                  "_type": "VARIABLE_REFERENCE",
                   "declaration": {
-                    "@type": "VARIABLE_DECLARATION",
+                    "_type": "VARIABLE_DECLARATION",
                     "name": "snaq_rc_bmi"
                   },
                   "precedence_overridden": false
@@ -6809,7 +6809,7 @@
                 "operator": "lt",
                 "precedence_overridden": false,
                 "right_operand": {
-                  "@type": "CONSTANT",
+                  "_type": "CONSTANT",
                   "precedence_overridden": false,
                   "type": "INTEGER",
                   "value": 28
@@ -6822,9 +6822,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6832,9 +6832,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -6870,17 +6870,17 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_bmi"
                 },
                 "precedence_overridden": false
@@ -6888,7 +6888,7 @@
               "operator": "ge",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 28
@@ -6898,9 +6898,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6908,9 +6908,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -6937,25 +6937,25 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_bmi"
                 },
                 "precedence_overridden": false
@@ -6963,7 +6963,7 @@
               "operator": "ge",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 28
@@ -6973,9 +6973,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id14]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -6983,9 +6983,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7021,22 +7021,22 @@
         ]
       },
       {
-        "@type": "EXPRESSION_VARIABLE",
+        "_type": "EXPRESSION_VARIABLE",
         "expression": {
-          "@type": "BINARY_OPERATOR",
+          "_type": "BINARY_OPERATOR",
           "left_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id10]/value/value",
                 "precedence_overridden": false
               },
               "operator": "plus",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id11]/value/value",
                 "precedence_overridden": false
               },
@@ -7045,7 +7045,7 @@
             "operator": "plus",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "MODEL_REFERENCE",
+              "_type": "MODEL_REFERENCE",
               "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id12]/value/value",
               "precedence_overridden": false
             },
@@ -7054,7 +7054,7 @@
           "operator": "plus",
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]/data[id2]/events[id3]/data[id4]/items[id14]/value/value",
             "precedence_overridden": false
           },
@@ -7064,17 +7064,17 @@
         "type": "INTEGER"
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_snaq_score"
                 },
                 "precedence_overridden": false
@@ -7082,7 +7082,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 0
@@ -7092,9 +7092,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7102,9 +7102,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7131,25 +7131,25 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_snaq_score"
                 },
                 "precedence_overridden": false
@@ -7157,7 +7157,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 0
@@ -7167,9 +7167,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7177,9 +7177,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7215,17 +7215,17 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_snaq_score"
                 },
                 "precedence_overridden": false
@@ -7233,7 +7233,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 1
@@ -7243,9 +7243,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7253,9 +7253,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7282,25 +7282,25 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_snaq_score"
                 },
                 "precedence_overridden": false
@@ -7308,7 +7308,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 1
@@ -7318,9 +7318,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7328,9 +7328,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7366,17 +7366,17 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_snaq_score"
                 },
                 "precedence_overridden": false
@@ -7384,7 +7384,7 @@
               "operator": "ge",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 2
@@ -7394,9 +7394,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7404,9 +7404,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7433,25 +7433,25 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "VARIABLE_REFERENCE",
+                "_type": "VARIABLE_REFERENCE",
                 "declaration": {
-                  "@type": "VARIABLE_DECLARATION",
+                  "_type": "VARIABLE_DECLARATION",
                   "name": "snaq_rc_snaq_score"
                 },
                 "precedence_overridden": false
@@ -7459,7 +7459,7 @@
               "operator": "ge",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 2
@@ -7469,9 +7469,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/symbol",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7479,9 +7479,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7517,23 +7517,23 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7544,15 +7544,15 @@
                 "unary": true
               },
               "operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7570,17 +7570,17 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7591,15 +7591,15 @@
                 "unary": true
               },
               "operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7618,31 +7618,31 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7653,15 +7653,15 @@
                 "unary": true
               },
               "operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7679,17 +7679,17 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7700,15 +7700,15 @@
                 "unary": true
               },
               "operand": {
-                "@type": "UNARY_OPERATOR",
+                "_type": "UNARY_OPERATOR",
                 "left_operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
                 },
                 "operand": {
-                  "@type": "MODEL_REFERENCE",
+                  "_type": "MODEL_REFERENCE",
                   "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                   "precedence_overridden": false,
                   "variable_reference_prefix": "snaq_rc_item"
@@ -7737,21 +7737,21 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
               },
               "operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7764,15 +7764,15 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
               },
               "operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7786,29 +7786,29 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
               },
               "operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7821,15 +7821,15 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "UNARY_OPERATOR",
+              "_type": "UNARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
               },
               "operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7853,15 +7853,15 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7869,7 +7869,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 0
@@ -7879,9 +7879,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7889,9 +7889,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -7918,23 +7918,23 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7942,7 +7942,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 0
@@ -7952,9 +7952,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -7962,9 +7962,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -8001,15 +8001,15 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8017,7 +8017,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 1
@@ -8027,9 +8027,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8037,9 +8037,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -8066,23 +8066,23 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8090,7 +8090,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 1
@@ -8100,9 +8100,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8110,9 +8110,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -8149,15 +8149,15 @@
         ]
       },
       {
-        "@type": "ASSERTION",
+        "_type": "ASSERTION",
         "expression": {
-          "@type": "FOR_ALL_STATEMENT",
+          "_type": "FOR_ALL_STATEMENT",
           "assertion": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8165,7 +8165,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 2
@@ -8175,9 +8175,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8185,9 +8185,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -8214,23 +8214,23 @@
             "unary": false
           },
           "left_operand": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "operator": "for_all",
           "path_expression": {
-            "@type": "MODEL_REFERENCE",
+            "_type": "MODEL_REFERENCE",
             "path": "/content[id0.0.100.1]",
             "precedence_overridden": false
           },
           "precedence_overridden": false,
           "right_operand": {
-            "@type": "BINARY_OPERATOR",
+            "_type": "BINARY_OPERATOR",
             "left_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id15]/value/value",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8238,7 +8238,7 @@
               "operator": "eq",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTANT",
+                "_type": "CONSTANT",
                 "precedence_overridden": false,
                 "type": "INTEGER",
                 "value": 2
@@ -8248,9 +8248,9 @@
             "operator": "implies",
             "precedence_overridden": false,
             "right_operand": {
-              "@type": "BINARY_OPERATOR",
+              "_type": "BINARY_OPERATOR",
               "left_operand": {
-                "@type": "MODEL_REFERENCE",
+                "_type": "MODEL_REFERENCE",
                 "path": "/data[id2]/events[id3]/data[id4]/items[id16]/value/defining_code",
                 "precedence_overridden": false,
                 "variable_reference_prefix": "snaq_rc_item"
@@ -8258,9 +8258,9 @@
               "operator": "matches",
               "precedence_overridden": false,
               "right_operand": {
-                "@type": "CONSTRAINT",
+                "_type": "CONSTRAINT",
                 "item": {
-                  "@type": "C_TERMINOLOGY_CODE",
+                  "_type": "C_TERMINOLOGY_CODE",
                   "allowed": true,
                   "attributes": [
 
@@ -8300,7 +8300,7 @@
   },
   "specialized": true,
   "terminology": {
-    "@type": "ARCHETYPE_TERMINOLOGY",
+    "_type": "ARCHETYPE_TERMINOLOGY",
     "concept_code": "id1.1.1.1",
     "differential": false,
     "original_language": "nl",
@@ -8312,170 +8312,170 @@
     "term_definitions": {
       "ar-sy": {
         "id1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "وثيقة لتوصيل المعلومات للآخرين, عادة كاستجابة لطلب من طرف آخر.",
           "text": "تقرير"
         },
         "id3": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "معلومات التعريف حول التقرير",
           "text": "العنصر التعريفي الفريد للتقرير"
         },
         "id6": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "حالة التقرير بشكل كلي. و لا تمثل هذه الحالة جزءا من التقرير و إنما جميعه ككل.",
           "text": "الحالة"
         },
         "id7": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*Additional information required to capture local context or to align with other reference models/formalisms.(en)",
           "text": "*Extension(en)"
         },
         "at1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*event (en)",
           "text": "*event (en)"
         },
         "id1.1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*Document to communicate information to others about the result of a test  or assessment.(en)",
           "text": "*Result Report(en)"
         }
       },
       "sl": {
         "id1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*Document to communicate information to others, commonly in response to a request from another party.(en)",
           "text": "Poročilo"
         },
         "id3": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*Identification information about the report.(en)",
           "text": "ID Poročila"
         },
         "id6": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*The status of the entire report. Note: This is not the status of any of the report components.(en)",
           "text": "Status"
         },
         "id7": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*Additional information required to capture local context or to align with other reference models/formalisms.(en)",
           "text": "*Extension(en)"
         },
         "at1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*event (en)",
           "text": "*event (en)"
         }
       },
       "en": {
         "id1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Document to communicate information to others, commonly in response to a request from another party.",
           "text": "Report"
         },
         "id3": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Identification information about the report.",
           "text": "Report ID"
         },
         "id6": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "The status of the entire report. Note: This is not the status of any of the report components.",
           "text": "Status"
         },
         "id7": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Additional information required to capture local context or to align with other reference models/formalisms.",
           "text": "Extension"
         },
         "at1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "event",
           "text": "event"
         },
         "id1.1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Document to communicate information to others about the result of a test  or assessment.",
           "text": "Result Report"
         }
       },
       "es-ar": {
         "id1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Documento para comunicar información a otros, comunmente en respuesta a la solicitud de un tercero.",
           "text": "Informe"
         },
         "id3": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Información para la identificación del informe.",
           "text": "ID del informe"
         },
         "id6": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "El estado del informe como un todo. Nota: no se refiere al estado de alguno de los componentes del informe.",
           "text": "Estado"
         },
         "id7": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*Additional information required to capture local context or to align with other reference models/formalisms.(en)",
           "text": "*Extension(en)"
         },
         "at1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "*event (en)",
           "text": "*event (en)"
         }
       },
       "nl": {
         "id1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Document om informatie met anderen te communiceren, vaak op verzoek van een andere partij.",
           "text": "Rapportage"
         },
         "id3": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Identificerende informatie over deze rapportage",
           "text": "Rapportage ID"
         },
         "id6": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "De status van de rapportage. Let op, dit is niet de status van een van de onderdelen van de rappotage",
           "text": "Status"
         },
         "id7": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Extra informatie nodig om de context te beschrijven of te voldoen met andere modellen of formalismes.",
           "text": "Uitbreiding"
         },
         "at1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "event",
           "text": "event"
         },
         "id1.1.1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Rapportage met resultaat van een meting en beoordeling",
           "text": "Rapportage met resultaat van een meting en beoordeling"
         },
         "id0.0.100": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Een observatie",
           "text": "Een observatie"
         },
         "id0.0.101": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Beschrijf hier eventueel de klinische beoordeling of opmerkingen van het resultaat van de meting.\n                    Dit kan bijvoorbeeld een uitgebreidere interpretatie van het resultaat zijn, of de betekenis van het resultaat voor de cliënt.",
           "text": "Beoordeling / opmerkingen"
         },
         "id1.1.1.1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "SNAQ RC",
           "text": "SNAQ RC"
         },
         "id0.0.100.1": {
-          "@type": "ARCHETYPE_TERM",
+          "_type": "ARCHETYPE_TERM",
           "description": "Short Nutritional Assessment Questionnaire for Residential care - Vroege herkenning en behandeling van ondervoeding in verpleeg- en verzorgingshuizen",
           "text": "SNAQ RC"
         }


### PR DESCRIPTION
fixes after testing with our mobile form implementation:
- ArchetypeParsePostProcessor did not set parent object for tuples
- archetype_details was not set in RMOBjectCreator when creating an object from a C_ARCHETYPE_ROOT
- terminology_id for DV_CODED_TEXT set/created in rules did not get set automatically