### PR TITLE
Fix serialization of closed archetype slot with occurrences still present

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/CComplexObjectParser.java
@@ -306,14 +306,14 @@ public class CComplexObjectParser extends BaseTreeWalker {
 
     private ArchetypeSlot parseArchetypeSlot(Archetype_slotContext slotContext) {
         ArchetypeSlot slot = new ArchetypeSlot();
-        C_archetype_slot_headContext headContext = slotContext.c_archetype_slot_head();
-        slot.setNodeId(headContext.c_archetype_slot_id().ID_CODE().getText());
-        slot.setRmTypeName(headContext.c_archetype_slot_id().type_id().getText());
-        if(headContext.c_archetype_slot_id().SYM_CLOSED() != null) {
+
+        slot.setNodeId(slotContext.ID_CODE().getText());
+        slot.setRmTypeName(slotContext.type_id().getText());
+        if(slotContext.SYM_CLOSED() != null) {
             slot.setClosed(true);
         }
-        if (headContext.c_occurrences() != null) {
-            slot.setOccurrences(parseMultiplicityInterval(headContext.c_occurrences()));
+        if (slotContext.c_occurrences() != null) {
+            slot.setOccurrences(parseMultiplicityInterval(slotContext.c_occurrences()));
         }
         RulesParser assertionParser = new RulesParser(getErrors());
         if (slotContext.c_excludes() != null) {

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
@@ -30,15 +30,15 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
                 .append(cobj.getRmTypeName()).append("[").append(cobj.getNodeId()).append("]");
         if(cobj.isClosed()) {
             builder.append(" closed");
-        }
-        if (cobj.getOccurrences() != null) {
-            builder.append(" occurrences matches {");
-            ArchetypeSerializeUtils.buildOccurrences(builder, cobj.getOccurrences());
-            builder.append("}");
-        }
-        if (!cobj.isClosed()) {
+        } else {
+            if (cobj.getOccurrences() != null) {
+                builder.append(" occurrences matches {");
+                ArchetypeSerializeUtils.buildOccurrences(builder, cobj.getOccurrences());
+                builder.append("}");
+            }
             appendMatches(cobj);
         }
+
         builder.unindent();
     }
 

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
@@ -28,14 +28,15 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
         builder.append("allow_archetype")
                 .append(" ")
                 .append(cobj.getRmTypeName()).append("[").append(cobj.getNodeId()).append("]");
+        if(cobj.isClosed()) {
+            builder.append(" closed");
+        }
         if (cobj.getOccurrences() != null) {
             builder.append(" occurrences matches {");
             ArchetypeSerializeUtils.buildOccurrences(builder, cobj.getOccurrences());
             builder.append("}");
         }
-        if (cobj.isClosed()) {
-            builder.append(" closed");
-        } else {
+        if (!cobj.isClosed()) {
             appendMatches(cobj);
         }
         builder.unindent();

--- a/grammars/src/main/antlr/cadl.g4
+++ b/grammars/src/main/antlr/cadl.g4
@@ -34,14 +34,7 @@ c_archetype_root: SYM_USE_ARCHETYPE type_id '[' ID_CODE (SYM_COMMA archetype_ref
 
 c_complex_object_proxy: SYM_USE_NODE type_id '[' ID_CODE ']' c_occurrences? adl_path ;
 
-archetype_slot:
-      c_archetype_slot_head SYM_MATCHES '{' c_includes? c_excludes? '}'
-    | c_archetype_slot_head
-    ;
-
-c_archetype_slot_head: c_archetype_slot_id c_occurrences? ;
-
-c_archetype_slot_id: SYM_ALLOW_ARCHETYPE type_id '[' ID_CODE ']' SYM_CLOSED? ;
+archetype_slot: SYM_ALLOW_ARCHETYPE type_id '[' ID_CODE ']' (( c_occurrences? ( SYM_MATCHES '{' c_includes? c_excludes? '}' )? ) | SYM_CLOSED ) ;
 
 c_attribute_def:
       c_attribute

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -270,7 +270,7 @@ public class ADLDefinitionSerializerTest {
         archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls");
         slot = archetype.itemAtPath("/items[id2]");
         serialized = serializeConstraint(slot);
-        assertEquals("\n    allow_archetype OBSERVATION[id2] closed occurrences matches {0..1}", serialized);
+        assertEquals("\n    allow_archetype OBSERVATION[id2] closed", serialized);
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -244,28 +244,33 @@ public class ADLDefinitionSerializerTest {
         Archetype archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_include_any_exclude_empty.v1.0.0.adls");
         ArchetypeSlot slot = archetype.itemAtPath("/items[id2]");
         String serialized = serializeConstraint(slot);
-        assertThat(serialized, equalTo("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {     -- Vital signs\n" +
+        assertEquals("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {     -- Vital signs\n" +
                 "        include\n" +
                 "            archetype_id/value matches {/.*/}\n" +
-                "    }"));
+                "    }", serialized);
 
 
         archetype = load("openEHR-EHR-CLUSTER.device.v1.adls");
         slot = archetype.itemAtPath("/items[id10]");
         serialized = serializeConstraint(slot);
-        assertThat(serialized, equalTo("\n    allow_archetype CLUSTER[id10] occurrences matches {0..*} matches {     -- Properties\n" +
+        assertEquals("\n    allow_archetype CLUSTER[id10] occurrences matches {0..*} matches {     -- Properties\n" +
                 "        include\n" +
                 "            archetype_id/value matches {/openEHR-EHR-CLUSTER\\.dimensions(-a-zA-Z0-9_]+)*\\.v1|openEHR-EHR-CLUSTER\\.catheter(-a-zA-Z0-9_]+)*\\.v1/}\n" +
-                "    }"));
+                "    }", serialized);
 
 
         archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_include_empty_exclude_non_any.v1.0.0.adls");
         slot = archetype.itemAtPath("/items[id2]");
         serialized = serializeConstraint(slot);
-        assertThat(serialized, equalTo("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {     -- Vital signs\n" +
+        assertEquals("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {     -- Vital signs\n" +
                 "        exclude\n" +
                 "            archetype_id/value matches {/openEHR-EHR-OBSERVATION\\.blood_pressure([a-zA-Z0-9_]+)*\\.v1/}\n" +
-                "    }"));
+                "    }", serialized);
+
+        archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls");
+        slot = archetype.itemAtPath("/items[id2]");
+        serialized = serializeConstraint(slot);
+        assertEquals("\n    allow_archetype OBSERVATION[id2] closed occurrences matches {0..1}", serialized);
     }
 
     @Test

--- a/tools/src/test/resources/adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls
+++ b/tools/src/test/resources/adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls
@@ -17,7 +17,7 @@ description
 	details = <
 		["en"] = <
 			language = <[ISO_639-1::en]>
-			purpose = <"Closed archetype slot with occurrences">
+			purpose = <"Closed archetype slot">
 			keywords = <"ADL", "test", "slots">
 		>
 	>

--- a/tools/src/test/resources/adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls
+++ b/tools/src/test/resources/adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls
@@ -1,0 +1,51 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2)
+	openEHR-EHR-SECTION.slot_cosed.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	custodian_namespace = <"org.openehr">
+	custodian_organisation = <"openEHR Foundation <http://www.openEHR.org>">
+
+	original_author = <
+		["name"] = <"Thomas Beale">
+ 		["email"] = <"thomas.beale@openEHR.org">
+		["organisation"] = <"openEHR Foundation <http://www.openEHR.org>">
+		["date"] = <"2010-03-14">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"Closed archetype slot with occurrences">
+			keywords = <"ADL", "test", "slots">
+		>
+	>
+
+	lifecycle_state = <"published">
+	other_details = <
+		["regression"] = <"PASS">
+	>
+	copyright = <"Copyright © 2010 openEHR Foundation <http://www.openEHR.org>">
+	licence = <"Creative Commons CC-BY-SA <https://creativecommons.org/licenses/by-sa/3.0/>">
+
+definition
+	SECTION[id1] matches {	-- Slot section
+		items cardinality matches {1..*; unordered} matches {
+			allow_archetype OBSERVATION[id2] closed occurrences matches {0..1}
+		}
+	}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"Slot section">
+				description = <"Slot section">
+			>
+			["id2"] = <
+				text = <"Vital signs">
+				description = <"Vital signs observations.">
+			>
+		>
+	>

--- a/tools/src/test/resources/adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls
+++ b/tools/src/test/resources/adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls
@@ -32,7 +32,7 @@ description
 definition
 	SECTION[id1] matches {	-- Slot section
 		items cardinality matches {1..*; unordered} matches {
-			allow_archetype OBSERVATION[id2] closed occurrences matches {0..1}
+			allow_archetype OBSERVATION[id2] closed
 		}
 	}
 


### PR DESCRIPTION
serialization serialized occurrences first, then closed. Should be the other way around.

The question arises whethger closed slots should have occurrences, but hey, if it's in the AOM and possible in the ADL, safe to serialize at least, and perhaps the OPT generator should not do this?