### PR TITLE
Upgrade antlr to 4.11.1, keeping JDK8 support

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,8 +10,10 @@ blocks:
       jobs:
         - name: Java 8 build
           commands:
+            - sem-version java 11
+            - ./gradlew clean compile testCompile
             - sem-version java 1.8
-            - ./gradlew clean build
+            - ./gradlew test
         - name: Java 11 build
           commands:
             - sem-version java 11

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,9 +11,9 @@ blocks:
         - name: Java 8 build
           commands:
             - sem-version java 11
-            - ./gradlew clean compile testCompile
+            - ./gradlew clean compileJava compileTestJava
             - sem-version java 1.8
-            - ./gradlew test
+            - ./gradlew check
         - name: Java 11 build
           commands:
             - sem-version java 11

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ If you want to depend on just the AOM and BMM, without any reference model imple
 [![Build Status](https://travis-ci.org/openEHR/archie.svg?branch=master)](https://travis-ci.org/openEHR/archie)
 [![codecov](https://codecov.io/gh/openEHR/archie/branch/master/graph/badge.svg)](https://codecov.io/gh/openEHR/archie)
 
-You need Java 8 to build. Check out the source and type:
+You need Java 11 or higher to build. When compiled, the library works on JDK 8, but building is not supported on that version.
+
+To build, Check out the source and type:
 
 ```sh
 ./gradlew build

--- a/grammars/build.gradle
+++ b/grammars/build.gradle
@@ -1,7 +1,7 @@
 description = "grammars for parsing ADL, ODIN and xpath"
 apply plugin: 'antlr'
 
-ext.antlrVersion = '4.11.0'
+ext.antlrVersion = '4.11.1'
 
 generateGrammarSource { //antlr4
   outputDirectory = new File("${project.buildDir}/generated-src/antlr/main/com/nedap/archie/adlparser/antlr".toString())
@@ -15,5 +15,5 @@ classes {
 
 dependencies {
   antlr "org.antlr:antlr4:${antlrVersion}"
-  api 'org.antlr:antlr4-runtime:4.11.0'
+  api 'org.antlr:antlr4-runtime:4.11.1'
 }

--- a/grammars/build.gradle
+++ b/grammars/build.gradle
@@ -1,7 +1,7 @@
 description = "grammars for parsing ADL, ODIN and xpath"
 apply plugin: 'antlr'
 
-ext.antlrVersion = '4.9.3'
+ext.antlrVersion = '4.11.0'
 
 generateGrammarSource { //antlr4
   outputDirectory = new File("${project.buildDir}/generated-src/antlr/main/com/nedap/archie/adlparser/antlr".toString())
@@ -15,5 +15,5 @@ classes {
 
 dependencies {
   antlr "org.antlr:antlr4:${antlrVersion}"
-  api 'org.antlr:antlr4-runtime:4.9.3'
+  api 'org.antlr:antlr4-runtime:4.11.0'
 }


### PR DESCRIPTION
…nded

ANTLR 4.10 and higher does not support generating code with java 8 anymore - java 11 is the minimum. For the runtime, java 8 is the new minimum.

This changes the CI configuration to compile with JDK 11, and test with JDK 8. It also updates ANTLR to the most recent version, 4.11.0.

This effectively no longer allows the project to be built on JDK 8, but allows the project to be run on JDK 8 just fine.

Fixes https://github.com/openEHR/archie/issues/455