### PR TITLE
Add rule evaluation for Temporal(Amount) data types

### DIFF
--- a/aom/src/main/java/com/nedap/archie/rules/ExpressionType.java
+++ b/aom/src/main/java/com/nedap/archie/rules/ExpressionType.java
@@ -5,7 +5,7 @@ package com.nedap.archie.rules;
  * Created by pieter.bos on 27/10/15.
  */
 public enum ExpressionType {
-     BOOLEAN, STRING, INTEGER, REAL;
+     BOOLEAN, STRING, INTEGER, REAL, DATE, TIME, DATETIME;
 
     public static ExpressionType fromString(String string) {
         switch(string) {
@@ -17,6 +17,12 @@ public enum ExpressionType {
                 return INTEGER;
             case "Real":
                 return REAL;
+            case "Date":
+                return DATE;
+            case "Time":
+                return TIME;
+            case "DateTime":
+                return DATETIME;
         }
         return null;
     }
@@ -31,6 +37,12 @@ public enum ExpressionType {
                 return "Integer";
             case REAL:
                 return "Real";
+            case DATE:
+                return "Date";
+            case TIME:
+                return "Time";
+            case DATETIME:
+                return "DateTime";
         }
         return null;
     }

--- a/aom/src/main/java/com/nedap/archie/rules/ExpressionType.java
+++ b/aom/src/main/java/com/nedap/archie/rules/ExpressionType.java
@@ -5,7 +5,7 @@ package com.nedap.archie.rules;
  * Created by pieter.bos on 27/10/15.
  */
 public enum ExpressionType {
-     BOOLEAN, STRING, INTEGER, REAL, DATE, TIME, DATETIME;
+     BOOLEAN, STRING, INTEGER, REAL, DATE, TIME, DATETIME, DURATION;
 
     public static ExpressionType fromString(String string) {
         switch(string) {
@@ -23,6 +23,8 @@ public enum ExpressionType {
                 return TIME;
             case "DateTime":
                 return DATETIME;
+            case "Duration":
+                return DURATION;
         }
         return null;
     }
@@ -43,6 +45,8 @@ public enum ExpressionType {
                 return "Time";
             case DATETIME:
                 return "DateTime";
+            case DURATION:
+                return "Duration";
         }
         return null;
     }

--- a/aom/src/main/java/com/nedap/archie/rules/PrimitiveType.java
+++ b/aom/src/main/java/com/nedap/archie/rules/PrimitiveType.java
@@ -45,6 +45,8 @@ public enum PrimitiveType {
                 return Time;
             case DATETIME:
                 return DateTime;
+            case DURATION:
+                return Duration;
         }
         return null;
     }

--- a/aom/src/main/java/com/nedap/archie/rules/PrimitiveType.java
+++ b/aom/src/main/java/com/nedap/archie/rules/PrimitiveType.java
@@ -39,6 +39,12 @@ public enum PrimitiveType {
                 return Integer;
             case REAL:
                 return Real;
+            case DATE:
+                return Date;
+            case TIME:
+                return Time;
+            case DATETIME:
+                return DateTime;
         }
         return null;
     }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -32,6 +32,9 @@ import static com.nedap.archie.rules.evaluation.evaluators.FunctionUtil.checkAnd
  */
 public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
     private static final double EPSILON = 0.00001d;
+    private static final EnumSet<PrimitiveType> SUPPORTED_TEMPORAL_TYPES = EnumSet.of(PrimitiveType.Date, PrimitiveType.Time, PrimitiveType.DateTime);
+    private static final EnumSet<PrimitiveType> SUPPORTED_TEMPORAL_AMOUNT_TYPES = EnumSet.of(PrimitiveType.Duration);
+
     private final Archetype archetype;
 
     private BinaryBooleanOperandEvaluator booleanOperandEvaluator = new BinaryBooleanOperandEvaluator(this);
@@ -350,9 +353,7 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
             result.addValue(stringOperandEvaluator.evaluateMultipleValuesStringRelOp(statement, leftValues, rightValues));
 
             return result;
-        } else if (PrimitiveType.Date.equals(leftValues.getType()) || PrimitiveType.Date.equals(rightValues.getType()) ||
-                PrimitiveType.Time.equals(leftValues.getType()) || PrimitiveType.Time.equals(rightValues.getType()) ||
-                PrimitiveType.DateTime.equals(leftValues.getType()) || PrimitiveType.DateTime.equals(rightValues.getType())) {
+        } else if (SUPPORTED_TEMPORAL_TYPES.contains(leftValues.getType()) || SUPPORTED_TEMPORAL_TYPES.contains(rightValues.getType())) {
             ValueList result = new ValueList();
             result.setType(PrimitiveType.Boolean);
 
@@ -361,7 +362,7 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
             result.addValue(temporalOperandEvaluator.evaluateMultipleValuesDateRelOp(statement, leftValues, rightValues));
 
             return result;
-        } else if (PrimitiveType.Duration.equals(leftValues.getType()) || PrimitiveType.Duration.equals(rightValues.getType())) {
+        } else if (SUPPORTED_TEMPORAL_AMOUNT_TYPES.contains(leftValues.getType()) || SUPPORTED_TEMPORAL_AMOUNT_TYPES.contains(rightValues.getType())) {
             ValueList result = new ValueList();
             result.setType(PrimitiveType.Boolean);
 

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -36,7 +36,8 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
 
     private BinaryBooleanOperandEvaluator booleanOperandEvaluator = new BinaryBooleanOperandEvaluator(this);
     private BinaryStringOperandEvaluator stringOperandEvaluator = new BinaryStringOperandEvaluator(this);
-    private BinaryTemporalOperandEvaluator dateOperandEvaluator = new BinaryTemporalOperandEvaluator(this);
+    private BinaryTemporalOperandEvaluator temporalOperandEvaluator = new BinaryTemporalOperandEvaluator(this);
+    private BinaryTemporalAmountOperandEvaluator temporalAmountOperandEvaluator = new BinaryTemporalAmountOperandEvaluator(this);
 
     private final ModelInfoLookup lookup; //for now only the archie rm model for rule evaluation
 
@@ -349,14 +350,24 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
             result.addValue(stringOperandEvaluator.evaluateMultipleValuesStringRelOp(statement, leftValues, rightValues));
 
             return result;
-        } else if (List.of(PrimitiveType.Date, PrimitiveType.Time, PrimitiveType.DateTime).contains(leftValues.getType()) ||
-                List.of(PrimitiveType.Date, PrimitiveType.Time, PrimitiveType.DateTime).contains(rightValues.getType())) {
+        } else if (PrimitiveType.Date.equals(leftValues.getType()) || PrimitiveType.Date.equals(rightValues.getType()) ||
+                PrimitiveType.Time.equals(leftValues.getType()) || PrimitiveType.Time.equals(rightValues.getType()) ||
+                PrimitiveType.DateTime.equals(leftValues.getType()) || PrimitiveType.DateTime.equals(rightValues.getType())) {
             ValueList result = new ValueList();
             result.setType(PrimitiveType.Boolean);
 
             //according to the xpath spec, at least one pair from both collections must exist that matches the condition.
             //want otherwise? Use for_all/every
-            result.addValue(dateOperandEvaluator.evaluateMultipleValuesDateRelOp(statement, leftValues, rightValues));
+            result.addValue(temporalOperandEvaluator.evaluateMultipleValuesDateRelOp(statement, leftValues, rightValues));
+
+            return result;
+        } else if (PrimitiveType.Duration.equals(leftValues.getType()) || PrimitiveType.Duration.equals(rightValues.getType())) {
+            ValueList result = new ValueList();
+            result.setType(PrimitiveType.Boolean);
+
+            //according to the xpath spec, at least one pair from both collections must exist that matches the condition.
+            //want otherwise? Use for_all/every
+            result.addValue(temporalAmountOperandEvaluator.evaluateMultipleValuesDateRelOp(statement, leftValues, rightValues));
 
             return result;
         } else {

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryOperatorEvaluator.java
@@ -36,6 +36,7 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
 
     private BinaryBooleanOperandEvaluator booleanOperandEvaluator = new BinaryBooleanOperandEvaluator(this);
     private BinaryStringOperandEvaluator stringOperandEvaluator = new BinaryStringOperandEvaluator(this);
+    private BinaryTemporalOperandEvaluator dateOperandEvaluator = new BinaryTemporalOperandEvaluator(this);
 
     private final ModelInfoLookup lookup; //for now only the archie rm model for rule evaluation
 
@@ -317,7 +318,6 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
         ValueList leftValues = evaluation.evaluate(statement.getLeftOperand());
         ValueList rightValues = evaluation.evaluate(statement.getRightOperand());
 
-
         ValueList possibleNullResult = handlePossibleNullRelOpResult(statement, leftValues, rightValues);
         if(possibleNullResult != null) {
             possibleNullResult.setType(PrimitiveType.Boolean);
@@ -347,6 +347,16 @@ public class BinaryOperatorEvaluator implements Evaluator<BinaryOperator> {
             //according to the xpath spec, at least one pair from both collections must exist that matches the condition.
             //want otherwise? Use for_all/every
             result.addValue(stringOperandEvaluator.evaluateMultipleValuesStringRelOp(statement, leftValues, rightValues));
+
+            return result;
+        } else if (List.of(PrimitiveType.Date, PrimitiveType.Time, PrimitiveType.DateTime).contains(leftValues.getType()) ||
+                List.of(PrimitiveType.Date, PrimitiveType.Time, PrimitiveType.DateTime).contains(rightValues.getType())) {
+            ValueList result = new ValueList();
+            result.setType(PrimitiveType.Boolean);
+
+            //according to the xpath spec, at least one pair from both collections must exist that matches the condition.
+            //want otherwise? Use for_all/every
+            result.addValue(dateOperandEvaluator.evaluateMultipleValuesDateRelOp(statement, leftValues, rightValues));
 
             return result;
         } else {

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalAmountOperandEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalAmountOperandEvaluator.java
@@ -45,7 +45,7 @@ public class BinaryTemporalAmountOperandEvaluator {
      * @param left left value
      * @param right right value
      *
-     * @return
+     * @return A {@link Boolean} result of the comparison
      */
     private Boolean evaluateBooleanRelOp(OperatorKind operator, TemporalAmount left, TemporalAmount right) {
         if (!left.getClass().equals(right.getClass())) {
@@ -72,7 +72,7 @@ public class BinaryTemporalAmountOperandEvaluator {
 
     private Boolean isLess(TemporalAmount left, TemporalAmount right) {
         if (left instanceof Period && right instanceof Period) {
-            return ((Period) left).minus(right).isNegative();
+            return periodToDaysEstimate((Period) left) - periodToDaysEstimate((Period) right) < 0;
         } else if (left instanceof Duration && right instanceof Duration) {
             return ((Duration) left).minus((Duration) right).isNegative();
         } else {
@@ -82,7 +82,7 @@ public class BinaryTemporalAmountOperandEvaluator {
 
     private Boolean isGreater(TemporalAmount left, TemporalAmount right) {
         if (left instanceof Period && right instanceof Period) {
-            return ((Period) right).minus(left).isNegative();
+            return periodToDaysEstimate((Period) left) - periodToDaysEstimate((Period) right) > 0;
         } else if (left instanceof Duration && right instanceof Duration) {
             return ((Duration) right).minus((Duration) left).isNegative();
         } else {
@@ -92,11 +92,25 @@ public class BinaryTemporalAmountOperandEvaluator {
 
     private Boolean isEqual(TemporalAmount left, TemporalAmount right) {
         if (left instanceof Period && right instanceof Period) {
-            return ((Period) right).minus(left).isZero();
+            return periodToDaysEstimate((Period) left) - periodToDaysEstimate((Period) right) == 0;
         } else if (left instanceof Duration && right instanceof Duration) {
             return ((Duration) right).minus((Duration) left).isZero();
         } else {
             throw new IllegalArgumentException("TemporalAmount class not supported: " + left.getClass().getSimpleName());
         }
+    }
+
+    /**
+     * Period is not really comparable as it depends on what date it's used with.
+     * Example: 30 days is not always 1 month.
+     * <p>
+     * This method calculates the estimated amount of days in a Period, so it can be used to compare.
+     *
+     * @param period The period of which the estimated days should be returned.
+     * @return An estimated amount of days for the given Period.
+     */
+    private int periodToDaysEstimate(Period period) {
+        if (period == null) return 0;
+        return (period.getYears() * 12 + period.getMonths()) * 30 + period.getDays();
     }
 }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalAmountOperandEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalAmountOperandEvaluator.java
@@ -1,0 +1,102 @@
+package com.nedap.archie.rules.evaluation.evaluators;
+
+import com.nedap.archie.rules.BinaryOperator;
+import com.nedap.archie.rules.OperatorKind;
+import com.nedap.archie.rules.evaluation.Value;
+import com.nedap.archie.rules.evaluation.ValueList;
+
+import java.time.*;
+import java.time.temporal.TemporalAmount;
+import java.util.List;
+
+public class BinaryTemporalAmountOperandEvaluator {
+    private BinaryOperatorEvaluator mainEvaluator;
+    public BinaryTemporalAmountOperandEvaluator(BinaryOperatorEvaluator mainEvaluator) {
+        this.mainEvaluator = mainEvaluator;
+    }
+
+    protected Value<Boolean> evaluateMultipleValuesDateRelOp(BinaryOperator statement, ValueList leftValues, ValueList rightValues) {
+        for (Value<?> leftValue : leftValues.getValues()) {
+            for (Value<?> rightValue : rightValues.getValues()) {
+                Value<Boolean> evaluatedRelOp = evaluateBooleanRelOp(statement, leftValue.getValue(), rightValue.getValue(), mainEvaluator.getPaths(leftValue, rightValue));
+                if (evaluatedRelOp.getValue().booleanValue()) {
+                    return evaluatedRelOp;
+                }
+            }
+        }
+
+        return new Value<>(false, mainEvaluator.getAllPaths(leftValues, rightValues));
+    }
+
+    private Value<Boolean> evaluateBooleanRelOp(BinaryOperator statement, Object leftValue, Object rightValue, List<String> paths) {
+        if(leftValue == null || rightValue == null) {
+            return new Value<>(mainEvaluator.evaluateNullRelOp(statement.getOperator(), leftValue, rightValue), paths);
+        } else if (leftValue instanceof TemporalAmount && rightValue instanceof TemporalAmount) {
+            return new Value<>(evaluateBooleanRelOp(statement.getOperator(), (TemporalAmount) leftValue, (TemporalAmount) rightValue), paths);
+        } else {
+            throw new IllegalStateException("operand types not supported: " + leftValue.getClass().getSimpleName() + " and " + rightValue.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Evaluate values that are an instance of TemporalAmount (Currently supported: Period and Duration)
+     *
+     * @param operator the operator of the expression
+     * @param left left value
+     * @param right right value
+     *
+     * @return
+     */
+    private Boolean evaluateBooleanRelOp(OperatorKind operator, TemporalAmount left, TemporalAmount right) {
+        if (!left.getClass().equals(right.getClass())) {
+            throw new IllegalArgumentException("non matching classes not supported: " + left.getClass().getSimpleName() + " and " + right.getClass().getSimpleName() + ".");
+        }
+
+        switch (operator) {
+            case ge:
+                if (isEqual(left, right)) return true;
+            case gt:
+                return isGreater(left, right);
+            case le:
+                if (isEqual(left, right)) return true;
+            case lt:
+                return isLess(left, right);
+            case eq:
+                return isEqual(left, right);
+            case ne:
+                return !isEqual(left, right);
+            default:
+                throw new IllegalArgumentException("Not a boolean operator with boolean operands: " + operator);
+        }
+    }
+
+    private Boolean isLess(TemporalAmount left, TemporalAmount right) {
+        if (left instanceof Period && right instanceof Period) {
+            return ((Period) left).minus(right).isNegative();
+        } else if (left instanceof Duration && right instanceof Duration) {
+            return ((Duration) left).minus((Duration) right).isNegative();
+        } else {
+            throw new IllegalArgumentException("TemporalAmount class not supported: " + left.getClass().getSimpleName());
+        }
+    }
+
+    private Boolean isGreater(TemporalAmount left, TemporalAmount right) {
+        if (left instanceof Period && right instanceof Period) {
+            return ((Period) right).minus(left).isNegative();
+        } else if (left instanceof Duration && right instanceof Duration) {
+            return ((Duration) right).minus((Duration) left).isNegative();
+        } else {
+            throw new IllegalArgumentException("TemporalAmount class not supported: " + left.getClass().getSimpleName());
+        }
+    }
+
+    private Boolean isEqual(TemporalAmount left, TemporalAmount right) {
+        if (left instanceof Period && right instanceof Period) {
+            return ((Period) right).minus(left).isZero();
+        } else if (left instanceof Duration && right instanceof Duration) {
+            return ((Duration) right).minus((Duration) left).isZero();
+        } else {
+            throw new IllegalArgumentException("TemporalAmount class not supported: " + left.getClass().getSimpleName());
+        }
+    }
+}

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalOperandEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalOperandEvaluator.java
@@ -45,7 +45,7 @@ public class BinaryTemporalOperandEvaluator {
      * @param left left value
      * @param right right value
      *
-     * @return
+     * @return A {@link Boolean} result of the comparison
      */
     private Boolean evaluateBooleanRelOp(OperatorKind operator, Temporal left, Temporal right) {
         if (!left.getClass().equals(right.getClass())) {

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalOperandEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalOperandEvaluator.java
@@ -5,10 +5,7 @@ import com.nedap.archie.rules.OperatorKind;
 import com.nedap.archie.rules.evaluation.Value;
 import com.nedap.archie.rules.evaluation.ValueList;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.temporal.Temporal;
 import java.util.List;
 
@@ -42,7 +39,7 @@ public class BinaryTemporalOperandEvaluator {
     }
 
     /**
-     * Evaluate values that are an instance of Temporal (LocalDate, LocalDateTime, OffsetDateTime and ZonedDateTime)
+     * Evaluate values that are an instance of Temporal (LocalDate, LocalTime, LocalDateTime, OffsetDateTime and ZonedDateTime)
      *
      * @param operator the operator of the expression
      * @param left left value
@@ -51,7 +48,7 @@ public class BinaryTemporalOperandEvaluator {
      * @return
      */
     private Boolean evaluateBooleanRelOp(OperatorKind operator, Temporal left, Temporal right) {
-        if (left.getClass().equals(right.getClass())) {
+        if (!left.getClass().equals(right.getClass())) {
             throw new IllegalArgumentException("non matching classes not supported: " + left.getClass().getSimpleName() + " and " + right.getClass().getSimpleName() + ".");
         }
 
@@ -76,6 +73,8 @@ public class BinaryTemporalOperandEvaluator {
     private Boolean isBefore(Temporal left, Temporal right) {
         if (left instanceof LocalDate && right instanceof LocalDate) {
             return ((LocalDate) left).isBefore((LocalDate) right);
+        } else if (left instanceof LocalTime && right instanceof LocalTime) {
+            return ((LocalTime) left).isBefore((LocalTime) right);
         } else if (left instanceof LocalDateTime && right instanceof LocalDateTime) {
             return ((LocalDateTime) left).isBefore((LocalDateTime) right);
         } else if (left instanceof OffsetDateTime && right instanceof OffsetDateTime) {
@@ -90,6 +89,8 @@ public class BinaryTemporalOperandEvaluator {
     private Boolean isAfter(Temporal left, Temporal right) {
         if (left instanceof LocalDate && right instanceof LocalDate) {
             return ((LocalDate) left).isAfter((LocalDate) right);
+        } else if (left instanceof LocalTime && right instanceof LocalTime) {
+            return ((LocalTime) left).isAfter((LocalTime) right);
         } else if (left instanceof LocalDateTime && right instanceof LocalDateTime) {
             return ((LocalDateTime) left).isAfter((LocalDateTime) right);
         } else if (left instanceof OffsetDateTime && right instanceof OffsetDateTime) {
@@ -104,6 +105,8 @@ public class BinaryTemporalOperandEvaluator {
     private Boolean isEqual(Temporal left, Temporal right) {
         if (left instanceof LocalDate && right instanceof LocalDate) {
             return ((LocalDate) left).isEqual((LocalDate) right);
+        } else if (left instanceof LocalTime && right instanceof LocalTime) {
+            return !isBefore(left, right) && !isAfter(left, right);
         } else if (left instanceof LocalDateTime && right instanceof LocalDateTime) {
             return ((LocalDateTime) left).isEqual((LocalDateTime) right);
         } else if (left instanceof OffsetDateTime && right instanceof OffsetDateTime) {

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalOperandEvaluator.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/evaluators/BinaryTemporalOperandEvaluator.java
@@ -1,0 +1,117 @@
+package com.nedap.archie.rules.evaluation.evaluators;
+
+import com.nedap.archie.rules.BinaryOperator;
+import com.nedap.archie.rules.OperatorKind;
+import com.nedap.archie.rules.evaluation.Value;
+import com.nedap.archie.rules.evaluation.ValueList;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.List;
+
+public class BinaryTemporalOperandEvaluator {
+    private BinaryOperatorEvaluator mainEvaluator;
+    public BinaryTemporalOperandEvaluator(BinaryOperatorEvaluator mainEvaluator) {
+        this.mainEvaluator = mainEvaluator;
+    }
+
+    protected Value<Boolean> evaluateMultipleValuesDateRelOp(BinaryOperator statement, ValueList leftValues, ValueList rightValues) {
+        for (Value<?> leftValue : leftValues.getValues()) {
+            for (Value<?> rightValue : rightValues.getValues()) {
+                Value<Boolean> evaluatedRelOp = evaluateBooleanRelOp(statement, leftValue.getValue(), rightValue.getValue(), mainEvaluator.getPaths(leftValue, rightValue));
+                if (evaluatedRelOp.getValue().booleanValue()) {
+                    return evaluatedRelOp;
+                }
+            }
+        }
+
+        return new Value<>(false, mainEvaluator.getAllPaths(leftValues, rightValues));
+    }
+
+    private Value<Boolean> evaluateBooleanRelOp(BinaryOperator statement, Object leftValue, Object rightValue, List<String> paths) {
+        if(leftValue == null || rightValue == null) {
+            return new Value<>(mainEvaluator.evaluateNullRelOp(statement.getOperator(), leftValue, rightValue), paths);
+        } else if (leftValue instanceof Temporal && rightValue instanceof Temporal) {
+            return new Value<>(evaluateBooleanRelOp(statement.getOperator(), (Temporal) leftValue, (Temporal) rightValue), paths);
+        } else {
+            throw new IllegalStateException("operand types not supported: " + leftValue.getClass().getSimpleName() + " and " + rightValue.getClass().getSimpleName());
+        }
+    }
+
+    /**
+     * Evaluate values that are an instance of Temporal (LocalDate, LocalDateTime, OffsetDateTime and ZonedDateTime)
+     *
+     * @param operator the operator of the expression
+     * @param left left value
+     * @param right right value
+     *
+     * @return
+     */
+    private Boolean evaluateBooleanRelOp(OperatorKind operator, Temporal left, Temporal right) {
+        if (left.getClass().equals(right.getClass())) {
+            throw new IllegalArgumentException("non matching classes not supported: " + left.getClass().getSimpleName() + " and " + right.getClass().getSimpleName() + ".");
+        }
+
+        switch (operator) {
+            case ge:
+                if (isEqual(left, right)) return true;
+            case gt:
+                return isAfter(left, right);
+            case le:
+                if (isEqual(left, right)) return true;
+            case lt:
+                return isBefore(left, right);
+            case eq:
+                return isEqual(left, right);
+            case ne:
+                return !isEqual(left, right);
+            default:
+                throw new IllegalArgumentException("Not a boolean operator with boolean operands: " + operator);
+        }
+    }
+
+    private Boolean isBefore(Temporal left, Temporal right) {
+        if (left instanceof LocalDate && right instanceof LocalDate) {
+            return ((LocalDate) left).isBefore((LocalDate) right);
+        } else if (left instanceof LocalDateTime && right instanceof LocalDateTime) {
+            return ((LocalDateTime) left).isBefore((LocalDateTime) right);
+        } else if (left instanceof OffsetDateTime && right instanceof OffsetDateTime) {
+            return ((OffsetDateTime) left).isBefore((OffsetDateTime) right);
+        } else if (left instanceof ZonedDateTime && right instanceof ZonedDateTime) {
+            return ((ZonedDateTime) left).isBefore((ZonedDateTime) right);
+        } else {
+            throw new IllegalArgumentException("Temporal class not supported: " + left.getClass().getSimpleName());
+        }
+    }
+
+    private Boolean isAfter(Temporal left, Temporal right) {
+        if (left instanceof LocalDate && right instanceof LocalDate) {
+            return ((LocalDate) left).isAfter((LocalDate) right);
+        } else if (left instanceof LocalDateTime && right instanceof LocalDateTime) {
+            return ((LocalDateTime) left).isAfter((LocalDateTime) right);
+        } else if (left instanceof OffsetDateTime && right instanceof OffsetDateTime) {
+            return ((OffsetDateTime) left).isAfter((OffsetDateTime) right);
+        } else if (left instanceof ZonedDateTime && right instanceof ZonedDateTime) {
+            return ((ZonedDateTime) left).isAfter((ZonedDateTime) right);
+        } else {
+            throw new IllegalArgumentException("Temporal class not supported: " + left.getClass().getSimpleName());
+        }
+    }
+
+    private Boolean isEqual(Temporal left, Temporal right) {
+        if (left instanceof LocalDate && right instanceof LocalDate) {
+            return ((LocalDate) left).isEqual((LocalDate) right);
+        } else if (left instanceof LocalDateTime && right instanceof LocalDateTime) {
+            return ((LocalDateTime) left).isEqual((LocalDateTime) right);
+        } else if (left instanceof OffsetDateTime && right instanceof OffsetDateTime) {
+            return ((OffsetDateTime) left).isEqual((OffsetDateTime) right);
+        } else if (left instanceof ZonedDateTime && right instanceof ZonedDateTime) {
+            return ((ZonedDateTime) left).isEqual((ZonedDateTime) right);
+        } else {
+            throw new IllegalArgumentException("Temporal class not supported: " + left.getClass().getSimpleName());
+        }
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
@@ -24,7 +24,6 @@ public class BinaryOperatorTest {
     @Test
     public void plus() {
         testBinaryOperator(7l, ExpressionType.INTEGER, 4l, 3l, OperatorKind.plus);
-
     }
 
     @Test
@@ -85,10 +84,10 @@ public class BinaryOperatorTest {
     @Test
     public void greaterThan() {
         // Date
-        LocalDate d1 = LocalDate.of(2022, 1, 1);
-        LocalDate d2 = LocalDate.of(2022, 1, 2);
-        testBinaryOperator(false, ExpressionType.DATE, d1, d2, OperatorKind.gt);
-        testBinaryOperator(true, ExpressionType.DATE, d2, d1, OperatorKind.gt);
+        LocalDate ld1 = LocalDate.of(2023, 1, 1);
+        LocalDate ld2 = LocalDate.of(2023, 1, 2);
+        testBinaryOperator(false, ExpressionType.DATE, ld1, ld2, OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DATE, ld2, ld1, OperatorKind.gt);
 
         // Time
         LocalTime t1 = LocalTime.of(12, 0);
@@ -97,35 +96,187 @@ public class BinaryOperatorTest {
         testBinaryOperator(true, ExpressionType.TIME, t2, t1, OperatorKind.gt);
 
         // DateTime
-        LocalDateTime dt1 = LocalDateTime.of(d1, t1);
-        LocalDateTime dt2 = LocalDateTime.of(d1, t2);
+        LocalDateTime dt1 = LocalDateTime.of(ld1, t1);
+        LocalDateTime dt2 = LocalDateTime.of(ld1, t2);
         testBinaryOperator(false, ExpressionType.DATETIME, dt1, dt2, OperatorKind.gt);
         testBinaryOperator(true, ExpressionType.DATETIME, dt2, dt1, OperatorKind.gt);
+
+        // Period
+        Period p1 = Period.of(1, 2, 3);
+        Period p2 = Period.of(3, 2, 1);
+        testBinaryOperator(false, ExpressionType.DURATION, p1, p2, OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DURATION, p2, p1, OperatorKind.gt);
+
+        // Duration
+        Duration d1 = Duration.ofHours(1);
+        Duration d2 = d1.plus(Duration.ofSeconds(1));
+        testBinaryOperator(false, ExpressionType.DURATION, d1, d2, OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DURATION, d2, d1, OperatorKind.gt);
     }
 
     @Test
     public void greaterEqual() {
+        // Date
+        LocalDate ld1 = LocalDate.of(2023, 1, 1);
+        LocalDate ld2 = LocalDate.of(2023, 1, 1);
+        LocalDate ld3 = LocalDate.of(2023, 1, 2);
+        testBinaryOperator(false, ExpressionType.DATE, ld1, ld3, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DATE, ld3, ld1, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DATE, ld1, ld2, OperatorKind.ge);
 
+        // Time
+        LocalTime t1 = LocalTime.of(12, 0);
+        LocalTime t2 = LocalTime.of(12, 0);
+        LocalTime t3 = LocalTime.of(12, 15);
+        testBinaryOperator(false, ExpressionType.TIME, t1, t3, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.TIME, t3, t1, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.TIME, t1, t2, OperatorKind.ge);
+
+        // DateTime
+        LocalDateTime dt1 = LocalDateTime.of(ld1, t1);
+        LocalDateTime dt2 = LocalDateTime.of(ld1, t3);
+        testBinaryOperator(false, ExpressionType.DATETIME, dt1, dt2, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DATETIME, dt2, dt1, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DATETIME, dt1, LocalDateTime.of(ld1, t2), OperatorKind.ge);
+
+        // Period
+        Period p1 = Period.of(1, 2, 3);
+        Period p2 = Period.of(0, 14, 3);
+        Period p3 = Period.of(3, 2, 1);
+        testBinaryOperator(false, ExpressionType.DURATION, p1, p3, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, p3, p1, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, p1, p2, OperatorKind.ge);
+
+        // Duration
+        Duration d1 = Duration.ofHours(1);
+        Duration d2 = Duration.ofMinutes(60);
+        Duration d3 = d1.plus(Duration.ofSeconds(1));
+        testBinaryOperator(false, ExpressionType.DURATION, d1, d3, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, d3, d1, OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, d1, d2, OperatorKind.ge);
     }
 
     @Test
     public void lesserThan() {
+        // Date
+        LocalDate ld1 = LocalDate.of(2023, 1, 1);
+        LocalDate ld2 = LocalDate.of(2023, 1, 2);
+        testBinaryOperator(true, ExpressionType.DATE, ld1, ld2, OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DATE, ld2, ld1, OperatorKind.lt);
 
+        // Time
+        LocalTime t1 = LocalTime.of(12, 0);
+        LocalTime t2 = LocalTime.of(12, 15);
+        testBinaryOperator(true, ExpressionType.TIME, t1, t2, OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.TIME, t2, t1, OperatorKind.lt);
+
+        // DateTime
+        LocalDateTime dt1 = LocalDateTime.of(ld1, t1);
+        LocalDateTime dt2 = LocalDateTime.of(ld1, t2);
+        testBinaryOperator(true, ExpressionType.DATETIME, dt1, dt2, OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DATETIME, dt2, dt1, OperatorKind.lt);
+
+        // Period
+        Period p1 = Period.of(1, 2, 3);
+        Period p2 = Period.of(3, 2, 1);
+        testBinaryOperator(true, ExpressionType.DURATION, p1, p2, OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DURATION, p2, p1, OperatorKind.lt);
+
+        // Duration
+        Duration d1 = Duration.ofHours(1);
+        Duration d2 = d1.plus(Duration.ofSeconds(1));
+        testBinaryOperator(true, ExpressionType.DURATION, d1, d2, OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DURATION, d2, d1, OperatorKind.lt);
     }
 
     @Test
     public void lesserEqual() {
+        // Date
+        LocalDate ld1 = LocalDate.of(2023, 1, 1);
+        LocalDate ld2 = LocalDate.of(2023, 1, 1);
+        LocalDate ld3 = LocalDate.of(2023, 1, 2);
+        testBinaryOperator(true, ExpressionType.DATE, ld1, ld3, OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DATE, ld3, ld1, OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DATE, ld1, ld2, OperatorKind.le);
 
+        // Time
+        LocalTime t1 = LocalTime.of(12, 0);
+        LocalTime t2 = LocalTime.of(12, 0);
+        LocalTime t3 = LocalTime.of(12, 15);
+        testBinaryOperator(true, ExpressionType.TIME, t1, t3, OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.TIME, t3, t1, OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.TIME, t1, t2, OperatorKind.le);
+
+        // DateTime
+        LocalDateTime dt1 = LocalDateTime.of(ld1, t1);
+        LocalDateTime dt2 = LocalDateTime.of(ld1, t3);
+        testBinaryOperator(true, ExpressionType.DATETIME, dt1, dt2, OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DATETIME, dt2, dt1, OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DATETIME, dt1, LocalDateTime.of(ld1, t2), OperatorKind.le);
+
+        // Period
+        Period p1 = Period.of(1, 2, 3);
+        Period p2 = Period.of(0, 14, 3);
+        Period p3 = Period.of(3, 2, 1);
+        testBinaryOperator(true, ExpressionType.DURATION, p1, p3, OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DURATION, p3, p1, OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, p1, p2, OperatorKind.le);
+
+        // Duration
+        Duration d1 = Duration.ofHours(1);
+        Duration d2 = Duration.ofMinutes(60);
+        Duration d3 = d1.plus(Duration.ofSeconds(1));
+        testBinaryOperator(true, ExpressionType.DURATION, d1, d3, OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DURATION, d3, d1, OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, d1, d2, OperatorKind.le);
     }
 
     @Test
     public void equal() {
+        // Date
+        testBinaryOperator(true, ExpressionType.DATE, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 1), OperatorKind.eq);
+        testBinaryOperator(false, ExpressionType.DATE, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 2), OperatorKind.eq);
 
+        // Time
+        testBinaryOperator(true, ExpressionType.TIME, LocalTime.of(10, 0), LocalTime.of(10, 0), OperatorKind.eq);
+        testBinaryOperator(false, ExpressionType.TIME, LocalTime.of(10, 0), LocalTime.of(11, 0), OperatorKind.eq);
+
+        // DateTime
+        testBinaryOperator(true, ExpressionType.DATETIME, LocalDateTime.of(2023, 1, 1, 10, 0), LocalDateTime.of(2023, 1, 1, 10, 0), OperatorKind.eq);
+        testBinaryOperator(false, ExpressionType.DATETIME, LocalDateTime.of(2023, 1, 1, 10, 0), LocalDateTime.of(2023, 1, 1, 10, 1), OperatorKind.eq);
+
+        // Period
+        testBinaryOperator(true, ExpressionType.DURATION, Period.of(1, 0, 0), Period.of(0, 12, 0), OperatorKind.eq);
+        testBinaryOperator(true, ExpressionType.DURATION, Period.of(1, 0, 0), Period.of(0, 0, 360), OperatorKind.eq);
+        testBinaryOperator(false, ExpressionType.DURATION, Period.of(1, 0, 0), Period.of(0, 0, 365), OperatorKind.eq);
+
+        // Duration
+        testBinaryOperator(true, ExpressionType.DURATION, Duration.ofHours(1), Duration.ofSeconds(3600), OperatorKind.eq);
+        testBinaryOperator(false, ExpressionType.DURATION, Duration.ofHours(1), Duration.ofSeconds(3599), OperatorKind.eq);
     }
 
     @Test
     public void notEqual() {
+        // Date
+        testBinaryOperator(false, ExpressionType.DATE, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 1), OperatorKind.ne);
+        testBinaryOperator(true, ExpressionType.DATE, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 2), OperatorKind.ne);
 
+        // Time
+        testBinaryOperator(false, ExpressionType.TIME, LocalTime.of(10, 0), LocalTime.of(10, 0), OperatorKind.ne);
+        testBinaryOperator(true, ExpressionType.TIME, LocalTime.of(10, 0), LocalTime.of(11, 0), OperatorKind.ne);
+
+        // DateTime
+        testBinaryOperator(false, ExpressionType.DATETIME, LocalDateTime.of(2023, 1, 1, 10, 0), LocalDateTime.of(2023, 1, 1, 10, 0), OperatorKind.ne);
+        testBinaryOperator(true, ExpressionType.DATETIME, LocalDateTime.of(2023, 1, 1, 10, 0), LocalDateTime.of(2023, 1, 1, 10, 1), OperatorKind.ne);
+
+        // Period
+        testBinaryOperator(false, ExpressionType.DURATION, Period.of(1, 0, 0), Period.of(0, 12, 0), OperatorKind.ne);
+        testBinaryOperator(false, ExpressionType.DURATION, Period.of(1, 0, 0), Period.of(0, 0, 360), OperatorKind.ne);
+        testBinaryOperator(true, ExpressionType.DURATION, Period.of(1, 0, 0), Period.of(0, 0, 365), OperatorKind.ne);
+
+        // Duration
+        testBinaryOperator(false, ExpressionType.DURATION, Duration.ofHours(1), Duration.ofSeconds(3600), OperatorKind.ne);
+        testBinaryOperator(true, ExpressionType.DURATION, Duration.ofHours(1), Duration.ofSeconds(3599), OperatorKind.ne);
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
@@ -8,6 +8,13 @@ import com.nedap.archie.rules.OperatorKind;
 import com.nedap.archie.xml.JAXBUtil;
 import org.junit.Test;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.temporal.TemporalAmount;
+import java.util.Calendar;
+import java.util.Date;
+
 import static org.junit.Assert.assertEquals;
 
 
@@ -75,6 +82,39 @@ public class BinaryOperatorTest {
     @Test
     public void exponentReal() {
         testBinaryOperator(8d, ExpressionType.REAL, 2d, 3d, OperatorKind.exponent);
+    }
+
+    @Test
+    public void greaterThan() {
+        LocalDate date1 = LocalDate.of(2022, 01, 01);
+        LocalDate date2 = LocalDate.of(2022, 01, 02);
+        testBinaryOperator(false, ExpressionType.DATE, date1, date2, OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DATE, date2, date1, OperatorKind.gt);
+    }
+
+    @Test
+    public void greaterEqual() {
+
+    }
+
+    @Test
+    public void lesserThan() {
+
+    }
+
+    @Test
+    public void lesserEqual() {
+
+    }
+
+    @Test
+    public void equal() {
+
+    }
+
+    @Test
+    public void notEqual() {
+
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
@@ -8,9 +8,7 @@ import com.nedap.archie.rules.OperatorKind;
 import com.nedap.archie.xml.JAXBUtil;
 import org.junit.Test;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.Period;
+import java.time.*;
 import java.time.temporal.TemporalAmount;
 import java.util.Calendar;
 import java.util.Date;
@@ -86,10 +84,23 @@ public class BinaryOperatorTest {
 
     @Test
     public void greaterThan() {
-        LocalDate date1 = LocalDate.of(2022, 01, 01);
-        LocalDate date2 = LocalDate.of(2022, 01, 02);
-        testBinaryOperator(false, ExpressionType.DATE, date1, date2, OperatorKind.gt);
-        testBinaryOperator(true, ExpressionType.DATE, date2, date1, OperatorKind.gt);
+        // Date
+        LocalDate d1 = LocalDate.of(2022, 1, 1);
+        LocalDate d2 = LocalDate.of(2022, 1, 2);
+        testBinaryOperator(false, ExpressionType.DATE, d1, d2, OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DATE, d2, d1, OperatorKind.gt);
+
+        // Time
+        LocalTime t1 = LocalTime.of(12, 0);
+        LocalTime t2 = LocalTime.of(12, 15);
+        testBinaryOperator(false, ExpressionType.TIME, t1, t2, OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.TIME, t2, t1, OperatorKind.gt);
+
+        // DateTime
+        LocalDateTime dt1 = LocalDateTime.of(d1, t1);
+        LocalDateTime dt2 = LocalDateTime.of(d1, t2);
+        testBinaryOperator(false, ExpressionType.DATETIME, dt1, dt2, OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DATETIME, dt2, dt1, OperatorKind.gt);
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
@@ -5,13 +5,9 @@ import com.nedap.archie.rules.BinaryOperator;
 import com.nedap.archie.rules.Constant;
 import com.nedap.archie.rules.ExpressionType;
 import com.nedap.archie.rules.OperatorKind;
-import com.nedap.archie.xml.JAXBUtil;
 import org.junit.Test;
 
 import java.time.*;
-import java.time.temporal.TemporalAmount;
-import java.util.Calendar;
-import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/BinaryOperatorTest.java
@@ -6,6 +6,7 @@ import com.nedap.archie.rules.Constant;
 import com.nedap.archie.rules.ExpressionType;
 import com.nedap.archie.rules.OperatorKind;
 import org.junit.Test;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.*;
 
@@ -108,6 +109,16 @@ public class BinaryOperatorTest {
         Duration d2 = d1.plus(Duration.ofSeconds(1));
         testBinaryOperator(false, ExpressionType.DURATION, d1, d2, OperatorKind.gt);
         testBinaryOperator(true, ExpressionType.DURATION, d2, d1, OperatorKind.gt);
+
+        // PeriodDuration
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1, d1), PeriodDuration.of(p1, d2), OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1, d2), PeriodDuration.of(p1, d1), OperatorKind.gt);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(p2), OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p2), PeriodDuration.of(p1), OperatorKind.gt);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(d1), PeriodDuration.of(d2), OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d2), PeriodDuration.of(d1), OperatorKind.gt);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(d2), PeriodDuration.of(p1), OperatorKind.gt);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(d2), OperatorKind.gt);
     }
 
     @Test
@@ -150,6 +161,22 @@ public class BinaryOperatorTest {
         testBinaryOperator(false, ExpressionType.DURATION, d1, d3, OperatorKind.ge);
         testBinaryOperator(true, ExpressionType.DURATION, d3, d1, OperatorKind.ge);
         testBinaryOperator(true, ExpressionType.DURATION, d1, d2, OperatorKind.ge);
+
+        // PeriodDuration
+        Period p4 = Period.ofDays(1);
+        Duration d4 = Duration.ofDays(1);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1, d1), PeriodDuration.of(p1, d3), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1, d3), PeriodDuration.of(p1, d2), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1, d2), PeriodDuration.of(p1, d1), OperatorKind.ge);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(p3), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(p1), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(p2), OperatorKind.ge);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(d1), PeriodDuration.of(d3), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d1), PeriodDuration.of(d2), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d2), PeriodDuration.of(d1), OperatorKind.ge);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(d2), PeriodDuration.of(p1), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d4), PeriodDuration.of(p4), OperatorKind.ge);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(d1), OperatorKind.ge);
     }
 
     @Test
@@ -183,6 +210,16 @@ public class BinaryOperatorTest {
         Duration d2 = d1.plus(Duration.ofSeconds(1));
         testBinaryOperator(true, ExpressionType.DURATION, d1, d2, OperatorKind.lt);
         testBinaryOperator(false, ExpressionType.DURATION, d2, d1, OperatorKind.lt);
+
+        // PeriodDuration
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1, d1), PeriodDuration.of(p1, d2), OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1, d2), PeriodDuration.of(p1, d1), OperatorKind.lt);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(p2), OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p2), PeriodDuration.of(p1), OperatorKind.lt);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d1), PeriodDuration.of(d2), OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(d2), PeriodDuration.of(d1), OperatorKind.lt);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d2), PeriodDuration.of(p1), OperatorKind.lt);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(d2), OperatorKind.lt);
     }
 
     @Test
@@ -225,6 +262,22 @@ public class BinaryOperatorTest {
         testBinaryOperator(true, ExpressionType.DURATION, d1, d3, OperatorKind.le);
         testBinaryOperator(false, ExpressionType.DURATION, d3, d1, OperatorKind.le);
         testBinaryOperator(true, ExpressionType.DURATION, d1, d2, OperatorKind.le);
+
+        // PeriodDuration
+        Period p4 = Period.ofDays(1);
+        Duration d4 = Duration.ofDays(1);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1, d1), PeriodDuration.of(p1, d3), OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1, d3), PeriodDuration.of(p1, d2), OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1, d2), PeriodDuration.of(p1, d1), OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(p3), OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p3), PeriodDuration.of(p1), OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(p2), OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d1), PeriodDuration.of(d3), OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(d3), PeriodDuration.of(d1), OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d1), PeriodDuration.of(d2), OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d2), PeriodDuration.of(p1), OperatorKind.le);
+        testBinaryOperator(false, ExpressionType.DURATION, PeriodDuration.of(p1), PeriodDuration.of(d1), OperatorKind.le);
+        testBinaryOperator(true, ExpressionType.DURATION, PeriodDuration.of(d4), PeriodDuration.of(p4), OperatorKind.le);
     }
 
     @Test


### PR DESCRIPTION
Adds rule evaluation for some supported data types:
* LocalDate (`PrimitiveType.Date`, `Temporal`)
* LocalTime (`PrimitiveType.Time`, `Temporal`)
* LocalDateTime (`PrimitiveType.DateTime`, `Temporal`)
* OffsetDateTime (`PrimitiveType.DateTime`, `Temporal`)
* ZonedDateTime (`PrimitiveType.DateTime`, `Temporal`)
* Period (`PrimitiveType.Duration`, `TemporalAmount`)
* Duration (`PrimitiveType.Duration`, `TemporalAmount`)

To discuss: Do we want to approach Period comparison this way, another way or not at all?