### PR TITLE
Add validation for OpenEHR term bindings

### DIFF
--- a/openehr-terminology/src/main/java/com/nedap/archie/terminology/OpenEHRTerminologyAccess.java
+++ b/openehr-terminology/src/main/java/com/nedap/archie/terminology/OpenEHRTerminologyAccess.java
@@ -1,6 +1,5 @@
 package com.nedap.archie.terminology;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nedap.archie.terminology.openehr.*;
@@ -10,7 +9,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -131,13 +129,21 @@ public class OpenEHRTerminologyAccess implements TerminologyAccess {
         return Collections.emptyList();
     }
 
-    private static Pattern openEHRTermIdPattern = Pattern.compile("http://openehr.org/id/(?<id>[0-9]+)");
+    private static final Pattern openEHRTermIdPattern = Pattern.compile("http://openehr.org/id/(?<id>[0-9]+)");
+
+    public String parseTerminologyURI(String uri) {
+        Matcher matcher = openEHRTermIdPattern.matcher(uri);
+        if(matcher.matches()) {
+            return matcher.group("id");
+        }
+        return null;
+    }
 
     @Override
     public TermCode getTermByTerminologyURI(String uri, String language) {
-        Matcher matcher = openEHRTermIdPattern.matcher(uri);
-        if(matcher.matches()) {
-            return getTerm("openehr", matcher.group("id"), language);
+        String code = parseTerminologyURI(uri);
+        if(code != null) {
+            return getTerm("openehr", code, language);
         }
         return null;
     }

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_term_binding.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_term_binding.adls
@@ -1,0 +1,63 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+    openEHR-EHR-CLUSTER.matches_term_binding.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Mathijs Hudepohl">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"Test for rules, simple constant arithmetics">
+            keywords = <"ADL", "test">
+        >
+    >
+    lifecycle_state = <"published">
+    other_details = <
+        ["regression"] = <"PASS">
+    >
+    copyright = <"copyright © 2004 openEHR Foundation <http://www.openEHR.org>">
+
+definition
+    CLUSTER[id1] matches {
+        items matches {
+            ELEMENT[id2] occurrences matches {1} matches {
+                value matches {
+                    DV_CODED_TEXT[id3]
+                }
+            }
+            ELEMENT[id4] occurrences matches {1} matches {
+                value matches {
+                    DV_CODED_TEXT[id5]
+                }
+            }
+        }
+    }
+
+rules
+    /items[id2]/value/defining_code matches {[at9000]}
+    /items[id4]/value/defining_code matches {[ac3]}
+
+terminology
+    term_bindings = <
+        ["openehr"] = <
+            ["at9004"] = <http://openehr.org/id/245>
+            ["at9000"] = <http://openehr.org/id/526>
+            ["at9001"] = <http://openehr.org/id/527>
+            ["at9002"] = <http://openehr.org/id/528>
+            ["at9003"] = <http://openehr.org/id/529>
+            ["at9005"] = <http://openehr.org/id/530>
+            ["at9006"] = <http://openehr.org/id/531>
+            ["at9007"] = <http://openehr.org/id/532>
+        >
+    >
+    value_sets = <
+        ["ac3"] = <
+            id = <"ac3">
+            members = <"at9000", "at9001">
+        >
+    >
+


### PR DESCRIPTION
Adds validation of OpenEHR term bindings.

**Remarks:**
* A helper method was added for fetching the term binding codes.
* Uses `atCodes` from the existing `getValueSetExpanded` method to get the term bindings of the `openehr` terminology ID.
* Refactored `isValidValue` method to work with both `local` and `openehr` terminologies.