### PR TITLE
Update Jackson Databind to version 2.13.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ subprojects {
     api 'org.slf4j:slf4j-api:1.7.36'
 
     api "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-    api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    api "com.fasterxml.jackson.core:jackson-databind:2.13.4.2"
     api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
     implementation 'com.google.guava:guava:31.1-jre'


### PR DESCRIPTION
This includes FasterXML/jackson-databind#3590: Add check in primitive value deserializers to avoid deep wrapper array
  nesting wrt `UNWRAP_SINGLE_VALUE_ARRAYS` [CVE-2022-42003]