### PR TITLE
Add equals() and hashCode() to RuleElement class tree

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
@@ -87,7 +87,8 @@ public abstract class ArchetypeConstraint extends ArchetypeModelObject {
         if (this == o) return true;
         if (!(o instanceof ArchetypeConstraint)) return false;
         ArchetypeConstraint that = (ArchetypeConstraint) o;
-        return Objects.equals(parent, that.parent) && Objects.equals(socParent, that.socParent);
+        return Objects.equals(parent, that.parent) &&
+                Objects.equals(socParent, that.socParent);
     }
 
     @Override

--- a/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -81,4 +82,16 @@ public abstract class ArchetypeConstraint extends ArchetypeModelObject {
         return constraint == null ? null : constraint.getArchetype();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ArchetypeConstraint)) return false;
+        ArchetypeConstraint that = (ArchetypeConstraint) o;
+        return Objects.equals(parent, that.parent) && Objects.equals(socParent, that.socParent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parent, socParent);
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
@@ -8,7 +8,6 @@ import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -80,19 +79,5 @@ public abstract class ArchetypeConstraint extends ArchetypeModelObject {
     public Archetype getArchetype() {
         ArchetypeConstraint constraint = getParent();
         return constraint == null ? null : constraint.getArchetype();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ArchetypeConstraint)) return false;
-        ArchetypeConstraint that = (ArchetypeConstraint) o;
-        return Objects.equals(parent, that.parent) &&
-                Objects.equals(socParent, that.socParent);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(parent, socParent);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/CDefinedObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CDefinedObject.java
@@ -3,6 +3,7 @@ package com.nedap.archie.aom;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.Objects;
 
 /**
  * Defined Object. Parameterized so the default value methods can be overridden with a different type
@@ -32,5 +33,19 @@ public abstract class CDefinedObject<T> extends CObject {
      */
     public Boolean hasDefaultValue() {
         return defaultValue != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CDefinedObject)) return false;
+        if (!super.equals(o)) return false;
+        CDefinedObject<?> that = (CDefinedObject<?>) o;
+        return Objects.equals(defaultValue, that.defaultValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), defaultValue);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/CObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CObject.java
@@ -365,7 +365,6 @@ public abstract class CObject extends ArchetypeConstraint {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof CObject)) return false;
-        if (!super.equals(o)) return false;
         CObject cObject = (CObject) o;
         return Objects.equals(rmTypeName, cObject.rmTypeName) &&
                 Objects.equals(occurrences, cObject.occurrences) &&

--- a/aom/src/main/java/com/nedap/archie/aom/CObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CObject.java
@@ -17,6 +17,7 @@ import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -360,4 +361,17 @@ public abstract class CObject extends ArchetypeConstraint {
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CObject)) return false;
+        if (!super.equals(o)) return false;
+        CObject cObject = (CObject) o;
+        return Objects.equals(rmTypeName, cObject.rmTypeName) && Objects.equals(occurrences, cObject.occurrences) && Objects.equals(nodeId, cObject.nodeId) && Objects.equals(deprecated, cObject.deprecated) && Objects.equals(siblingOrder, cObject.siblingOrder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), rmTypeName, occurrences, nodeId, deprecated, siblingOrder);
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/CObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CObject.java
@@ -367,11 +367,20 @@ public abstract class CObject extends ArchetypeConstraint {
         if (!(o instanceof CObject)) return false;
         if (!super.equals(o)) return false;
         CObject cObject = (CObject) o;
-        return Objects.equals(rmTypeName, cObject.rmTypeName) && Objects.equals(occurrences, cObject.occurrences) && Objects.equals(nodeId, cObject.nodeId) && Objects.equals(deprecated, cObject.deprecated) && Objects.equals(siblingOrder, cObject.siblingOrder);
+        return Objects.equals(rmTypeName, cObject.rmTypeName) &&
+                Objects.equals(occurrences, cObject.occurrences) &&
+                Objects.equals(nodeId, cObject.nodeId) &&
+                Objects.equals(deprecated, cObject.deprecated) &&
+                Objects.equals(siblingOrder, cObject.siblingOrder);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), rmTypeName, occurrences, nodeId, deprecated, siblingOrder);
+        return Objects.hash(super.hashCode(),
+                rmTypeName,
+                occurrences,
+                nodeId,
+                deprecated,
+                siblingOrder);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/CPrimitiveObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CPrimitiveObject.java
@@ -157,5 +157,18 @@ public abstract class CPrimitiveObject<Constraint, ValueType> extends CDefinedOb
         return true; //primitive nodes are leafs.
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CPrimitiveObject)) return false;
+        if (!super.equals(o)) return false;
+        CPrimitiveObject<?, ?> that = (CPrimitiveObject<?, ?>) o;
+        return Objects.equals(enumeratedTypeConstraint, that.enumeratedTypeConstraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), enumeratedTypeConstraint);
+    }
 }
 

--- a/aom/src/main/java/com/nedap/archie/aom/CSecondOrder.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CSecondOrder.java
@@ -4,6 +4,7 @@ import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -37,5 +38,18 @@ public class CSecondOrder<T extends ArchetypeConstraint> extends ArchetypeModelO
     public void addMember(T member) {
         members.add(member);
         setThisAsSocParent(member);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CSecondOrder)) return false;
+        CSecondOrder<?> that = (CSecondOrder<?>) o;
+        return Objects.equals(members, that.members);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(members);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CBoolean.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CBoolean.java
@@ -85,11 +85,14 @@ public class CBoolean extends CPrimitiveObject<Boolean, Boolean> {
         if (!(o instanceof CBoolean)) return false;
         if (!super.equals(o)) return false;
         CBoolean cBoolean = (CBoolean) o;
-        return Objects.equals(assumedValue, cBoolean.assumedValue) && Objects.equals(constraint, cBoolean.constraint);
+        return Objects.equals(assumedValue, cBoolean.assumedValue) &&
+                Objects.equals(constraint, cBoolean.constraint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CBoolean.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CBoolean.java
@@ -13,6 +13,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -76,5 +77,19 @@ public class CBoolean extends CPrimitiveObject<Boolean, Boolean> {
             }
         }
         return ConformanceCheckResult.conforms();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CBoolean)) return false;
+        if (!super.equals(o)) return false;
+        CBoolean cBoolean = (CBoolean) o;
+        return Objects.equals(assumedValue, cBoolean.assumedValue) && Objects.equals(constraint, cBoolean.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CDate.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CDate.java
@@ -60,11 +60,14 @@ public class CDate extends CTemporal<Temporal> {
         if (!(o instanceof CDate)) return false;
         if (!super.equals(o)) return false;
         CDate cDate = (CDate) o;
-        return Objects.equals(assumedValue, cDate.assumedValue) && Objects.equals(constraint, cDate.constraint);
+        return Objects.equals(assumedValue, cDate.assumedValue) &&
+                Objects.equals(constraint, cDate.constraint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CDate.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CDate.java
@@ -13,6 +13,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -51,5 +52,19 @@ public class CDate extends CTemporal<Temporal> {
     @Override
     public void addConstraint(Interval<Temporal> constraint) {
         this.constraint.add(constraint);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CDate)) return false;
+        if (!super.equals(o)) return false;
+        CDate cDate = (CDate) o;
+        return Objects.equals(assumedValue, cDate.assumedValue) && Objects.equals(constraint, cDate.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CDateTime.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CDateTime.java
@@ -60,11 +60,14 @@ public class CDateTime extends CTemporal<TemporalAccessor> {
         if (!(o instanceof CDateTime)) return false;
         if (!super.equals(o)) return false;
         CDateTime cDateTime = (CDateTime) o;
-        return Objects.equals(assumedValue, cDateTime.assumedValue) && Objects.equals(constraint, cDateTime.constraint);
+        return Objects.equals(assumedValue, cDateTime.assumedValue) &&
+                Objects.equals(constraint, cDateTime.constraint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CDateTime.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CDateTime.java
@@ -13,6 +13,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -51,5 +52,19 @@ public class CDateTime extends CTemporal<TemporalAccessor> {
     @Override
     public void addConstraint(Interval<TemporalAccessor> constraint) {
         this.constraint.add(constraint);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CDateTime)) return false;
+        if (!super.equals(o)) return false;
+        CDateTime cDateTime = (CDateTime) o;
+        return Objects.equals(assumedValue, cDateTime.assumedValue) && Objects.equals(constraint, cDateTime.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CDuration.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CDuration.java
@@ -60,11 +60,14 @@ public class CDuration extends CTemporal<TemporalAmount> {
         if (!(o instanceof CDuration)) return false;
         if (!super.equals(o)) return false;
         CDuration cDuration = (CDuration) o;
-        return Objects.equals(assumedValue, cDuration.assumedValue) && Objects.equals(constraint, cDuration.constraint);
+        return Objects.equals(assumedValue, cDuration.assumedValue) &&
+                Objects.equals(constraint, cDuration.constraint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CDuration.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CDuration.java
@@ -13,6 +13,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -48,10 +49,22 @@ public class CDuration extends CTemporal<TemporalAmount> {
         this.constraint = constraint;
     }
 
-
     @Override
     public void addConstraint(Interval<TemporalAmount> constraint) {
         this.constraint.add(constraint);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CDuration)) return false;
+        if (!super.equals(o)) return false;
+        CDuration cDuration = (CDuration) o;
+        return Objects.equals(assumedValue, cDuration.assumedValue) && Objects.equals(constraint, cDuration.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint);
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CInteger.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CInteger.java
@@ -12,6 +12,7 @@ import java.beans.Transient;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -70,5 +71,19 @@ public class CInteger extends COrdered<Long> {
             }
         }
         return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CInteger)) return false;
+        if (!super.equals(o)) return false;
+        CInteger cInteger = (CInteger) o;
+        return Objects.equals(assumedValue, cInteger.assumedValue) && Objects.equals(constraint, cInteger.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CInteger.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CInteger.java
@@ -79,11 +79,14 @@ public class CInteger extends COrdered<Long> {
         if (!(o instanceof CInteger)) return false;
         if (!super.equals(o)) return false;
         CInteger cInteger = (CInteger) o;
-        return Objects.equals(assumedValue, cInteger.assumedValue) && Objects.equals(constraint, cInteger.constraint);
+        return Objects.equals(assumedValue, cInteger.assumedValue) &&
+                Objects.equals(constraint, cInteger.constraint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CReal.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CReal.java
@@ -55,11 +55,14 @@ public class CReal extends COrdered<Double> {
         if (!(o instanceof CReal)) return false;
         if (!super.equals(o)) return false;
         CReal cReal = (CReal) o;
-        return Objects.equals(assumedValue, cReal.assumedValue) && Objects.equals(constraint, cReal.constraint);
+        return Objects.equals(assumedValue, cReal.assumedValue) &&
+                Objects.equals(constraint, cReal.constraint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CReal.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CReal.java
@@ -9,6 +9,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * TODO: a real is perhaps not a double.
@@ -46,5 +47,19 @@ public class CReal extends COrdered<Double> {
     @Override
     public void addConstraint(Interval<Double> constraint) {
         this.constraint.add(constraint);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CReal)) return false;
+        if (!super.equals(o)) return false;
+        CReal cReal = (CReal) o;
+        return Objects.equals(assumedValue, cReal.assumedValue) && Objects.equals(constraint, cReal.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTemporal.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTemporal.java
@@ -2,6 +2,8 @@ package com.nedap.archie.aom.primitives;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 
+import java.util.Objects;
+
 /**
  * TODO: cConformsTo for temporal and date types
  * Created by pieter.bos on 15/10/15.
@@ -29,5 +31,19 @@ public abstract class CTemporal<T> extends COrdered<T>{
             //TODO: find a library that validates ISO 8601 patterns
             return true;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CTemporal)) return false;
+        if (!super.equals(o)) return false;
+        CTemporal<?> cTemporal = (CTemporal<?>) o;
+        return Objects.equals(patternConstraint, cTemporal.patternConstraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), patternConstraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -305,11 +305,16 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
         if (!(o instanceof CTerminologyCode)) return false;
         if (!super.equals(o)) return false;
         CTerminologyCode that = (CTerminologyCode) o;
-        return Objects.equals(assumedValue, that.assumedValue) && Objects.equals(constraint, that.constraint) && constraintStatus == that.constraintStatus;
+        return Objects.equals(assumedValue, that.assumedValue) &&
+                Objects.equals(constraint, that.constraint) &&
+                constraintStatus == that.constraintStatus;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint, constraintStatus);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint,
+                constraintStatus);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTerminologyCode.java
@@ -25,6 +25,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
@@ -298,4 +299,17 @@ public class CTerminologyCode extends CPrimitiveObject<String, TerminologyCode> 
         return result.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CTerminologyCode)) return false;
+        if (!super.equals(o)) return false;
+        CTerminologyCode that = (CTerminologyCode) o;
+        return Objects.equals(assumedValue, that.assumedValue) && Objects.equals(constraint, that.constraint) && constraintStatus == that.constraintStatus;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint, constraintStatus);
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTime.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTime.java
@@ -13,6 +13,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 15/10/15.
@@ -53,4 +54,17 @@ public class CTime extends CTemporal<TemporalAccessor> {
         this.constraint.add(constraint);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CTime)) return false;
+        if (!super.equals(o)) return false;
+        CTime cTime = (CTime) o;
+        return Objects.equals(assumedValue, cTime.assumedValue) && Objects.equals(constraint, cTime.constraint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), assumedValue, constraint);
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CTime.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CTime.java
@@ -60,11 +60,14 @@ public class CTime extends CTemporal<TemporalAccessor> {
         if (!(o instanceof CTime)) return false;
         if (!super.equals(o)) return false;
         CTime cTime = (CTime) o;
-        return Objects.equals(assumedValue, cTime.assumedValue) && Objects.equals(constraint, cTime.constraint);
+        return Objects.equals(assumedValue, cTime.assumedValue) &&
+                Objects.equals(constraint, cTime.constraint);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), assumedValue, constraint);
+        return Objects.hash(super.hashCode(),
+                assumedValue,
+                constraint);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Assertion.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Assertion.java
@@ -92,11 +92,18 @@ public final class Assertion extends RuleStatement {
         if (!(o instanceof Assertion)) return false;
         if (!super.equals(o)) return false;
         Assertion assertion = (Assertion) o;
-        return Objects.equals(stringExpression, assertion.stringExpression) && Objects.equals(expression, assertion.expression) && Objects.equals(tag, assertion.tag) && Objects.equals(variables, assertion.variables);
+        return Objects.equals(stringExpression, assertion.stringExpression) &&
+                Objects.equals(expression, assertion.expression) &&
+                Objects.equals(tag, assertion.tag) &&
+                Objects.equals(variables, assertion.variables);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), stringExpression, expression, tag, variables);
+        return Objects.hash(super.hashCode(),
+                stringExpression,
+                expression,
+                tag,
+                variables);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Assertion.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Assertion.java
@@ -5,6 +5,7 @@ import com.nedap.archie.aom.primitives.CString;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Assertion object.
@@ -83,5 +84,19 @@ public final class Assertion extends RuleStatement {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Assertion)) return false;
+        if (!super.equals(o)) return false;
+        Assertion assertion = (Assertion) o;
+        return Objects.equals(stringExpression, assertion.stringExpression) && Objects.equals(expression, assertion.expression) && Objects.equals(tag, assertion.tag) && Objects.equals(variables, assertion.variables);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), stringExpression, expression, tag, variables);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Constant.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Constant.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -23,5 +25,19 @@ public class Constant<T> extends Leaf {
 
     public void setValue(T value) {
         this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Constant)) return false;
+        if (!super.equals(o)) return false;
+        Constant<?> constant = (Constant<?>) o;
+        return Objects.equals(value, constant.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), value);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Constraint.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Constraint.java
@@ -3,6 +3,8 @@ package com.nedap.archie.rules;
 
 import com.nedap.archie.aom.CPrimitiveObject;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -24,5 +26,19 @@ public class Constraint<T extends CPrimitiveObject<?, ?>> extends Leaf {
 
     public void setItem(T item) {
         this.item = item;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Constraint)) return false;
+        if (!super.equals(o)) return false;
+        Constraint<?> that = (Constraint<?>) o;
+        return Objects.equals(item, that.item);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), item);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Expression.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Expression.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -15,5 +17,19 @@ public abstract class Expression extends RuleElement {
 
     public void setPrecedenceOverridden(boolean precedenceOverridden) {
         this.precedenceOverridden = precedenceOverridden;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Expression)) return false;
+        if (!super.equals(o)) return false;
+        Expression that = (Expression) o;
+        return precedenceOverridden == that.precedenceOverridden;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), precedenceOverridden);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/ExpressionVariable.java
+++ b/aom/src/main/java/com/nedap/archie/rules/ExpressionVariable.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -15,4 +17,17 @@ public class ExpressionVariable extends VariableDeclaration {
         this.expression = expression;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExpressionVariable)) return false;
+        if (!super.equals(o)) return false;
+        ExpressionVariable that = (ExpressionVariable) o;
+        return Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), expression);
+    }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/ForAllStatement.java
+++ b/aom/src/main/java/com/nedap/archie/rules/ForAllStatement.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 10/05/16.
  */
@@ -42,5 +44,19 @@ public class ForAllStatement extends Operator {
 
     public void setAssertion(Expression assertion) {
         super.setSecondOperand(assertion);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ForAllStatement)) return false;
+        if (!super.equals(o)) return false;
+        ForAllStatement that = (ForAllStatement) o;
+        return Objects.equals(variableName, that.variableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), variableName);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Function.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Function.java
@@ -34,11 +34,14 @@ public class Function extends Expression {
         if (!(o instanceof Function)) return false;
         if (!super.equals(o)) return false;
         Function function = (Function) o;
-        return Objects.equals(functionName, function.functionName) && Objects.equals(arguments, function.arguments);
+        return Objects.equals(functionName, function.functionName) &&
+                Objects.equals(arguments, function.arguments);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), functionName, arguments);
+        return Objects.hash(super.hashCode(),
+                functionName,
+                arguments);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Function.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Function.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rules;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 06/04/2017.
@@ -25,5 +26,19 @@ public class Function extends Expression {
 
     public List<Expression> getArguments() {
         return arguments;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Function)) return false;
+        if (!super.equals(o)) return false;
+        Function function = (Function) o;
+        return Objects.equals(functionName, function.functionName) && Objects.equals(arguments, function.arguments);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), functionName, arguments);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Leaf.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Leaf.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -14,5 +16,19 @@ public class Leaf extends Expression {
 
     public void setReferenceType(ReferenceType referenceType) {
         this.referenceType = referenceType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Leaf)) return false;
+        if (!super.equals(o)) return false;
+        Leaf leaf = (Leaf) o;
+        return referenceType == leaf.referenceType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), referenceType);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/ModelReference.java
+++ b/aom/src/main/java/com/nedap/archie/rules/ModelReference.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -48,5 +50,19 @@ public class ModelReference extends Leaf {
 
     public void setVariableReferencePrefix(String variableReferencePrefix) {
         this.variableReferencePrefix = variableReferencePrefix;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ModelReference)) return false;
+        if (!super.equals(o)) return false;
+        ModelReference that = (ModelReference) o;
+        return Objects.equals(variableReferencePrefix, that.variableReferencePrefix) && Objects.equals(path, that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), variableReferencePrefix, path);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/ModelReference.java
+++ b/aom/src/main/java/com/nedap/archie/rules/ModelReference.java
@@ -58,11 +58,14 @@ public class ModelReference extends Leaf {
         if (!(o instanceof ModelReference)) return false;
         if (!super.equals(o)) return false;
         ModelReference that = (ModelReference) o;
-        return Objects.equals(variableReferencePrefix, that.variableReferencePrefix) && Objects.equals(path, that.path);
+        return Objects.equals(variableReferencePrefix, that.variableReferencePrefix)
+                && Objects.equals(path, that.path);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), variableReferencePrefix, path);
+        return Objects.hash(super.hashCode(),
+                variableReferencePrefix,
+                path);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Operator.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Operator.java
@@ -107,11 +107,16 @@ public class Operator extends Expression {
         if (!(o instanceof Operator)) return false;
         if (!super.equals(o)) return false;
         Operator operator1 = (Operator) o;
-        return operator == operator1.operator && Objects.equals(operands, operator1.operands) && Objects.equals(symbol, operator1.symbol);
+        return operator == operator1.operator &&
+                Objects.equals(operands, operator1.operands) &&
+                Objects.equals(symbol, operator1.symbol);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), operator, operands, symbol);
+        return Objects.hash(super.hashCode(),
+                operator,
+                operands,
+                symbol);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/Operator.java
+++ b/aom/src/main/java/com/nedap/archie/rules/Operator.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by pieter.bos on 27/10/15.
@@ -98,5 +99,19 @@ public class Operator extends Expression {
 
     public void addOperand(Expression expression) {
         operands.add(expression);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Operator)) return false;
+        if (!super.equals(o)) return false;
+        Operator operator1 = (Operator) o;
+        return operator == operator1.operator && Objects.equals(operands, operator1.operands) && Objects.equals(symbol, operator1.symbol);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), operator, operands, symbol);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/QueryVariable.java
+++ b/aom/src/main/java/com/nedap/archie/rules/QueryVariable.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -32,5 +34,19 @@ public class QueryVariable extends VariableDeclaration {
 
     public void setQueryArgs(String queryArgs) {
         this.queryArgs = queryArgs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof QueryVariable)) return false;
+        if (!super.equals(o)) return false;
+        QueryVariable that = (QueryVariable) o;
+        return Objects.equals(context, that.context) && Objects.equals(queryId, that.queryId) && Objects.equals(queryArgs, that.queryArgs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), context, queryId, queryArgs);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/QueryVariable.java
+++ b/aom/src/main/java/com/nedap/archie/rules/QueryVariable.java
@@ -42,11 +42,16 @@ public class QueryVariable extends VariableDeclaration {
         if (!(o instanceof QueryVariable)) return false;
         if (!super.equals(o)) return false;
         QueryVariable that = (QueryVariable) o;
-        return Objects.equals(context, that.context) && Objects.equals(queryId, that.queryId) && Objects.equals(queryArgs, that.queryArgs);
+        return Objects.equals(context, that.context) &&
+                Objects.equals(queryId, that.queryId) &&
+                Objects.equals(queryArgs, that.queryArgs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), context, queryId, queryArgs);
+        return Objects.hash(super.hashCode(),
+                context,
+                queryId,
+                queryArgs);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/RuleElement.java
+++ b/aom/src/main/java/com/nedap/archie/rules/RuleElement.java
@@ -2,6 +2,8 @@ package com.nedap.archie.rules;
 
 import com.nedap.archie.aom.ArchetypeModelObject;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -15,5 +17,18 @@ public class RuleElement extends ArchetypeModelObject {
 
     public void setType(ExpressionType type) {
         this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RuleElement)) return false;
+        RuleElement that = (RuleElement) o;
+        return type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/RuleStatement.java
+++ b/aom/src/main/java/com/nedap/archie/rules/RuleStatement.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Temporary placeholder for rules.
  * Created by pieter.bos on 15/10/15.
@@ -15,5 +17,19 @@ public class RuleStatement extends RuleElement {
 
     public void setRuleContent(String ruleContent) {
         this.ruleContent = ruleContent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RuleStatement)) return false;
+        if (!super.equals(o)) return false;
+        RuleStatement that = (RuleStatement) o;
+        return Objects.equals(ruleContent, that.ruleContent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), ruleContent);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/VariableDeclaration.java
+++ b/aom/src/main/java/com/nedap/archie/rules/VariableDeclaration.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -13,5 +15,19 @@ public class VariableDeclaration extends RuleStatement {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof VariableDeclaration)) return false;
+        if (!super.equals(o)) return false;
+        VariableDeclaration that = (VariableDeclaration) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name);
     }
 }

--- a/aom/src/main/java/com/nedap/archie/rules/VariableReference.java
+++ b/aom/src/main/java/com/nedap/archie/rules/VariableReference.java
@@ -1,5 +1,7 @@
 package com.nedap.archie.rules;
 
+import java.util.Objects;
+
 /**
  * Created by pieter.bos on 27/10/15.
  */
@@ -12,5 +14,19 @@ public class VariableReference extends Leaf {
 
     public void setDeclaration(VariableDeclaration declaration) {
         this.declaration = declaration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof VariableReference)) return false;
+        if (!super.equals(o)) return false;
+        VariableReference that = (VariableReference) o;
+        return Objects.equals(declaration, that.declaration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), declaration);
     }
 }

--- a/base/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
+++ b/base/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
@@ -111,11 +111,17 @@ public class TerminologyCode extends OpenEHRBase {
         if (this == o) return true;
         if (!(o instanceof TerminologyCode)) return false;
         TerminologyCode that = (TerminologyCode) o;
-        return Objects.equals(terminologyId, that.terminologyId) && Objects.equals(terminologyVersion, that.terminologyVersion) && Objects.equals(codeString, that.codeString) && Objects.equals(uri, that.uri);
+        return Objects.equals(terminologyId, that.terminologyId) &&
+                Objects.equals(terminologyVersion, that.terminologyVersion) &&
+                Objects.equals(codeString, that.codeString) &&
+                Objects.equals(uri, that.uri);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(terminologyId, terminologyVersion, codeString, uri);
+        return Objects.hash(terminologyId,
+                terminologyVersion,
+                codeString,
+                uri);
     }
 }

--- a/base/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
+++ b/base/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
@@ -11,6 +11,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import java.net.URI;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -103,5 +104,18 @@ public class TerminologyCode extends OpenEHRBase {
 
     public void setUri(URI uri) {
         this.uri = uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TerminologyCode)) return false;
+        TerminologyCode that = (TerminologyCode) o;
+        return Objects.equals(terminologyId, that.terminologyId) && Objects.equals(terminologyVersion, that.terminologyVersion) && Objects.equals(codeString, that.codeString) && Objects.equals(uri, that.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(terminologyId, terminologyVersion, codeString, uri);
     }
 }


### PR DESCRIPTION
We want to be able to compare RuleElements to each other for a future RulesDifferentiator, therefore the equals() method is added to that class and all other classes belonging to it (see class diagrams). The hashCode() method was also added for convenience in the future when using Maps. 

![RulesEquals (1)](https://user-images.githubusercontent.com/33416829/226290963-01389ff0-9322-4d74-b32f-ff16961de59e.jpg)
![CPrimitiveObject (1)](https://user-images.githubusercontent.com/33416829/226290974-348827e8-8275-4831-bdb6-9f08d6247b0e.jpg)
