### PR TITLE
Fix indices of paths returned for RM path queries with indices

### DIFF
--- a/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
+++ b/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
@@ -245,7 +245,7 @@ public class RMPathQuery {
             for(Object object:collection) {
                 if(number == i) {
                     //TODO: check for other constraints as well
-                    return Lists.newArrayList(new RMObjectWithPath(object, path + buildPathConstraint(i-1, lookup.getArchetypeNodeIdFromRMObject(object))));
+                    return Lists.newArrayList(new RMObjectWithPath(object, path + buildPathConstraint(i, lookup.getArchetypeNodeIdFromRMObject(object))));
                 }
                 i++;
             }

--- a/tools/src/test/java/com/nedap/archie/adlparser/RMPathQueryTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/RMPathQueryTest.java
@@ -99,6 +99,14 @@ public class RMPathQueryTest {
         for(RMObjectWithPath value:values) {
             assertEquals(value.getObject(), new RMPathQuery(value.getPath()).findList(modelInfoLookup, composition).get(0).getObject());
         }
+
+        // check that one result is returned when specifying an index, and with the correct path
+        values = new RMPathQuery("/context[id11]/other_context[id2]/items[id3,1]/items[id5]/value").findList(modelInfoLookup, composition);
+        assertEquals(1, values.size());
+        assertEquals("/context/other_context[id2]/items[id3, 1]/items[id5, 2]/value", values.get(0).getPath());
+        for(RMObjectWithPath value:values) {
+            assertEquals(value.getObject(), new RMPathQuery(value.getPath()).findList(modelInfoLookup, composition).get(0).getObject());
+        }
     }
 
 


### PR DESCRIPTION
RMPathQuery.findList would return incorrect paths when an query with an index is used.

E.g. with the query "/context[id11]/other_context[id2]/items[id3,1]/items[id5]/value" (containing an `,1`) the returned path was `/context/other_context[id2]/items[id3, 0]/items[id5, 2]/value` instead of `/context/other_context[id2]/items[id3, 1]/items[id5, 2]/value`. So the index of id3 was one off.

Reported by @EdwardvanRaak 