### PR TITLE
Add equal/hash in RMObjectValidationMessage

### DIFF
--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
@@ -3,6 +3,8 @@ package com.nedap.archie.rmobjectvalidator;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.ArchetypeConstraint;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 02/09/15.
  */
@@ -115,5 +117,23 @@ public class RMObjectValidationMessage {
             return archetype.getArchetypeId().getFullId();
         }
         return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RMObjectValidationMessage that = (RMObjectValidationMessage) o;
+        return Objects.equals(archetypePath, that.archetypePath) &&
+                Objects.equals(path, that.path) &&
+                Objects.equals(humanReadableArchetypePath, that.humanReadableArchetypePath) &&
+                Objects.equals(message, that.message) &&
+                Objects.equals(archetypeId, that.archetypeId) &&
+                type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(archetypePath, path, humanReadableArchetypePath, message, archetypeId, type);
     }
 }


### PR DESCRIPTION
Reason for this PR:

When `validate()` is called on an `RMObjectValidator` a list of `RMObjectValidationMessage` is returned. 

In our frontend, we validate for error messages anytime a user changes values in the UI. 
UI views are observing changes in the list of `RMObjectValidationMessage` and re-render accordingly when a change is detected. However we noticed that the UI was re-rendering even if the validation/error messages remained the same. I traced back this problem to a missing equals implementation.

I know that these equal checks have also been added for classes in (for example) the package `com.nedap.archie.rm.datavalues` but I don't know exactly what qualifies classes to have these equal overrides. If this doesn't make sense, we'll probably have to resort to mapping these `RMObjectValidationMessage` to our own stable error message objects.