### PR TITLE
Use operational templates during validation in ExampleJsonInstanceGeneratorTest

### DIFF
--- a/tools/src/test/java/com/nedap/archie/testutil/DummyOperationalTemplateProvider.java
+++ b/tools/src/test/java/com/nedap/archie/testutil/DummyOperationalTemplateProvider.java
@@ -1,0 +1,37 @@
+package com.nedap.archie.testutil;
+
+import com.nedap.archie.aom.ArchetypeHRID;
+import com.nedap.archie.aom.CComplexObject;
+import com.nedap.archie.aom.OperationalTemplate;
+import com.nedap.archie.flattener.OperationalTemplateProvider;
+
+/**
+ * Generates dummy operational templates when one is requested with the given concept id.
+ */
+public class DummyOperationalTemplateProvider implements OperationalTemplateProvider {
+    private final String conceptId;
+
+    public DummyOperationalTemplateProvider(String conceptId) {
+        this.conceptId = conceptId;
+    }
+
+    @Override
+    public OperationalTemplate getOperationalTemplate(String archetypeId) {
+        ArchetypeHRID archetypeHRID = new ArchetypeHRID(archetypeId);
+        if(conceptId.equals(archetypeHRID.getConceptId())) {
+            return generateDummyOperationalTemplate(archetypeHRID);
+        }
+        return null;
+    }
+
+    private static OperationalTemplate generateDummyOperationalTemplate(ArchetypeHRID archetypeHRID) {
+        CComplexObject cComplexObject = new CComplexObject();
+        cComplexObject.setNodeId("id1");
+        cComplexObject.setRmTypeName(archetypeHRID.getRmClass());
+
+        OperationalTemplate result = new OperationalTemplate();
+        result.setArchetypeId(archetypeHRID);
+        result.setDefinition(cComplexObject);
+        return result;
+    }
+}


### PR DESCRIPTION
Use operational templates during validation in ExampleJsonInstanceGeneratorTest.

This uses the new DummyOperationalTemplateProvider which will provide dummy operational templates for `openEHR-EHR-*.archetype-slot.v1` archetypes.

This also adds a filter for validation errors caused by unsupported features in the generator. These validation errors will be ignored.