### PR TITLE
Allow Kryo serializer registration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
     implementation 'com.google.guava:guava:31.1-jre'
 
     implementation "org.reflections:reflections:${reflectionsVersion}"
-    implementation 'com.esotericsoftware.kryo:kryo5:5.3.0'
+    api 'com.esotericsoftware.kryo:kryo5:5.3.0'
 
     implementation('commons-io:commons-io:2.11.0'){
       exclude group: 'commons-logging', module: 'commons-logging'

--- a/utils/src/main/java/com/nedap/archie/util/KryoUtil.java
+++ b/utils/src/main/java/com/nedap/archie/util/KryoUtil.java
@@ -1,8 +1,10 @@
 package com.nedap.archie.util;
 
 import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
 import com.esotericsoftware.kryo.kryo5.util.Pool;
 
+import java.util.HashMap;
 
 /**
  * Created by pieter.bos on 03/11/15.
@@ -10,16 +12,23 @@ import com.esotericsoftware.kryo.kryo5.util.Pool;
 public class KryoUtil {
 
     // Build pool with SoftReferences enabled (optional)
-    private static Pool<Kryo> pool;
+    private static final Pool<Kryo> pool;
+
+    @SuppressWarnings("rawtypes")
+    private static final HashMap<Class, Serializer> serializers = new HashMap<>();
 
     static {
         // Pool constructor arguments: thread safe, soft references, maximum capacity
         pool = new Pool<Kryo>(true, false) {
-            protected Kryo create () {
+            protected Kryo create() {
                 Kryo kryo = new Kryo();
+
                 kryo.setRegistrationRequired(false);
                 kryo.setReferences(true);
                 kryo.setCopyReferences(true);
+
+                serializers.forEach(kryo::register);
+
                 return kryo;
             }
         };
@@ -28,5 +37,10 @@ public class KryoUtil {
 
     public static Pool<Kryo> getPool() {
         return pool;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static void addSerializer(Class clazz, Serializer serializer) {
+        serializers.put(clazz, serializer);
     }
 }


### PR DESCRIPTION
Need to discuss this solution.

This would allow implementing applications to use `KryoUtil.addSerializer(URI::class.java, URISerializer())` for example. 

Which solves this crash when attempting to clone anything with a `DV_MULTIMEDIA` on Android (where `java.net.URI` can be from Java 8 which has no default empty constructor)
>com.esotericsoftware.kryo.kryo5.KryoException: Class cannot be created (missing no-arg constructor): java.net.URI
Serialization trace:
    value (com.nedap.archie.rm.datavalues.DvURI)

Note: I grabbed a serializer to test this out from https://github.com/magro/kryo-serializers

**Example from Android side (Kotlin)**

![Screenshot from 2022-09-29 17-38-15](https://user-images.githubusercontent.com/1560465/193076171-56d28df8-7dbf-48c6-9223-0bd728bf0f63.png)
