### PR TITLE
Add workaround for Javadoc bug JDK-8222255 / JDK-8295850

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/package-info.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/package-info.java
@@ -1,3 +1,7 @@
+// The empty comment below is a workaround for https://bugs.openjdk.org/browse/JDK-8222255 / https://bugs.openjdk.org/browse/JDK-8295850
+/**
+ * 
+ */
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 
 package com.nedap.archie.rm;


### PR DESCRIPTION
Add workaround for Javadoc bug [JDK-8222255](https://bugs.openjdk.org/browse/JDK-8222255) / [JDK-8295850](https://bugs.openjdk.org/browse/JDK-8295850)

This fixes the error below which was thrown during Java 11 builds in Semaphore CI.
```
/home/semaphore/archie/openehr-rm/src/main/java/com/nedap/archie/rm/package-info.java:1: error: unknown tag: javax.xml.bind.annotation.XmlSchema
@javax.xml.bind.annotation.XmlSchema(namespace = "http://schemas.openehr.org/v1", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
^
```