### PR TITLE
Disable lazy evaluation implies

### DIFF
--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -77,8 +77,8 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
 
     private ValueList evaluateImplies(RuleEvaluation<?> evaluation, BinaryOperator statement) {
         ValueList leftValue = evaluation.evaluate(statement.getLeftOperand());
+        ValueList rightValue = evaluation.evaluate(statement.getRightOperand());
         if(leftValue.getSingleBooleanResult()) {
-            ValueList rightValue  = evaluation.evaluate(statement.getRightOperand());
             return rightValue;
         } else {
             //if the left operand evaluates to false, this implies nothing and the result is true

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -7,6 +7,11 @@ import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.creation.RMObjectCreator;
 import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rm.archetyped.Pathable;
+import com.nedap.archie.rm.datastructures.Cluster;
+import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datastructures.ItemTree;
+import com.nedap.archie.rm.datavalues.DvBoolean;
+import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.testutil.TestUtil;
 import com.nedap.archie.xml.JAXBUtil;
@@ -14,6 +19,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -50,8 +57,17 @@ public class FixableAssertionsCheckerTest {
         RuleEvaluation<Locatable> ruleEvaluation = getRuleEvaluation();
 
         Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        ItemTree itemTree = (ItemTree) root.itemAtPath("/data[id2]/events[id3]/data[id4]");
+
+        // Add a second cluster with the boolean set to true
+        Cluster cluster2 = new Cluster("id81", new DvText("Cluster"), new ArrayList<>());
+        DvBoolean dvBoolean = new DvBoolean();
+        dvBoolean.setValue(true);
+        cluster2.addItem(new Element("id82", new DvText("First element"), dvBoolean));
+        itemTree.addItem(cluster2);
+
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
-        assertEquals("There are ten values that must be set", 10, evaluate.getSetPathValues().size());
+        assertEquals("There are eleven values that must be set", 11, evaluate.getSetPathValues().size());
 
         //assert that paths must be set to specific values
         assertEquals("test string", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value").getValue());
@@ -64,6 +80,7 @@ public class FixableAssertionsCheckerTest {
         assertEquals("at1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/code_string").getValue());
         assertEquals("local", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/terminology_id/value").getValue());
         assertEquals("Option 1", evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/value").getValue());
+        assertEquals("The boolean is true", evaluate.getSetPathValues().get("/data[id2]/events[id3, 1]/data[id4]/items[id81, 6]/items[id84]/value/value").getValue());
 
         //now assert that the RM Object cloned by rule evaluation has been modified with the new values for further evaluation
         assertEquals("test string", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
@@ -76,6 +93,7 @@ public class FixableAssertionsCheckerTest {
         assertEquals("at1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/code_string"));
         assertEquals("local", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code/terminology_id/value"));
         assertEquals("Option 1", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/value"));
+        assertEquals("The boolean is true", ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3, 1]/data[id4]/items[id81, 6]/items[id84]/value/value"));
 
         //and of course the DV_ORDINAL and DV_CODED_TEXT should be constructed correctly, with the correct numeric respectively a textual value
         assertEquals(0l, ruleEvaluation.getRMRoot().itemAtPath("/data[id2]/events[id3]/data[id4]/items[id7]/value/value"));

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/fixable_matches.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/fixable_matches.adls
@@ -60,6 +60,20 @@ definition
 											}
 										}
 									}
+									CLUSTER[id81] matches {	-- Repeatable cluster
+										items matches {
+											ELEMENT[id82] occurrences matches {0..1} matches {	-- First element
+												value matches {
+													DV_BOOLEAN[id83] 
+												}
+											}
+											ELEMENT[id84] occurrences matches {0..1} matches {	-- Second element
+												value matches {
+													DV_TEXT[id85] 
+												}
+											}
+										}
+									}
 								}
 							}
 						}
@@ -74,6 +88,10 @@ rules
 	/data[id2]/events[id3]/data[id4]/items[id6]/value/defining_code matches {[at1]}
 	/data[id2]/events[id3]/data[id4]/items[id7]/value/symbol matches {[at6]}
 	/data[id2]/events[id3]/data[id4]/items[id8]/null_flavour/defining_code matches {[at1]}
+    for_all $cluster in /data[id2]/events[id3]/data[id4]/items[id81]
+          ($cluster/items[id82]/value/value implies
+            $cluster/items[id84]/value/value matches {"The boolean is true"})
+
 
 terminology
 	term_definitions = <
@@ -85,6 +103,18 @@ terminology
 			["at1"] = <
 				text = <"Option 1">
 				description = <"Option 1">
+			>
+			["id81"] = <
+				text = <"Repeatable cluster">
+				description = <"">
+			>
+			["id82"] = <
+				text = <"First element">
+				description = <"">
+			>
+			["id84"] = <
+				text = <"Second element">
+				description = <"">
 			>
 		>
 	>


### PR DESCRIPTION
Disable lazy evaluation of implies operator as it breaks the FixableAssertionsChecker in for_all statements.