### PR TITLE
Add default constructor to DefaultValueContainer class

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/DefaultValueContainer.java
+++ b/aom/src/main/java/com/nedap/archie/aom/DefaultValueContainer.java
@@ -19,6 +19,10 @@ public class DefaultValueContainer extends OpenEHRBase {
     private String format;
     private String content;
 
+    public DefaultValueContainer() {
+        
+    }
+
     public DefaultValueContainer(String format, String content) {
         this.format = format;
         this.content = content;


### PR DESCRIPTION
At the moment when trying to serialise an archetype with a default value, the following error occurs:

`Class cannot be created (missing no-arg constructor): com.nedap.archie.aom.DefaultValueContainer`