### PR TITLE
Add RulesDifferentiator to Differentiator

### DIFF
--- a/tools/src/main/java/com/nedap/archie/diff/Differentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/Differentiator.java
@@ -35,6 +35,7 @@ public class Differentiator {
             new LCSOrderingDiff(metaModels).addSiblingOrder(result, flatChild, flatParent);
         }
         new ConstraintDifferentiator(constraintImposer, flatParent).removeUnspecializedConstraints(result, flatParent);
+        new RulesDifferentiator().differentiate(result, flatParent);
 
         new DifferentialPathGenerator().replace(result);
         new TerminologyDifferentiator().differentiate(result);

--- a/tools/src/main/java/com/nedap/archie/diff/RulesDifferentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/RulesDifferentiator.java
@@ -16,12 +16,6 @@ public class RulesDifferentiator {
             return;
         }
 
-        if (result.getRules().getRules().size() == flatParent.getRules().getRules().size()) {
-            // If the amount of rules is the same, can you assume there are no new rules in the child archetype?
-            result.setRules(null);
-            return;
-        }
-
         List<RuleStatement> rulesToRemove = new ArrayList<>();
         for (RuleStatement rule : result.getRules().getRules()) {
             if (flatParent.getRules().getRules().contains(rule)) {

--- a/tools/src/main/java/com/nedap/archie/diff/RulesDifferentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/RulesDifferentiator.java
@@ -1,0 +1,35 @@
+package com.nedap.archie.diff;
+
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.rules.RuleStatement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RulesDifferentiator {
+
+    public void differentiate(Archetype result, Archetype flatParent) {
+        if (flatParent.getRules() == null
+                || flatParent.getRules().getRules() == null
+                || flatParent.getRules().getRules().size() == 0) {
+            // Parent has no rules, all rules can stay in the child archetype
+            return;
+        }
+
+        if (result.getRules().getRules().size() == flatParent.getRules().getRules().size()) {
+            // If the amount of rules is the same, can you assume there are no new rules in the child archetype?
+            result.setRules(null);
+            return;
+        }
+
+        List<RuleStatement> rulesToRemove = new ArrayList<>();
+        for (RuleStatement rule : result.getRules().getRules()) {
+            if (flatParent.getRules().getRules().contains(rule)) {
+                rulesToRemove.add(rule);
+            }
+        }
+        for (RuleStatement rule : rulesToRemove) {
+            result.getRules().getRules().remove(rule);
+        }
+    }
+}

--- a/tools/src/main/java/com/nedap/archie/diff/RulesDifferentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/RulesDifferentiator.java
@@ -1,29 +1,35 @@
 package com.nedap.archie.diff;
 
 import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.rules.RuleStatement;
-
-import java.util.ArrayList;
-import java.util.List;
+import java.util.stream.Collectors;
 
 public class RulesDifferentiator {
 
+    /**
+     * Removes rules from the result archetypes which are also present in the flatParent archetype
+     *      - The differentiator does not take into account changing or deletion of rules in the flat archetype
+     */
     public void differentiate(Archetype result, Archetype flatParent) {
+        if (result.getRules() == null
+                || result.getRules().getRules() == null
+                || result.getRules().getRules().isEmpty()) {
+            // There are no rules in the result archetype
+            return;
+        }
+
         if (flatParent.getRules() == null
                 || flatParent.getRules().getRules() == null
-                || flatParent.getRules().getRules().size() == 0) {
+                || flatParent.getRules().getRules().isEmpty()) {
             // Parent has no rules, all rules can stay in the child archetype
             return;
         }
 
-        List<RuleStatement> rulesToRemove = new ArrayList<>();
-        for (RuleStatement rule : result.getRules().getRules()) {
-            if (flatParent.getRules().getRules().contains(rule)) {
-                rulesToRemove.add(rule);
-            }
-        }
-        for (RuleStatement rule : rulesToRemove) {
-            result.getRules().getRules().remove(rule);
-        }
+        // For each rule in the result archetype, check if the exact rule is in the flat parent archetype
+        // If it is, remove it from the result archetype
+        result.getRules().getRules().removeAll(
+                result.getRules().getRules().stream().filter(
+                        rule -> flatParent.getRules().getRules().contains(rule)
+                ).collect(Collectors.toList())
+        );
     }
 }

--- a/tools/src/test/java/com/nedap/archie/diff/RulesDifferentiatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/diff/RulesDifferentiatorTest.java
@@ -30,6 +30,9 @@ public class RulesDifferentiatorTest {
         inMemoryFullArchetypeRepository.compile(BuiltinReferenceModels.getMetaModels());
         Archetype result = inMemoryFullArchetypeRepository.getFlattenedArchetype(CHILD_ARCHETYPE_ID);
         Archetype flatParent = inMemoryFullArchetypeRepository.getFlattenedArchetype(PARENT_ARCHETYPE_ID);
+
+        assertEquals(2, result.getRules().getRules().size());
+
         new RulesDifferentiator().differentiate(result, flatParent);
 
         // Tests
@@ -52,6 +55,9 @@ public class RulesDifferentiatorTest {
         inMemoryFullArchetypeRepository.compile(BuiltinReferenceModels.getMetaModels());
         Archetype result = inMemoryFullArchetypeRepository.getFlattenedArchetype(GRANDCHILD_ARCHETYPE_ID);
         Archetype flatParent = inMemoryFullArchetypeRepository.getFlattenedArchetype(CHILD_ARCHETYPE_ID);
+
+        assertEquals(3, result.getRules().getRules().size());
+
         new RulesDifferentiator().differentiate(result, flatParent);
 
         // Tests

--- a/tools/src/test/java/com/nedap/archie/diff/RulesDifferentiatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/diff/RulesDifferentiatorTest.java
@@ -1,0 +1,72 @@
+package com.nedap.archie.diff;
+
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
+import com.nedap.archie.rules.RuleStatement;
+import com.nedap.archie.serializer.adl.ADLDefinitionSerializer;
+import com.nedap.archie.serializer.adl.ADLRulesSerializer;
+import com.nedap.archie.serializer.adl.ADLStringBuilder;
+import com.nedap.archie.testutil.TestUtil;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import static org.junit.Assert.*;
+
+public class RulesDifferentiatorTest {
+
+    private String archetypesResourceLocation = "/com/nedap/archie/diff/rulesdifferentiator/";
+    private final String PARENT_ARCHETYPE_ID = "openEHR-EHR-OBSERVATION.rules_parent.v0.0.1";
+    private final String CHILD_ARCHETYPE_ID = "openEHR-EHR-OBSERVATION.rules_child.v0.0.1";
+    private final String GRANDCHILD_ARCHETYPE_ID = "openEHR-EHR-OBSERVATION.rules_grandchild.v0.0.1";
+
+    @Test
+    public void differentiateRulesInChildArchetype() throws Exception {
+        InMemoryFullArchetypeRepository inMemoryFullArchetypeRepository = new InMemoryFullArchetypeRepository();
+        Archetype parent = TestUtil.parseFailOnErrors(archetypesResourceLocation + PARENT_ARCHETYPE_ID + ".adls");
+        Archetype child = TestUtil.parseFailOnErrors(archetypesResourceLocation + CHILD_ARCHETYPE_ID + ".adls");
+        inMemoryFullArchetypeRepository.addArchetype(parent);
+        inMemoryFullArchetypeRepository.addArchetype(child);
+
+        inMemoryFullArchetypeRepository.compile(BuiltinReferenceModels.getMetaModels());
+        Archetype result = inMemoryFullArchetypeRepository.getFlattenedArchetype(CHILD_ARCHETYPE_ID);
+        Archetype flatParent = inMemoryFullArchetypeRepository.getFlattenedArchetype(PARENT_ARCHETYPE_ID);
+        new RulesDifferentiator().differentiate(result, flatParent);
+
+        // Tests
+        assertEquals(1, result.getRules().getRules().size());
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id0.4]/value/magnitude = round(\n" +
+                "    /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude + \n" +
+                "    /data[id2]/events[id3]/data[id4]/items[id0.2]/value/magnitude)\n", serializeRuleStatement(result.getRules().getRules().get(0)));
+    }
+
+    @Test
+    public void differentiateRulesInGrandchildArchetype() throws Exception {
+        InMemoryFullArchetypeRepository inMemoryFullArchetypeRepository = new InMemoryFullArchetypeRepository();
+        Archetype parent = TestUtil.parseFailOnErrors(archetypesResourceLocation + PARENT_ARCHETYPE_ID + ".adls");
+        Archetype child = TestUtil.parseFailOnErrors(archetypesResourceLocation + CHILD_ARCHETYPE_ID + ".adls");
+        Archetype grandchild = TestUtil.parseFailOnErrors(archetypesResourceLocation + GRANDCHILD_ARCHETYPE_ID + ".adls");
+        inMemoryFullArchetypeRepository.addArchetype(parent);
+        inMemoryFullArchetypeRepository.addArchetype(child);
+        inMemoryFullArchetypeRepository.addArchetype(grandchild);
+
+        inMemoryFullArchetypeRepository.compile(BuiltinReferenceModels.getMetaModels());
+        Archetype result = inMemoryFullArchetypeRepository.getFlattenedArchetype(GRANDCHILD_ARCHETYPE_ID);
+        Archetype flatParent = inMemoryFullArchetypeRepository.getFlattenedArchetype(CHILD_ARCHETYPE_ID);
+        new RulesDifferentiator().differentiate(result, flatParent);
+
+        // Tests
+        assertEquals(1, result.getRules().getRules().size());
+        assertEquals("/data[id2]/events[id3]/data[id4]/items[id0.0.4]/value/magnitude = round(\n" +
+                "    /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude + \n" +
+                "    /data[id2]/events[id3]/data[id4]/items[id0.0.2]/value/magnitude)\n", serializeRuleStatement(result.getRules().getRules().get(0)));
+    }
+
+    /**
+     * Convert RuleStatement into a String
+     */
+    public static String serializeRuleStatement(RuleStatement ruleStatement) {
+        ADLStringBuilder builder = new ADLStringBuilder();
+        new ADLRulesSerializer(builder, new ADLDefinitionSerializer(builder, null, null)).serializeRuleElement(ruleStatement);
+        return builder.toString();
+    }
+}

--- a/tools/src/test/resources/com/nedap/archie/diff/rulesdifferentiator/openEHR-EHR-OBSERVATION.rules_child.v0.0.1.adls
+++ b/tools/src/test/resources/com/nedap/archie/diff/rulesdifferentiator/openEHR-EHR-OBSERVATION.rules_child.v0.0.1.adls
@@ -1,0 +1,62 @@
+archetype (adl_version=2.0.5; rm_release=1.0.4; generated)
+    openEHR-EHR-OBSERVATION.rules_child.v0.0.1
+
+specialize
+    openEHR-EHR-OBSERVATION.rules_parent.v0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Vera">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["en"] = <
+            language = <[ISO-639_1::en]>
+            purpose = <"Rules child archetype testing">
+        >
+    >
+
+definition
+    OBSERVATION[id1.1] matches {    -- RulesChild
+        /data[id2]/events[id3]/data[id4]/items matches {
+            after [id7]
+            ELEMENT[id0.2] occurrences matches {0..1} matches {    -- Count 3
+                value matches {
+                    DV_COUNT[id0.3] 
+                }
+            }
+            ELEMENT[id0.4] occurrences matches {0..1} matches {    -- Sum 2
+                value matches {
+                    DV_COUNT[id0.5] 
+                }
+            }
+        }
+    }
+
+rules
+    /data[id2]/events[id3]/data[id4]/items[id0.4]/value/magnitude = round(
+        /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude + 
+        /data[id2]/events[id3]/data[id4]/items[id0.2]/value/magnitude)
+
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1.1"] = <
+                text = <"RulesChild">
+                description = <"Rules child archetype">
+                code = <"id1">
+            >
+            ["id0.2"] = <
+                text = <"Count 3">
+                description = <"">
+            >
+            ["id0.4"] = <
+                text = <"Sum 2">
+                description = <"">
+            >
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/diff/rulesdifferentiator/openEHR-EHR-OBSERVATION.rules_grandchild.v0.0.1.adls
+++ b/tools/src/test/resources/com/nedap/archie/diff/rulesdifferentiator/openEHR-EHR-OBSERVATION.rules_grandchild.v0.0.1.adls
@@ -1,0 +1,62 @@
+archetype (adl_version=2.0.5; rm_release=1.0.4; generated)
+    openEHR-EHR-OBSERVATION.rules_grandchild.v0.0.1
+
+specialize
+    openEHR-EHR-OBSERVATION.rules_child.v0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Vera">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["en"] = <
+            language = <[ISO-639_1::en]>
+            purpose = <"Rules child archetype testing">
+        >
+    >
+
+definition
+    OBSERVATION[id1.1.1] matches {    -- RulesGrandchild
+        /data[id2]/events[id3]/data[id4]/items matches {
+            after [id7]
+            ELEMENT[id0.0.2] occurrences matches {0..1} matches {    -- Count 4
+                value matches {
+                    DV_COUNT[id0.0.3]
+                }
+            }
+            ELEMENT[id0.0.4] occurrences matches {0..1} matches {    -- Sum 3
+                value matches {
+                    DV_COUNT[id0.0.5]
+                }
+            }
+        }
+    }
+
+rules
+    /data[id2]/events[id3]/data[id4]/items[id0.0.4]/value/magnitude = round(
+        /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude + 
+        /data[id2]/events[id3]/data[id4]/items[id0.0.2]/value/magnitude)
+
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1.1.1"] = <
+                text = <"RulesGrandchild">
+                description = <"Rules child archetype">
+                code = <"id1">
+            >
+            ["id0.0.2"] = <
+                text = <"Count 4">
+                description = <"">
+            >
+            ["id0.0.4"] = <
+                text = <"Sum 3">
+                description = <"">
+            >
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/diff/rulesdifferentiator/openEHR-EHR-OBSERVATION.rules_parent.v0.0.1.adls
+++ b/tools/src/test/resources/com/nedap/archie/diff/rulesdifferentiator/openEHR-EHR-OBSERVATION.rules_parent.v0.0.1.adls
@@ -1,0 +1,83 @@
+archetype (adl_version=2.0.5; rm_release=1.0.4)
+    openEHR-EHR-OBSERVATION.rules_parent.v0.0.1
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Vera">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["en"] = <
+            language = <[ISO-639_1::en]>
+            purpose = <"Rules parent archetype testing">
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- RulesParent
+        data matches {
+            HISTORY[id2] matches {
+                events matches {
+                    POINT_EVENT[id3] matches {    -- Point event
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items matches {
+                                    ELEMENT[id5] occurrences matches {0..1} matches {    -- Count 1
+                                        value matches {
+                                            DV_COUNT[id6] 
+                                        }
+                                    }
+                                    ELEMENT[id7] occurrences matches {0..1} matches {    -- Count 2
+                                        value matches {
+                                            DV_COUNT[id8] 
+                                        }
+                                    }
+                                    ELEMENT[id9] occurrences matches {0..1} matches {    -- Sum
+                                        value matches {
+                                            DV_COUNT[id10] 
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+rules
+    /data[id2]/events[id3]/data[id4]/items[id9]/value/magnitude = round(
+        /data[id2]/events[id3]/data[id4]/items[id5]/value/magnitude + 
+        /data[id2]/events[id3]/data[id4]/items[id7]/value/magnitude)
+
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"RulesParent">
+                description = <"Rules parent archetype">
+                code = <"id1">
+            >
+            ["id3"] = <
+                text = <"Point event">
+                description = <"Point event">
+            >
+            ["id5"] = <
+                text = <"Count 1">
+                description = <"">
+            >
+            ["id7"] = <
+                text = <"Count 2">
+                description = <"">
+            >
+            ["id9"] = <
+                text = <"Sum">
+                description = <"">
+            >
+        >
+    >


### PR DESCRIPTION
At the moment the Differentiator does not take into account rules in any form. This RulesDifferentiator is added to at least make sure that rules from parent archetypes are not duplicated in child archetypes. 

**What does happen when adding, changing and deleting rules to the flat archetype:**
* Adding a rule in the flat archetype will result in this rule being added in the child archetype. 
* Changing rules in the flat archetype will result in adding this as a new rule in the child archetype. The old rule will stay in the parent archetype. This will finally result in both rules being present when the child archetype if flattened in the future. Dependent on the change this can result in conflicting rules, but I feel like this is up to the user to keep in mind. With or without rules differentiator, this will not be possible either way.
* Deleting rules in the flat archetype will not change anything. There are no new rules added to the child archetype and the parent archetype still keeps the deleted rule. As a result the final flattened child archetype will still have the old rule. Also here, with or without rules differentiator, this will not be possible either way.

Functionally this should not change anything about (the operational template / flattened form of) existing archetypes, because it only removes rules that already exist in the parent archetype.