### PR TITLE
Add default URL serializer (Kryo)

### DIFF
--- a/utils/src/main/java/com/nedap/archie/util/KryoUtil.java
+++ b/utils/src/main/java/com/nedap/archie/util/KryoUtil.java
@@ -1,8 +1,8 @@
 package com.nedap.archie.util;
 
 import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.serializers.DefaultSerializers;
 import com.esotericsoftware.kryo.kryo5.util.Pool;
-
 
 /**
  * Created by pieter.bos on 03/11/15.
@@ -20,6 +20,7 @@ public class KryoUtil {
                 kryo.setRegistrationRequired(false);
                 kryo.setReferences(true);
                 kryo.setCopyReferences(true);
+                kryo.setDefaultSerializer(DefaultSerializers.URLSerializer.class);
                 return kryo;
             }
         };


### PR DESCRIPTION
See earlier discussion at https://github.com/openEHR/archie/pull/441

This was the only default serializer that was available that made sense to add at this time.

This needs to be removed (and tested again) when Kryo 6 is released.