### PR TITLE
Validate archetyped objects

### DIFF
--- a/tools/src/test/java/com/nedap/archie/rmobjectvalidator/ValidateArchetypedTest.java
+++ b/tools/src/test/java/com/nedap/archie/rmobjectvalidator/ValidateArchetypedTest.java
@@ -59,6 +59,7 @@ public class ValidateArchetypedTest {
     public void testArchetypedOtherDetails() {
         Element element = (Element) testUtil.constructEmptyRMObject(elementArchetype.getDefinition());
         DvProportion dvProportion = (DvProportion) element.getValue();
+        dvProportion.setNumerator(3D);
         dvProportion.setDenominator(4D);
         dvProportion.setType(3L);
 
@@ -79,14 +80,10 @@ public class ValidateArchetypedTest {
 
         validator.setRunInvariantChecks(false);
         List<RMObjectValidationMessage> validationMessages = validator.validate(elementOpt, element);
-        assertEquals("There should be 2 errors", 2, validationMessages.size());
-        assertEquals("There should be a validation message about the numerator", "Attribute numerator of class DV_PROPORTION does not match existence 1..1", validationMessages.get(0).getMessage());
-        assertEquals("The path should be correct", "/value/numerator", validationMessages.get(0).getPath());
-        assertEquals("The archetype path should be correct", "/value[id2]/numerator", validationMessages.get(0).getArchetypePath());
-
-        assertEquals("Attribute does not match cardinality 1..2", validationMessages.get(1).getMessage());
-        // Type should be REQUIRED
-        assertEquals(RMObjectValidationMessageType.CARDINALITY_MISMATCH, validationMessages.get(1).getType());
+        assertEquals("There should be 1 error", 1, validationMessages.size());
+        assertEquals("Attribute does not match cardinality 1..2", validationMessages.get(0).getMessage());
+        assertEquals("The path should be correct", "/feeder_audit/originating_system_audit/other_details[id1]/items", validationMessages.get(0).getPath());
+        assertEquals(RMObjectValidationMessageType.CARDINALITY_MISMATCH, validationMessages.get(0).getType());
     }
 
     private OperationalTemplate createOpt(Archetype archetype) {

--- a/tools/src/test/java/com/nedap/archie/rmobjectvalidator/ValidateArchetypedTest.java
+++ b/tools/src/test/java/com/nedap/archie/rmobjectvalidator/ValidateArchetypedTest.java
@@ -1,0 +1,99 @@
+package com.nedap.archie.rmobjectvalidator;
+
+import com.nedap.archie.adlparser.ADLParseException;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.OperationalTemplate;
+import com.nedap.archie.flattener.Flattener;
+import com.nedap.archie.flattener.FlattenerConfiguration;
+import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
+import com.nedap.archie.rm.archetyped.Archetyped;
+import com.nedap.archie.rm.archetyped.FeederAudit;
+import com.nedap.archie.rm.archetyped.FeederAuditDetails;
+import com.nedap.archie.rm.datastructures.Element;
+import com.nedap.archie.rm.datastructures.Item;
+import com.nedap.archie.rm.datastructures.ItemTree;
+import com.nedap.archie.rm.datavalues.quantity.DvProportion;
+import com.nedap.archie.rm.support.identification.ArchetypeID;
+import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.testutil.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ValidateArchetypedTest {
+
+    private TestUtil testUtil;
+    private InMemoryFullArchetypeRepository repo;
+    private RMObjectValidator validator;
+
+    private Archetype elementArchetype;
+    private OperationalTemplate elementOpt;
+    private Archetype itemTreeArchetype;
+
+    @Before
+    public void setup() throws Exception {
+        testUtil = new TestUtil();
+
+        repo = new InMemoryFullArchetypeRepository();
+        validator = new RMObjectValidator(ArchieRMInfoLookup.getInstance(), repo);
+
+        elementArchetype = parse("/adl2-tests/rmobjectvalidity/openEHR-EHR-ELEMENT.element_with_required_attributes.v1.0.0.adls");
+        elementOpt = createOpt(elementArchetype);
+
+        repo.addArchetype(elementArchetype);
+        repo.setOperationalTemplate(elementOpt);
+
+        itemTreeArchetype = parse("/adl2-tests/rmobjectvalidity/openEHR-EHR-ITEM_TREE.cardinality_testing.v1.0.0.adls");
+        OperationalTemplate itemTreeOpt = createOpt(itemTreeArchetype);
+
+        repo.addArchetype(itemTreeArchetype);
+        repo.setOperationalTemplate(itemTreeOpt);
+    }
+
+    @Test
+    public void testArchetypedOtherDetails() {
+        Element element = (Element) testUtil.constructEmptyRMObject(elementArchetype.getDefinition());
+        DvProportion dvProportion = (DvProportion) element.getValue();
+        dvProportion.setDenominator(4D);
+        dvProportion.setType(3L);
+
+        ItemTree itemTree = (ItemTree) testUtil.constructEmptyRMObject(itemTreeArchetype.getDefinition());
+        List<Item> items = itemTree.getItems();
+        items.clear();
+
+        Archetyped details = new Archetyped();
+        details.setArchetypeId(new ArchetypeID(itemTreeArchetype.getArchetypeId().toString()));
+        details.setRmVersion(ArchieRMInfoLookup.RM_VERSION);
+        itemTree.setArchetypeDetails(details);
+
+        FeederAudit feederAudit = new FeederAudit();
+        FeederAuditDetails feederAuditDetails = new FeederAuditDetails("archie");
+        feederAuditDetails.setOtherDetails(itemTree);
+        feederAudit.setOriginatingSystemAudit(feederAuditDetails);
+        element.setFeederAudit(feederAudit);
+
+        validator.setRunInvariantChecks(false);
+        List<RMObjectValidationMessage> validationMessages = validator.validate(elementOpt, element);
+        assertEquals("There should be 2 errors", 2, validationMessages.size());
+        assertEquals("There should be a validation message about the numerator", "Attribute numerator of class DV_PROPORTION does not match existence 1..1", validationMessages.get(0).getMessage());
+        assertEquals("The path should be correct", "/value/numerator", validationMessages.get(0).getPath());
+        assertEquals("The archetype path should be correct", "/value[id2]/numerator", validationMessages.get(0).getArchetypePath());
+
+        assertEquals("Attribute does not match cardinality 1..2", validationMessages.get(1).getMessage());
+        // Type should be REQUIRED
+        assertEquals(RMObjectValidationMessageType.CARDINALITY_MISMATCH, validationMessages.get(1).getType());
+    }
+
+    private OperationalTemplate createOpt(Archetype archetype) {
+        return (OperationalTemplate) new Flattener(repo, BuiltinReferenceModels.getMetaModels(), FlattenerConfiguration.forOperationalTemplate()).flatten(archetype);
+    }
+
+    private Archetype parse(String filename) throws IOException, ADLParseException {
+        return TestUtil.parseFailOnErrors(filename);
+    }
+}

--- a/tools/src/test/java/com/nedap/archie/rmobjectvalidator/invariants/InvariantTestUtil.java
+++ b/tools/src/test/java/com/nedap/archie/rmobjectvalidator/invariants/InvariantTestUtil.java
@@ -1,5 +1,6 @@
 package com.nedap.archie.rmobjectvalidator.invariants;
 
+import com.nedap.archie.flattener.OperationalTemplateProvider;
 import com.nedap.archie.rm.archetyped.Archetyped;
 import com.nedap.archie.rm.archetyped.Locatable;
 import com.nedap.archie.rm.composition.Entry;
@@ -12,6 +13,7 @@ import com.nedap.archie.rm.support.identification.TerminologyId;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rmobjectvalidator.RMObjectValidationMessage;
 import com.nedap.archie.rmobjectvalidator.RMObjectValidator;
+import com.nedap.archie.testutil.DummyOperationalTemplateProvider;
 
 import java.util.List;
 
@@ -19,9 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class InvariantTestUtil {
+    private static final OperationalTemplateProvider optProvider = new DummyOperationalTemplateProvider("example");
 
     public static void assertValid(Object object) {
-        RMObjectValidator validator = new RMObjectValidator(ArchieRMInfoLookup.getInstance(), (templateId) -> null);
+        RMObjectValidator validator = new RMObjectValidator(ArchieRMInfoLookup.getInstance(), optProvider);
         List<RMObjectValidationMessage> messages = validator.validate(object);
         assertTrue("object should be valid, was not: " + messages, messages.isEmpty());
     }
@@ -31,7 +34,7 @@ public class InvariantTestUtil {
     }
 
     public static void assertInvariantInvalid(Object object, String invariantName, String rmTypeName, String path) {
-        RMObjectValidator validator = new RMObjectValidator(ArchieRMInfoLookup.getInstance(), (templateId) -> null);
+        RMObjectValidator validator = new RMObjectValidator(ArchieRMInfoLookup.getInstance(), optProvider);
         List<RMObjectValidationMessage> messages = validator.validate(object);
         assertEquals(messages.toString(), 1, messages.size());
         assertEquals("Invariant " + invariantName + " failed on type " + rmTypeName, messages.get(0).getMessage());


### PR DESCRIPTION
Add support for validating archetyped objects which are not part of the provided operational template.

This can be used for example in [FEEDER_AUDIT_DETAILS](https://specifications.openehr.org/releases/RM/latest/common.html#_feeder_audit_details_class).other_details to make that field archetyped. 

Example structure:
```json
{
  "feeder_audit": {
    "originating_system_audit": {
      "system_id": "archie",
      "other_details": {
        "_type": "ITEM_TREE",
        "archetype_details": {
          "archetype_id": {
            "value": "openEHR-EHR-ITEM_TREE.feeder_audit_other_details.v1.0.0"
          },
          "rm_version": "1.1.0"
        },
        "archetype_node_id": "id1",
        "name": {
          "_type": "DV_TEXT",
          "value": "Feeder Audit Other Details",
          "mappings": []
        }
      }
    }
  }
}
```

The validator will look up the operational template for the mentioned archetype id in the provided OperationalTemplateProvider similar to how ArchetypeSlots are currently validated. This will only be done when the object doesn't match a CObject from the provided operational template.
