### PR TITLE
BUGFIX nullpointer parent archetype id

### DIFF
--- a/tools/src/main/java/com/nedap/archie/flattener/ArchetypeRepository.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/ArchetypeRepository.java
@@ -29,7 +29,7 @@ public interface ArchetypeRepository {
         if(child.getArchetypeId().equals(parent.getArchetypeId()) || child.getArchetypeId().toString().equals(parent.getArchetypeId().getSemanticId())) {
             return true;
         }
-        Archetype nextChild = getArchetype(child.getParentArchetypeId());
+        Archetype nextChild = child.getParentArchetypeId() == null ? null : getArchetype(child.getParentArchetypeId());
         if(nextChild != null) {
             return isChildOf(parent, nextChild);
         }

--- a/tools/src/main/java/com/nedap/archie/flattener/ArchetypeRepository.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/ArchetypeRepository.java
@@ -34,6 +34,5 @@ public interface ArchetypeRepository {
             return isChildOf(parent, nextChild);
         }
         return false;
-
     }
 }


### PR DESCRIPTION
Make sure false is returned for `ArchetypeRepository.isChildOf` when `child.getParentArchetypeId` returns null.