### PR TITLE
Add name and versionId functions to TerminologyId

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/TerminologyId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/TerminologyId.java
@@ -1,7 +1,10 @@
 package com.nedap.archie.rm.support.identification;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 /**
@@ -27,6 +30,8 @@ public class TerminologyId extends ObjectId {
         this(terminologyId, null);
     }
 
+    @JsonIgnore
+    @XmlTransient
     public String getName() {
         String[] valueParts = getValueAsParts();
         if (valueParts != null && valueParts.length >= 1) {
@@ -36,6 +41,8 @@ public class TerminologyId extends ObjectId {
         }
     }
 
+    @JsonIgnore
+    @XmlTransient
     public String getVersionId() {
         String[] valueParts = getValueAsParts();
         if (valueParts != null && valueParts.length >= 2) {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/TerminologyId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/TerminologyId.java
@@ -27,7 +27,7 @@ public class TerminologyId extends ObjectId {
         this(terminologyId, null);
     }
 
-    public String name() {
+    public String getName() {
         String[] valueParts = getValueAsParts();
         if (valueParts != null && valueParts.length >= 1) {
             return valueParts[0];
@@ -36,7 +36,7 @@ public class TerminologyId extends ObjectId {
         }
     }
 
-    public String versionId() {
+    public String getVersionId() {
         String[] valueParts = getValueAsParts();
         if (valueParts != null && valueParts.length >= 2) {
             return valueParts[1];

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/TerminologyId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/TerminologyId.java
@@ -27,5 +27,31 @@ public class TerminologyId extends ObjectId {
         this(terminologyId, null);
     }
 
+    public String name() {
+        String[] valueParts = getValueAsParts();
+        if (valueParts != null && valueParts.length >= 1) {
+            return valueParts[0];
+        } else {
+            return null;
+        }
+    }
+
+    public String versionId() {
+        String[] valueParts = getValueAsParts();
+        if (valueParts != null && valueParts.length >= 2) {
+            return valueParts[1];
+        } else {
+            return null;
+        }
+    }
+
+    private String[] getValueAsParts() {
+        String value = getValue();
+        if (value != null) {
+            return value.split("[()]");
+        } else {
+            return null;
+        }
+    }
 
 }

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/TerminologyIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/TerminologyIdTest.java
@@ -10,27 +10,24 @@ public class TerminologyIdTest {
     public void createTerminologyIdWithNameAndVersionSuccessfully() {
         TerminologyId terminologyId = new TerminologyId("name", "version");
         assertEquals("name(version)", terminologyId.getValue());
-        assertNotNull(terminologyId.name());
-        assertEquals("name", terminologyId.name());
-        assertNotNull(terminologyId.versionId());
-        assertEquals("version", terminologyId.versionId());
+        assertEquals("name", terminologyId.getName());
+        assertEquals("version", terminologyId.getVersionId());
     }
 
     @Test
     public void createTerminologyIdWithOnlyNameSuccessfully() {
         TerminologyId terminologyId = new TerminologyId("name");
         assertEquals("name", terminologyId.getValue());
-        assertNotNull(terminologyId.name());
-        assertEquals("name", terminologyId.name());
-        assertNull(terminologyId.versionId());
+        assertEquals("name", terminologyId.getName());
+        assertNull(terminologyId.getVersionId());
     }
 
     @Test
     public void createTerminologyIdWithNoNameOrVersionSuccessfully() {
         TerminologyId terminologyId = new TerminologyId();
         assertNull(terminologyId.getValue());
-        assertNull(terminologyId.name());
-        assertNull(terminologyId.versionId());
+        assertNull(terminologyId.getName());
+        assertNull(terminologyId.getVersionId());
     }
 
 }

--- a/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/TerminologyIdTest.java
+++ b/openehr-rm/src/test/java/com/nedap/archie/rm/support/identification/TerminologyIdTest.java
@@ -1,0 +1,36 @@
+package com.nedap.archie.rm.support.identification;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TerminologyIdTest {
+
+    @Test
+    public void createTerminologyIdWithNameAndVersionSuccessfully() {
+        TerminologyId terminologyId = new TerminologyId("name", "version");
+        assertEquals("name(version)", terminologyId.getValue());
+        assertNotNull(terminologyId.name());
+        assertEquals("name", terminologyId.name());
+        assertNotNull(terminologyId.versionId());
+        assertEquals("version", terminologyId.versionId());
+    }
+
+    @Test
+    public void createTerminologyIdWithOnlyNameSuccessfully() {
+        TerminologyId terminologyId = new TerminologyId("name");
+        assertEquals("name", terminologyId.getValue());
+        assertNotNull(terminologyId.name());
+        assertEquals("name", terminologyId.name());
+        assertNull(terminologyId.versionId());
+    }
+
+    @Test
+    public void createTerminologyIdWithNoNameOrVersionSuccessfully() {
+        TerminologyId terminologyId = new TerminologyId();
+        assertNull(terminologyId.getValue());
+        assertNull(terminologyId.name());
+        assertNull(terminologyId.versionId());
+    }
+
+}

--- a/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
+++ b/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
@@ -148,6 +148,7 @@ public class RMComparedWithBmmTest {
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "branch_number"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "branch_version"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "is_branch"));
+        //The bmm files from the standard, are missing the next two fields, although they are specified in the relevant specification
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "TERMINOLOGY_ID", "name"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "TERMINOLOGY_ID", "version_id"));
         //System.out.println(Joiner.on("\n").join(compared));

--- a/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
+++ b/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
@@ -148,7 +148,8 @@ public class RMComparedWithBmmTest {
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "branch_number"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "branch_version"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "VERSION_TREE_ID", "is_branch"));
-
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "TERMINOLOGY_ID", "name"));
+        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "TERMINOLOGY_ID", "version_id"));
         //System.out.println(Joiner.on("\n").join(compared));
         List<ModelDifference> foundErrors = new ArrayList<>();
 


### PR DESCRIPTION
I considered adding instance fields, but decided against it because one would have to override `getValue` and `setValue`. This seemed more in line with the existing implementation, and the specification.

The names of the fields added were kept close to [the specification](https://specifications.openehr.org/releases/BASE/latest/base_types.html#_terminology_id_class), but I would be OK with prefixing them with `get` as well.

Resolves #479.