### PR TITLE
Restore thread local language after buildPathsAndValues call

### DIFF
--- a/base/src/main/java/com/nedap/archie/ArchieLanguageConfiguration.java
+++ b/base/src/main/java/com/nedap/archie/ArchieLanguageConfiguration.java
@@ -54,6 +54,13 @@ public class ArchieLanguageConfiguration {
         currentLogicalPathLanguage.set(language);
     }
 
+    /**
+     * Get the overridden language for descriptions and meanings in the current thread.
+     *
+     * In general you should use the {@link #getMeaningAndDescriptionLanguage()} function
+     * as it will automatically fall back to the default setting when no thread specific
+     * language is set.
+     */
     public static String getThreadLocalDescriptiongAndMeaningLanguage() {
         return currentMeaningAndDescriptionLanguage.get();
     }

--- a/base/src/main/java/com/nedap/archie/ArchieLanguageConfiguration.java
+++ b/base/src/main/java/com/nedap/archie/ArchieLanguageConfiguration.java
@@ -54,6 +54,10 @@ public class ArchieLanguageConfiguration {
         currentLogicalPathLanguage.set(language);
     }
 
+    public static String getThreadLocalDescriptiongAndMeaningLanguage() {
+        return currentMeaningAndDescriptionLanguage.get();
+    }
+
     /*
      * Override the language used in descriptions and meanings, on a thread local basis
      * @Param language the language to use

--- a/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
+++ b/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
@@ -79,13 +79,23 @@ public class FlatJsonGenerator {
      */
 
     public Map<String, Object> buildPathsAndValues(OpenEHRBase rmObject) throws DuplicateKeyException {
-        return buildPathsAndValues(rmObject, null, null);
+        return buildPathsAndValues(rmObject, null);
     }
 
     public Map<String, Object> buildPathsAndValues(OpenEHRBase rmObject, OperationalTemplate archetype, String language) throws DuplicateKeyException {
+        String previousLanguage = ArchieLanguageConfiguration.getThreadLocalDescriptiongAndMeaningLanguage();
         if(language != null) {
             ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage(language);
         }
+
+        try {
+            return buildPathsAndValues(rmObject, archetype);
+        } finally {
+            ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage(previousLanguage);
+        }
+    }
+
+    public Map<String, Object> buildPathsAndValues(OpenEHRBase rmObject, OperationalTemplate archetype) throws DuplicateKeyException {
         Map<String, Object> result = new LinkedHashMap<>();
         CObject definition = archetype == null ? null : archetype.getDefinition();
         buildPathsAndValuesInner(result, null, "/", rmObject, definition, false);
@@ -99,7 +109,6 @@ public class FlatJsonGenerator {
             }
         }
         return result;
-
     }
 
     private void buildPathsAndValuesInner(Map<String, Object> result, RMTypeInfo rmAttributeTypeInfo, String pathSoFar, OpenEHRBase rmObject, CObject cObject, boolean typeAlternativesPresent) throws DuplicateKeyException {


### PR DESCRIPTION
When given a language, the FlatJsonGenerator.buildPathsAndValues method will set the ThreadLocalDescriptiongAndMeaningLanguage in ArchieLanguageConfiguration, but doesn't restore the original value. This causes the language to be unexpectedly changed after the method call.

This PR changes the buildPathsAndValues method to restore the ThreadLocalDescriptiongAndMeaningLanguage after the main logic to the value it was before the call. I have implemented this by splitting the method in a part that changes the language and moved the main logic to a new overloading method without the language parameter.