### PR TITLE
OPENEHR-885: ADLParseException when duplicate MetaDataItem identifiers 

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -126,22 +126,22 @@ public class ADLListener extends AdlBaseListener {
             // If metaDataValue present, value can be 'primitive_value', 'GUID' or 'VERSION_ID'
             switch (identifier) {
                 case ADL_VERSION:
-                    setMetaDataItemWithValue(authoredArchetype::getAdlVersion, authoredArchetype::setAdlVersion, VERSION_ID_REGEX, ADL_VERSION, metaDataValue);
+                    setMetaDataItemWithValue(authoredArchetype::setAdlVersion, authoredArchetype.getAdlVersion(), VERSION_ID_REGEX, ADL_VERSION, metaDataValue);
                     break;
                 case RM_RELEASE:
-                    setMetaDataItemWithValue(authoredArchetype::getRmRelease, authoredArchetype::setRmRelease, VERSION_ID_REGEX, RM_RELEASE, metaDataValue);
+                    setMetaDataItemWithValue(authoredArchetype::setRmRelease, authoredArchetype.getRmRelease(), VERSION_ID_REGEX, RM_RELEASE, metaDataValue);
                     break;
                 case BUILD_UID:
-                    setMetaDataItemWithValue(authoredArchetype::getBuildUid, authoredArchetype::setBuildUid, GUID_REGEX, BUILD_UID, metaDataValue);
+                    setMetaDataItemWithValue(authoredArchetype::setBuildUid, authoredArchetype.getBuildUid(), GUID_REGEX, BUILD_UID, metaDataValue);
                     break;
                 case UID:
-                    setMetaDataItemWithValue(authoredArchetype::getUid, authoredArchetype::setUid, GUID_REGEX, UID, metaDataValue);
+                    setMetaDataItemWithValue(authoredArchetype::setUid, authoredArchetype.getUid(), GUID_REGEX, UID, metaDataValue);
                     break;
                 case CONTROLLED:
-                    setMetaDataItemWithoutValue(authoredArchetype::getControlled, authoredArchetype::setControlled, CONTROLLED, metaDataValue);
+                    setMetaDataItemWithoutValue(authoredArchetype::setControlled, authoredArchetype.getControlled(), CONTROLLED, metaDataValue);
                     break;
                 case GENERATED:
-                    setMetaDataItemWithoutValue(authoredArchetype::getGenerated, authoredArchetype::setGenerated, GENERATED, metaDataValue);
+                    setMetaDataItemWithoutValue(authoredArchetype::setGenerated, authoredArchetype.getGenerated(), GENERATED, metaDataValue);
                     break;
                 default:
                     if (authoredArchetype.getOtherMetaData().containsKey(identifier)) {
@@ -234,15 +234,15 @@ public class ADLListener extends AdlBaseListener {
     /**
      * Sets MetaDataItem with identifier and value in archetype.
      *
-     * @param getExistingValue Get method for value of the identifier in archetype to check whether this readily exists
-     * @param setNewValue      Set method for value of the identifier in archetype to set the new value if it does not exist
-     * @param valuePattern     Pattern to which the value should match
-     * @param identifier       Identifier of the MetaDataItem
-     * @param newValue         New value to set for the identifier
+     * @param setNewValue   Set method for value of the identifier in archetype to set the new value if it does not exist
+     * @param existingValue Not null means the identifier has been declared before in the metadata of the archetype
+     * @param valuePattern  Pattern to which the value should match
+     * @param identifier    Identifier of the MetaDataItem
+     * @param newValue      New value to set for the identifier
      */
-    private void setMetaDataItemWithValue(Supplier<String> getExistingValue, Consumer<String> setNewValue, Pattern valuePattern, String identifier, String newValue) {
+    private void setMetaDataItemWithValue(Consumer<String> setNewValue, String existingValue, Pattern valuePattern, String identifier, String newValue) {
         if (newValue != null && valuePattern.matcher(newValue).matches()) {
-            if (getExistingValue.get() != null) {
+            if (existingValue != null) {
                 errors.addError("Encountered additional declaration for metadata tag '" + identifier + "' while only single is allowed");
             } else {
                 setNewValue.accept(newValue);
@@ -255,13 +255,13 @@ public class ADLListener extends AdlBaseListener {
     /**
      * Sets MetaDataItem with identifier and no value. Identifier has boolean value which will only be set to true whenever conditions are met.
      *
-     * @param getExistingBoolean Get method for boolean of the identifier in archetype to check whether boolean was readily set to true
-     * @param setBooleanTrue     Set method for boolean of the identifier in archetype to set the boolean to true if not done before
-     * @param identifier         Identifier of the MetaDataItem
-     * @param unexpectedValue    Expected to be null because identifier should not have a value
+     * @param setBooleanTrue  Set method for boolean of the identifier in archetype to set the boolean to true if not done before
+     * @param existingBoolean Not null and true means the identifier has been declared before in the metadata of the archetype
+     * @param identifier      Identifier of the MetaDataItem
+     * @param unexpectedValue Expected to be null because identifier should not have a value
      */
-    private void setMetaDataItemWithoutValue(Supplier<Boolean> getExistingBoolean, Consumer<Boolean> setBooleanTrue, String identifier, String unexpectedValue) {
-        if (getExistingBoolean.get() != null && getExistingBoolean.get()) {
+    private void setMetaDataItemWithoutValue(Consumer<Boolean> setBooleanTrue, Boolean existingBoolean, String identifier, String unexpectedValue) {
+        if (existingBoolean != null && existingBoolean) {
             errors.addError("Encountered additional metadata tag for '" + identifier + "' while only single is allowed");
         } else if (unexpectedValue == null) {
             setBooleanTrue.accept(Boolean.TRUE);

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -2,20 +2,17 @@ package com.nedap.archie.adlparser.treewalkers;
 
 import com.fasterxml.jackson.databind.type.MapType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.antlr.errors.ANTLRParserErrors;
 import com.nedap.archie.adlparser.antlr.AdlBaseListener;
 import com.nedap.archie.adlparser.antlr.AdlParser;
 import com.nedap.archie.adlparser.antlr.AdlParser.*;
 import com.nedap.archie.aom.rmoverlay.RmOverlay;
-import com.nedap.archie.definitions.OpenEhrDefinitions;
 import com.nedap.archie.rminfo.MetaModels;
 import com.nedap.archie.serializer.odin.OdinObjectParser;
 import com.nedap.archie.serializer.odin.AdlOdinToJsonConverter;
 import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.checkerframework.checker.guieffect.qual.UI;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -129,49 +126,29 @@ public class ADLListener extends AdlBaseListener {
             // If metaDataValue present, value can be 'primitive_value', 'GUID' or 'VERSION_ID'
             switch (identifier) {
                 case ADL_VERSION:
-                    if (metaDataValue != null && VERSION_ID_REGEX.matcher(metaDataValue).matches()) {
-                        authoredArchetype.setAdlVersion(metaDataValue);
-                    } else {
-                        errors.addError("Encountered metadata tag '" + ADL_VERSION + "' with an invalid version id: " + metaDataValue);
-                    }
+                    setMetaDataItemWithValue(authoredArchetype::getAdlVersion, authoredArchetype::setAdlVersion, VERSION_ID_REGEX, ADL_VERSION, metaDataValue);
                     break;
                 case RM_RELEASE:
-                    if (metaDataValue != null && VERSION_ID_REGEX.matcher(metaDataValue).matches()) {
-                        authoredArchetype.setRmRelease(metaDataValue);
-                    } else {
-                        errors.addError("Encountered metadata tag '" + RM_RELEASE + "' with an invalid version id: " + metaDataValue);
-                    }
+                    setMetaDataItemWithValue(authoredArchetype::getRmRelease, authoredArchetype::setRmRelease, VERSION_ID_REGEX, RM_RELEASE, metaDataValue);
                     break;
                 case BUILD_UID:
-                    if (metaDataValue != null && GUID_REGEX.matcher(metaDataValue).matches()) {
-                        authoredArchetype.setBuildUid(metaDataValue);
-                    } else {
-                        errors.addError("Encountered metadata tag '" + BUILD_UID + "' with an invalid guid: " + metaDataValue);
-                    }
+                    setMetaDataItemWithValue(authoredArchetype::getBuildUid, authoredArchetype::setBuildUid, GUID_REGEX, BUILD_UID, metaDataValue);
                     break;
                 case UID:
-                    if (metaDataValue != null && GUID_REGEX.matcher(metaDataValue).matches()) {
-                        authoredArchetype.setUid(metaDataValue);
-                    } else {
-                        errors.addError("Encountered metadata tag '" + UID + "' with an invalid guid: " + metaDataValue);
-                    }
+                    setMetaDataItemWithValue(authoredArchetype::getUid, authoredArchetype::setUid, GUID_REGEX, UID, metaDataValue);
                     break;
                 case CONTROLLED:
-                    if (metaDataValue == null) {
-                        authoredArchetype.setControlled(true);
-                    } else {
-                        errors.addError("Encountered metadata tag '" + CONTROLLED + "' with a value assignment while expecting none");
-                    }
+                    setMetaDataItemWithoutValue(authoredArchetype::getControlled, authoredArchetype::setControlled, CONTROLLED, metaDataValue);
                     break;
                 case GENERATED:
-                    if (metaDataValue == null) {
-                        authoredArchetype.setGenerated(true);
-                    } else {
-                        errors.addError("Encountered metadata tag '" + GENERATED + "' with a value assignment while expecting none");
-                    }
+                    setMetaDataItemWithoutValue(authoredArchetype::getGenerated, authoredArchetype::setGenerated, GENERATED, metaDataValue);
                     break;
                 default:
-                    authoredArchetype.addOtherMetadata(identifier, metaDataValue);
+                    if (authoredArchetype.getOtherMetaData().containsKey(identifier)) {
+                        errors.addError("Encountered additional declaration for metadata tag '" + identifier + "' while only single is allowed");
+                    } else {
+                        authoredArchetype.addOtherMetadata(identifier, metaDataValue);
+                    }
                     break;
             }
         }
@@ -254,5 +231,42 @@ public class ADLListener extends AdlBaseListener {
         return errors;
     }
 
+    /**
+     * Sets MetaDataItem with identifier and value in archetype.
+     *
+     * @param getExistingValue Get method for value of the identifier in archetype to check whether this readily exists
+     * @param setNewValue      Set method for value of the identifier in archetype to set the new value if it does not exist
+     * @param valuePattern     Pattern to which the value should match
+     * @param identifier       Identifier of the MetaDataItem
+     * @param newValue         New value to set for the identifier
+     */
+    private void setMetaDataItemWithValue(Supplier<String> getExistingValue, Consumer<String> setNewValue, Pattern valuePattern, String identifier, String newValue) {
+        if (newValue != null && valuePattern.matcher(newValue).matches()) {
+            if (getExistingValue.get() != null) {
+                errors.addError("Encountered additional declaration for metadata tag '" + identifier + "' while only single is allowed");
+            } else {
+                setNewValue.accept(newValue);
+            }
+        } else {
+            errors.addError("Encountered metadata tag '" + identifier + "' with an invalid value: " + newValue + ". Value should match pattern: " + valuePattern.pattern());
+        }
+    }
 
+    /**
+     * Sets MetaDataItem with identifier and no value. Identifier has boolean value which will only be set to true whenever conditions are met.
+     *
+     * @param getExistingBoolean Get method for boolean of the identifier in archetype to check whether boolean was readily set to true
+     * @param setBooleanTrue     Set method for boolean of the identifier in archetype to set the boolean to true if not done before
+     * @param identifier         Identifier of the MetaDataItem
+     * @param unexpectedValue    Expected to be null because identifier should not have a value
+     */
+    private void setMetaDataItemWithoutValue(Supplier<Boolean> getExistingBoolean, Consumer<Boolean> setBooleanTrue, String identifier, String unexpectedValue) {
+        if (getExistingBoolean.get() != null && getExistingBoolean.get()) {
+            errors.addError("Encountered additional metadata tag for '" + identifier + "' while only single is allowed");
+        } else if (unexpectedValue == null) {
+            setBooleanTrue.accept(Boolean.TRUE);
+        } else {
+            errors.addError("Encountered metadata tag '" + identifier + "' with a value assignment while expecting none");
+        }
+    }
 }

--- a/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
@@ -69,12 +69,28 @@ public class MetadataTest {
         try {
             TestUtil.parseFailOnErrors("/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.invalid_metadata.v1.0.0.adls");
         } catch (ADLParseException ex) {
-            assertEquals("Error: Encountered metadata tag 'adl_version' with an invalid version id: null\n" +
-                            "Error: Encountered metadata tag 'rm_release' with an invalid version id: 1-1-1-1-1\n" +
+            assertEquals("Error: Encountered metadata tag 'adl_version' with an invalid value: null. Value should match pattern: [0-9]+.[0-9]+.[0-9]+((-rc|-alpha)(.[0-9]+)?)?\n" +
+                            "Error: Encountered metadata tag 'rm_release' with an invalid value: 1-1-1-1-1. Value should match pattern: [0-9]+.[0-9]+.[0-9]+((-rc|-alpha)(.[0-9]+)?)?\n" +
                             "Error: Encountered metadata tag 'generated' with a value assignment while expecting none\n" +
                             "Error: Encountered metadata tag 'controlled' with a value assignment while expecting none\n" +
-                            "Error: Encountered metadata tag 'uid' with an invalid guid: 1.0.0-rc\n" +
-                            "Error: Encountered metadata tag 'build_uid' with an invalid guid: null\n",
+                            "Error: Encountered metadata tag 'uid' with an invalid value: 1.0.0-rc. Value should match pattern: [0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+\n" +
+                            "Error: Encountered metadata tag 'build_uid' with an invalid value: null. Value should match pattern: [0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+\n",
+                    ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testDuplicateMetadata() throws IOException {
+        try {
+            TestUtil.parseFailOnErrors("/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.duplicate_metadata.v1.0.0.adls");
+        } catch (ADLParseException ex) {
+            assertEquals("Error: Encountered metadata tag 'rm_release' with an invalid value: null. Value should match pattern: [0-9]+.[0-9]+.[0-9]+((-rc|-alpha)(.[0-9]+)?)?\n" +
+                            "Error: Encountered additional metadata tag for 'generated' while only single is allowed\n" +
+                            "Error: Encountered additional metadata tag for 'controlled' while only single is allowed\n" +
+                            "Error: Encountered metadata tag 'uid' with an invalid value: null. Value should match pattern: [0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+-[0-9a-fA-F]+\n" +
+                            "Error: Encountered additional declaration for metadata tag 'build_uid' while only single is allowed\n" +
+                            "Error: Encountered additional declaration for metadata tag 'pieter' while only single is allowed\n" +
+                            "Error: Encountered additional declaration for metadata tag 'bos' while only single is allowed\n",
                     ex.getMessage());
         }
     }

--- a/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.duplicate_metadata.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.duplicate_metadata.v1.0.0.adls
@@ -1,0 +1,23 @@
+archetype (adl_version=1.0.0; rm_release; rm_release=1.0.0; generated; generated; controlled; controlled=1; uid=1-1-1-1-1; uid; build_uid=1-1-1-1-1; build_uid=2-2-2-2-2; reviewed; reviewed; by; pieter=0.0.7; pieter; bos=0.0.7; bos=1-1-1-1-1)
+	openEHR-EHR-COMPOSITION.duplicate_metadata.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Eline Brader">
+	>
+
+definition
+	COMPOSITION[id1] -- test duplicate metadata
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"test duplicate metadata">
+				description = <"">
+			>
+		>
+	>


### PR DESCRIPTION
https://jira.nedap.healthcare/browse/OPENEHR-885
solves #497 

When MetaDataItem is visited, identifier and value pair are put in a Map. 
Whenever identifier occurs more then once and declared correctly, its key/value mapping is always set to the last declaration and all preceding ones are lost without giving any error. 

This PR makes sure that whenever a duplicate identifier is encountered, an ADLParseException is thrown with detailed message. 

PS: there is one scenario left where no exception is thrown. This is whenever an identifier has no value and does not conform to the `CONTROLLED` or `GENERATED` tag. Currently, whenever this happens, nothing is done at all and the identifier itself is not even added to the Map with a null value. This might need to be solved in another PR.