### PR TITLE
Add missing operand setters

### DIFF
--- a/aom/src/main/java/com/nedap/archie/rules/ForAllStatement.java
+++ b/aom/src/main/java/com/nedap/archie/rules/ForAllStatement.java
@@ -32,7 +32,15 @@ public class ForAllStatement extends Operator {
         return getFirstOperand();
     }
 
+    public void setPathExpression(Expression pathExpression) {
+        super.setFirstOperand(pathExpression);
+    }
+
     public Expression getAssertion() {
         return getSecondOperand();
+    }
+
+    public void setAssertion(Expression assertion) {
+        super.setSecondOperand(assertion);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Operator.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Operator.java
@@ -39,9 +39,17 @@ public class Operator extends Expression {
         return operands.size() > 0 ? operands.get(0) : null;
     }
 
+    protected void setFirstOperand(Expression firstOperand) {
+        setLeftOperand(firstOperand);
+    }
+
     @JsonIgnore
     protected Expression getSecondOperand() {
         return operands.size() > 1 ? operands.get(1) : null;
+    }
+
+    protected void setSecondOperand(Expression secondOperand) {
+        setRightOperand(secondOperand);
     }
 
     public String getSymbol() {

--- a/aom/src/main/java/com/nedap/archie/rules/UnaryOperator.java
+++ b/aom/src/main/java/com/nedap/archie/rules/UnaryOperator.java
@@ -20,4 +20,8 @@ public class UnaryOperator extends Operator {
         return super.getFirstOperand();
     }
 
+    public void setOperand(Expression operand) {
+        super.setFirstOperand(operand);
+    }
+
 }


### PR DESCRIPTION
Deserializing of ForAllStatement and UnaryOperator didn't work correctly because of missing setter for the operands since Archie 2. This PR adds the missing setters in ForAllStatement and UnaryOperator.