### PR TITLE
Fix BMM object mapper being used before being fully configured

### DIFF
--- a/bmm/src/main/java/org/openehr/bmm/v2/persistence/jackson/BmmJacksonUtil.java
+++ b/bmm/src/main/java/org/openehr/bmm/v2/persistence/jackson/BmmJacksonUtil.java
@@ -36,9 +36,11 @@ public class BmmJacksonUtil {
      */
     public static ObjectMapper getObjectMapper() {
         if(objectMapper == null) {
-            objectMapper = new ObjectMapper();
-            configureObjectMapper(objectMapper);
-
+            ObjectMapper newObjectMapper = new ObjectMapper();
+            configureObjectMapper(newObjectMapper);
+            // Assign to the static variable after configuration, so it can't be accessed by other thread before it is
+            // fully configured.
+            objectMapper = newObjectMapper;
         }
         return objectMapper;
     }


### PR DESCRIPTION
When two or more threads call `BmmJacksonUtil.getObjectMapper()` simultaneously some threads could receive unconfigured object mappers resulting into deserialization errors.

This could happen because the static `objectMapper` variable is filled with an object mapper before it is configured. In the moment between the `objectMapper` variable being set and the `configureObjectMapper` method being (fully) executed, other threads can already see and use the unconfigured object mapper.

This PR solves the problem by first fully configuring the object mapper before assigning it to the `objectMapper` static variable. This is similar to the flow in https://github.com/openEHR/archie/blob/4b5e684c75e6efaa9d67a0a80540cefb7259c2fa/archie-utils/src/main/java/com/nedap/archie/json/JacksonUtil.java#L54-L63

A drawback of this solution is that multiple object mappers might get created and configured when this method is called initially by multiple threads at the same time, but I considered the costs of this low enough and did not implement any locking to prevent this from happening.