### PR TITLE
OPENEHR-885: ADLParseException duplicate metadata identifiers

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -12,6 +12,7 @@ import com.nedap.archie.serializer.odin.OdinObjectParser;
 import com.nedap.archie.serializer.odin.AdlOdinToJsonConverter;
 import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.terminology.ArchetypeTerminology;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.HashSet;
@@ -124,7 +125,7 @@ public class ADLListener extends AdlBaseListener {
             String identifier = ctx.identifier().getText();
             String metaDataValue = ctx.metaDataValue() != null ? ctx.metaDataValue().getText() : null;
             // Check if identifier is declared only once
-            checkMetaDataIdentifier(identifier);
+            checkMetaDataIdentifier(identifier, ctx.identifier());
 
             // If metaDataValue present, value can be 'primitive_value', 'GUID' or 'VERSION_ID'
             switch (identifier) {
@@ -132,42 +133,54 @@ public class ADLListener extends AdlBaseListener {
                     if (metaDataValue != null && VERSION_ID_REGEX.matcher(metaDataValue).matches()) {
                         authoredArchetype.setAdlVersion(metaDataValue);
                     } else {
-                        errors.addError("Encountered metadata tag '" + ADL_VERSION + "' with an invalid version id: " + metaDataValue);
+                        addError("Encountered metadata tag '" + ADL_VERSION + "' with an invalid version id: " + metaDataValue,
+                                "incorrect header metadata format",
+                                ctx.identifier());
                     }
                     break;
                 case RM_RELEASE:
                     if (metaDataValue != null && VERSION_ID_REGEX.matcher(metaDataValue).matches()) {
                         authoredArchetype.setRmRelease(metaDataValue);
                     } else {
-                        errors.addError("Encountered metadata tag '" + RM_RELEASE + "' with an invalid version id: " + metaDataValue);
+                        addError("Encountered metadata tag '" + RM_RELEASE + "' with an invalid version id: " + metaDataValue,
+                                "incorrect header metadata format",
+                                ctx.identifier());
                     }
                     break;
                 case BUILD_UID:
                     if (metaDataValue != null && GUID_REGEX.matcher(metaDataValue).matches()) {
                         authoredArchetype.setBuildUid(metaDataValue);
                     } else {
-                        errors.addError("Encountered metadata tag '" + BUILD_UID + "' with an invalid guid: " + metaDataValue);
+                        addError("Encountered metadata tag '" + BUILD_UID + "' with an invalid guid: " + metaDataValue,
+                                "incorrect header metadata format",
+                                ctx.identifier());
                     }
                     break;
                 case UID:
                     if (metaDataValue != null && GUID_REGEX.matcher(metaDataValue).matches()) {
                         authoredArchetype.setUid(metaDataValue);
                     } else {
-                        errors.addError("Encountered metadata tag '" + UID + "' with an invalid guid: " + metaDataValue);
+                        addError("Encountered metadata tag '" + UID + "' with an invalid guid: " + metaDataValue,
+                                "incorrect header metadata format",
+                                ctx.identifier());
                     }
                     break;
                 case CONTROLLED:
                     if (metaDataValue == null) {
                         authoredArchetype.setControlled(true);
                     } else {
-                        errors.addError("Encountered metadata tag '" + CONTROLLED + "' with a value assignment while expecting none");
+                        addError("Encountered metadata tag '" + CONTROLLED + "' with a value assignment while expecting none",
+                                "incorrect header metadata format",
+                                ctx.identifier());
                     }
                     break;
                 case GENERATED:
                     if (metaDataValue == null) {
                         authoredArchetype.setGenerated(true);
                     } else {
-                        errors.addError("Encountered metadata tag '" + GENERATED + "' with a value assignment while expecting none");
+                        addError("Encountered metadata tag '" + GENERATED + "' with a value assignment while expecting none",
+                                "incorrect header metadata format",
+                                ctx.identifier());
                     }
                     break;
                 default:
@@ -223,12 +236,23 @@ public class ADLListener extends AdlBaseListener {
         archetype.setRmOverlay(OdinObjectParser.convert(ctx.odin_text(), RmOverlay.class));
     }
 
-    private void checkMetaDataIdentifier(String identifier) {
+    private void checkMetaDataIdentifier(String identifier, IdentifierContext identifierContext) {
         if(seenMetaDataIdentifiers.contains(identifier)) {
-            errors.addError("Encountered another metadata tag for '" + identifier + "' whilst single allowed");
+            addError("Encountered another metadata tag for '" + identifier + "' whilst single allowed",
+                    "only one header metadata tag allowed",
+                    identifierContext);
         } else {
             seenMetaDataIdentifiers.add(identifier);
         }
+    }
+
+    private void addError(String message, String shortMessage, ParserRuleContext identifierContext) {
+        errors.addError(message,
+                shortMessage,
+                identifierContext.getStart().getLine(),
+                identifierContext.getStart().getCharPositionInLine(),
+                identifierContext.getStart().getText().length(),
+                identifierContext.getStart().getText());
     }
 
     public void enterComponentTerminologiesSection(AdlParser.ComponentTerminologiesSectionContext ctx) {

--- a/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
+++ b/aom/src/main/java/com/nedap/archie/adlparser/treewalkers/ADLListener.java
@@ -247,8 +247,7 @@ public class ADLListener extends AdlBaseListener {
     }
 
     private void addError(String message, String shortMessage, ParserRuleContext identifierContext) {
-        errors.addError(message,
-                shortMessage,
+        errors.addError(message, shortMessage,
                 identifierContext.getStart().getLine(),
                 identifierContext.getStart().getCharPositionInLine(),
                 identifierContext.getStart().getText().length(),

--- a/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -84,8 +85,24 @@ public class MetadataTest {
                             "Error: Encountered metadata tag 'build_uid' with an invalid guid: null\n" +
                             "Error: Encountered another metadata tag for 'pieter' whilst single allowed\n",
                     ex.getMessage());
-            ANTLRParserMessage adlVersionError = ex.getErrors().getErrors().get(0);
+
+            List<ANTLRParserMessage> errors = ex.getErrors().getErrors();
+            // Assert first error
+            ANTLRParserMessage adlVersionError = errors.get(0);
+            assertEquals("adl_version", adlVersionError.getOffendingSymbol());
+            assertEquals("incorrect header metadata format", adlVersionError.getShortMessage());
+            assertEquals("Encountered metadata tag 'adl_version' with an invalid version id: null", adlVersionError.getMessage());
             assertEquals(1, adlVersionError.getLineNumber());
+            assertEquals(11, adlVersionError.getColumnNumber());
+            assertEquals(11, (int) adlVersionError.getLength());
+            // Assert last error
+            ANTLRParserMessage pieterError = errors.get(errors.size() - 1);
+            assertEquals("pieter", pieterError.getOffendingSymbol());
+            assertEquals("only one header metadata tag allowed", pieterError.getShortMessage());
+            assertEquals("Encountered another metadata tag for 'pieter' whilst single allowed", pieterError.getMessage());
+            assertEquals(1, pieterError.getLineNumber());
+            assertEquals(177, pieterError.getColumnNumber());
+            assertEquals(6, (int) pieterError.getLength());
         }
     }
 }

--- a/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.adlparser;
 
+import com.nedap.archie.antlr.errors.ANTLRParserMessage;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.aom.AuthoredArchetype;
 import com.nedap.archie.aom.CAttribute;
@@ -68,6 +69,7 @@ public class MetadataTest {
     public void testInvalidMetadata() throws IOException {
         try {
             TestUtil.parseFailOnErrors("/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.invalid_metadata.v1.0.0.adls");
+            fail();
         } catch (ADLParseException ex) {
             assertEquals("Error: Encountered metadata tag 'adl_version' with an invalid version id: null\n" +
                             "Error: Encountered another metadata tag for 'adl_version' whilst single allowed\n" +
@@ -82,6 +84,8 @@ public class MetadataTest {
                             "Error: Encountered metadata tag 'build_uid' with an invalid guid: null\n" +
                             "Error: Encountered another metadata tag for 'pieter' whilst single allowed\n",
                     ex.getMessage());
+            ANTLRParserMessage adlVersionError = ex.getErrors().getErrors().get(0);
+            assertEquals(1, adlVersionError.getLineNumber());
         }
     }
 }

--- a/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/MetadataTest.java
@@ -70,11 +70,17 @@ public class MetadataTest {
             TestUtil.parseFailOnErrors("/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.invalid_metadata.v1.0.0.adls");
         } catch (ADLParseException ex) {
             assertEquals("Error: Encountered metadata tag 'adl_version' with an invalid version id: null\n" +
+                            "Error: Encountered another metadata tag for 'adl_version' whilst single allowed\n" +
+                            "Error: Encountered another metadata tag for 'adl_version' whilst single allowed\n" +
+                            "Error: Encountered metadata tag 'adl_version' with an invalid version id: null\n" +
+                            "Error: Encountered another metadata tag for 'rm_release' whilst single allowed\n" +
                             "Error: Encountered metadata tag 'rm_release' with an invalid version id: 1-1-1-1-1\n" +
+                            "Error: Encountered another metadata tag for 'generated' whilst single allowed\n" +
                             "Error: Encountered metadata tag 'generated' with a value assignment while expecting none\n" +
                             "Error: Encountered metadata tag 'controlled' with a value assignment while expecting none\n" +
                             "Error: Encountered metadata tag 'uid' with an invalid guid: 1.0.0-rc\n" +
-                            "Error: Encountered metadata tag 'build_uid' with an invalid guid: null\n",
+                            "Error: Encountered metadata tag 'build_uid' with an invalid guid: null\n" +
+                            "Error: Encountered another metadata tag for 'pieter' whilst single allowed\n",
                     ex.getMessage());
         }
     }

--- a/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.invalid_metadata.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/adlparser/openEHR-EHR-COMPOSITION.invalid_metadata.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version; rm_release=1-1-1-1-1; generated=1; controlled=1.0.0; uid=1.0.0-rc; build_uid)
+archetype (adl_version; adl_version=1.0.0; adl_version; rm_release=1.0.0; rm_release=1-1-1-1-1; generated; generated=1; controlled=1.0.0; uid=1.0.0-rc; build_uid; pieter=0.0.7; pieter=0.0.7)
 	openEHR-EHR-COMPOSITION.invalid_metadata.v1.0.0
 
 language


### PR DESCRIPTION
https://jira.nedap.healthcare/browse/OPENEHR-885
solves https://github.com/openEHR/archie/issues/497

When MetaDataItem is visited, identifier and value pair are put in a Map.
Whenever identifier occurs more then once and declared correctly, its key/value mapping is always set to the last declaration and all preceding ones are lost without giving any error.

This PR makes sure that whenever a duplicate identifier is encountered, an ADLParseException is thrown with detailed message.