### PR TITLE
Issue: ReflectionModelInfoLookup sometimes adds a method from a superclass instead of a subclass to the RM model metadata

### DIFF
--- a/aom/src/main/java/com/nedap/archie/rminfo/SpecificMethodSelector.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/SpecificMethodSelector.java
@@ -18,30 +18,14 @@ class SpecificMethodSelector implements BinaryOperator<Method> {
         Class<?> returnType1 = method1.getReturnType();
         Class<?> returnType2 = method2.getReturnType();
 
-        if (class1 == class2) {
-            return mostSpecificReturnType(method1, method2);
+        if (class1 == class2 && returnType1 == returnType2) {
+            throw new IllegalArgumentException("Similar methods " + method1.toGenericString() + " and " + method2.toGenericString());
         } else if (class1.isAssignableFrom(class2) && returnType1.isAssignableFrom(returnType2)) {
             return method2;
         } else if (class2.isAssignableFrom(class1) && returnType2.isAssignableFrom(returnType1)) {
             return method1;
         } else {
             // Methods are incompatible
-            throw new IllegalArgumentException("Incompatible methods " + method1.toGenericString() + " and " + method2.toGenericString());
-        }
-    }
-
-    private Method mostSpecificReturnType(Method method1, Method method2) {
-        Class<?> returnType1 = method1.getReturnType();
-        Class<?> returnType2 = method2.getReturnType();
-
-        if(returnType1 == returnType2) {
-            throw new IllegalArgumentException("Similar methods " + method1.toGenericString() + " and " + method2.toGenericString());
-        } else if (returnType1.isAssignableFrom(returnType2)) {
-            return method2;
-        } else if (returnType2.isAssignableFrom(returnType1)) {
-            return method1;
-        } else {
-            // Return types are incompatible
             throw new IllegalArgumentException("Incompatible methods " + method1.toGenericString() + " and " + method2.toGenericString());
         }
     }

--- a/aom/src/main/java/com/nedap/archie/rminfo/SpecificMethodSelector.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/SpecificMethodSelector.java
@@ -1,0 +1,48 @@
+package com.nedap.archie.rminfo;
+
+import java.lang.reflect.Method;
+import java.util.function.BinaryOperator;
+
+/**
+ * Selector which returns the most specific method of two methods.
+ *
+ * This will return the method with the most specific declaring class and return type.
+ *
+ * This will throw a IllegalArgumentException if the methods are incompatible or similar.
+ */
+class SpecificMethodSelector implements BinaryOperator<Method> {
+    public Method apply(Method method1, Method method2) {
+        Class<?> class1 = method1.getDeclaringClass();
+        Class<?> class2 = method2.getDeclaringClass();
+
+        Class<?> returnType1 = method1.getReturnType();
+        Class<?> returnType2 = method2.getReturnType();
+
+        if (class1 == class2) {
+            return mostSpecificReturnType(method1, method2);
+        } else if (class1.isAssignableFrom(class2) && returnType1.isAssignableFrom(returnType2)) {
+            return method2;
+        } else if (class2.isAssignableFrom(class1) && returnType2.isAssignableFrom(returnType1)) {
+            return method1;
+        } else {
+            // Methods are incompatible
+            throw new IllegalArgumentException("Incompatible methods " + method1.toGenericString() + " and " + method2.toGenericString());
+        }
+    }
+
+    private Method mostSpecificReturnType(Method method1, Method method2) {
+        Class<?> returnType1 = method1.getReturnType();
+        Class<?> returnType2 = method2.getReturnType();
+
+        if(returnType1 == returnType2) {
+            throw new IllegalArgumentException("Similar methods " + method1.toGenericString() + " and " + method2.toGenericString());
+        } else if (returnType1.isAssignableFrom(returnType2)) {
+            return method2;
+        } else if (returnType2.isAssignableFrom(returnType1)) {
+            return method1;
+        } else {
+            // Return types are incompatible
+            throw new IllegalArgumentException("Incompatible methods " + method1.toGenericString() + " and " + method2.toGenericString());
+        }
+    }
+}

--- a/aom/src/main/java/com/nedap/archie/rminfo/SpecificMethodSelector.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/SpecificMethodSelector.java
@@ -8,7 +8,7 @@ import java.util.function.BinaryOperator;
  *
  * This will return the method with the most specific declaring class and return type.
  *
- * This will throw a IllegalArgumentException if the methods are incompatible or similar.
+ * This will throw an IllegalArgumentException if the methods are incompatible or similar.
  */
 class SpecificMethodSelector implements BinaryOperator<Method> {
     public Method apply(Method method1, Method method2) {

--- a/aom/src/test/java/com/nedap/archie/rminfo/SpecificMethodSelectorTest.java
+++ b/aom/src/test/java/com/nedap/archie/rminfo/SpecificMethodSelectorTest.java
@@ -16,12 +16,15 @@ public class SpecificMethodSelectorTest {
     }
 
     private static class B extends A {
+        @Override
         A getA() { return null; }
+        @Override
         B getB() { return null; }
         C getC() { return null; }
     }
 
     private static class C extends A {
+        @Override
         A getA() { return null; }
     }
 
@@ -50,8 +53,11 @@ public class SpecificMethodSelectorTest {
 
         SpecificMethodSelector selector = new SpecificMethodSelector();
 
-        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetA, methodAgetA));
-        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetA, methodAgetAnotherA));
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetA, methodAgetA));
+        assertEquals("Similar methods com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$A.getA() and com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$A.getA()", exception.getMessage());
+
+        exception = assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetA, methodAgetAnotherA));
+        assertEquals("Similar methods com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$A.getA() and com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$A.getAnotherA()", exception.getMessage());
     }
 
     @Test
@@ -61,7 +67,8 @@ public class SpecificMethodSelectorTest {
 
         SpecificMethodSelector selector = new SpecificMethodSelector();
 
-        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetA, methodCgetA));
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetA, methodCgetA));
+        assertEquals("Incompatible methods com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$B.getA() and com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$C.getA()", exception.getMessage());
     }
 
     @Test
@@ -71,7 +78,8 @@ public class SpecificMethodSelectorTest {
 
         SpecificMethodSelector selector = new SpecificMethodSelector();
 
-        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetB, methodBgetC));
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetB, methodBgetC));
+        assertEquals("Incompatible methods com.nedap.archie.rminfo.SpecificMethodSelectorTest$B com.nedap.archie.rminfo.SpecificMethodSelectorTest$B.getB() and com.nedap.archie.rminfo.SpecificMethodSelectorTest$C com.nedap.archie.rminfo.SpecificMethodSelectorTest$B.getC()", exception.getMessage());
     }
 
     @Test
@@ -81,7 +89,10 @@ public class SpecificMethodSelectorTest {
 
         SpecificMethodSelector selector = new SpecificMethodSelector();
 
-        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetB, methodBgetA));
-        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetA, methodAgetB));
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetB, methodBgetA));
+        assertEquals("Incompatible methods com.nedap.archie.rminfo.SpecificMethodSelectorTest$B com.nedap.archie.rminfo.SpecificMethodSelectorTest$A.getB() and com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$B.getA()", exception.getMessage());
+
+        exception = assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetA, methodAgetB));
+        assertEquals("Incompatible methods com.nedap.archie.rminfo.SpecificMethodSelectorTest$A com.nedap.archie.rminfo.SpecificMethodSelectorTest$B.getA() and com.nedap.archie.rminfo.SpecificMethodSelectorTest$B com.nedap.archie.rminfo.SpecificMethodSelectorTest$A.getB()", exception.getMessage());
     }
 }

--- a/aom/src/test/java/com/nedap/archie/rminfo/SpecificMethodSelectorTest.java
+++ b/aom/src/test/java/com/nedap/archie/rminfo/SpecificMethodSelectorTest.java
@@ -1,0 +1,87 @@
+package com.nedap.archie.rminfo;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class SpecificMethodSelectorTest {
+
+    private static class A {
+        A getA() { return null; }
+        A getAnotherA() { return null; }
+        B getB() { return null; }
+    }
+
+    private static class B extends A {
+        A getA() { return null; }
+        B getB() { return null; }
+        C getC() { return null; }
+    }
+
+    private static class C extends A {
+        A getA() { return null; }
+    }
+
+    @Test
+    public void testCorrect() throws NoSuchMethodException {
+        Method methodAgetA = A.class.getDeclaredMethod("getA");
+        Method methodBgetA = B.class.getDeclaredMethod("getA");
+        Method methodBgetB = B.class.getDeclaredMethod("getB");
+
+        SpecificMethodSelector selector = new SpecificMethodSelector();
+
+        assertEquals(methodBgetA, selector.apply(methodAgetA, methodBgetA));
+        assertEquals(methodBgetA, selector.apply(methodBgetA, methodAgetA));
+
+        assertEquals(methodBgetB, selector.apply(methodBgetA, methodBgetB));
+        assertEquals(methodBgetB, selector.apply(methodBgetB, methodBgetA));
+
+        assertEquals(methodBgetB, selector.apply(methodAgetA, methodBgetB));
+        assertEquals(methodBgetB, selector.apply(methodBgetB, methodAgetA));
+    }
+
+    @Test
+    public void testSameMethod() throws NoSuchMethodException {
+        Method methodAgetA = A.class.getDeclaredMethod("getA");
+        Method methodAgetAnotherA = A.class.getDeclaredMethod("getAnotherA");
+
+        SpecificMethodSelector selector = new SpecificMethodSelector();
+
+        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetA, methodAgetA));
+        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetA, methodAgetAnotherA));
+    }
+
+    @Test
+    public void testIncompatibleDeclaringClass() throws NoSuchMethodException {
+        Method methodBgetA = B.class.getDeclaredMethod("getA");
+        Method methodCgetA = C.class.getDeclaredMethod("getA");
+
+        SpecificMethodSelector selector = new SpecificMethodSelector();
+
+        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetA, methodCgetA));
+    }
+
+    @Test
+    public void testIncompatibleReturnType() throws NoSuchMethodException {
+        Method methodBgetB = B.class.getDeclaredMethod("getB");
+        Method methodBgetC = B.class.getDeclaredMethod("getC");
+
+        SpecificMethodSelector selector = new SpecificMethodSelector();
+
+        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetB, methodBgetC));
+    }
+
+    @Test
+    public void testMixedSpecific() throws NoSuchMethodException {
+        Method methodAgetB = A.class.getDeclaredMethod("getB");
+        Method methodBgetA = B.class.getDeclaredMethod("getA");
+
+        SpecificMethodSelector selector = new SpecificMethodSelector();
+
+        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodAgetB, methodBgetA));
+        assertThrows(IllegalArgumentException.class, () -> selector.apply(methodBgetA, methodAgetB));
+    }
+}

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/ImportedVersion.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/ImportedVersion.java
@@ -5,6 +5,7 @@ import com.nedap.archie.rm.generic.AuditDetails;
 import com.nedap.archie.rm.support.identification.ObjectId;
 import com.nedap.archie.rm.support.identification.ObjectRef;
 import com.nedap.archie.rm.support.identification.ObjectVersionId;
+import com.nedap.archie.rminfo.RMProperty;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlType;
@@ -52,6 +53,7 @@ public class ImportedVersion<T> extends Version<T> {
     }
 
     @Override
+    @RMProperty("is_branch")
     public boolean isBranch() {
         return item == null ? null : item.isBranch();//TODO: this is probably not right
     }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDate.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDate.java
@@ -8,6 +8,8 @@ import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.SingleValuedDataValue;
 import com.nedap.archie.rm.datavalues.quantity.DvInterval;
 import com.nedap.archie.rm.datavalues.quantity.ReferenceRange;
+import com.nedap.archie.rminfo.PropertyType;
+import com.nedap.archie.rminfo.RMProperty;
 import com.nedap.archie.xml.adapters.DateXmlAdapter;
 
 import javax.annotation.Nullable;
@@ -97,6 +99,7 @@ public class DvDate extends DvTemporal<DvDate, Long> implements SingleValuedData
     @Override
     @JsonIgnore
     @XmlTransient
+    @RMProperty(value = "magnitude", computed = PropertyType.COMPUTED)
     public Long getMagnitude() {
         return value == null ? null : (long) LocalDate.from(value).toEpochDay() + DAYS_BETWEEN_0001_AND_1970;
     }

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
@@ -10,6 +10,8 @@ import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.SingleValuedDataValue;
 import com.nedap.archie.rm.datavalues.quantity.DvInterval;
 import com.nedap.archie.rm.datavalues.quantity.ReferenceRange;
+import com.nedap.archie.rminfo.PropertyType;
+import com.nedap.archie.rminfo.RMProperty;
 import com.nedap.archie.xml.adapters.DateTimeXmlAdapter;
 
 import javax.annotation.Nullable;
@@ -82,6 +84,7 @@ public class DvDateTime extends DvTemporal<DvDateTime, Long> implements SingleVa
 	@Override
 	@XmlTransient
 	@JsonIgnore
+	@RMProperty(value = "magnitude", computed = PropertyType.COMPUTED)
 	public Long getMagnitude() {
 		if (value == null) {
 			return null;

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
@@ -8,6 +8,8 @@ import com.nedap.archie.rm.datatypes.CodePhrase;
 import com.nedap.archie.rm.datavalues.SingleValuedDataValue;
 import com.nedap.archie.rm.datavalues.quantity.DvInterval;
 import com.nedap.archie.rm.datavalues.quantity.ReferenceRange;
+import com.nedap.archie.rminfo.PropertyType;
+import com.nedap.archie.rminfo.RMProperty;
 import com.nedap.archie.xml.adapters.TimeXmlAdapter;
 
 import javax.annotation.Nullable;
@@ -79,6 +81,7 @@ public class DvTime extends DvTemporal<DvTime, Double> implements SingleValuedDa
     @Override
     @JsonIgnore
     @XmlTransient
+    @RMProperty(value = "magnitude", computed = PropertyType.COMPUTED)
     public Double getMagnitude() {
         return value == null ? null : (double) LocalTime.from(value).toSecondOfDay();
     }

--- a/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
+++ b/referencemodels/src/test/java/org/openehr/referencemodels/RMComparedWithBmmTest.java
@@ -126,7 +126,6 @@ public class RMComparedWithBmmTest {
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "IMPORTED_VERSION", "lifecycle_state"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "IMPORTED_VERSION", "data"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "IMPORTED_VERSION", "preceding_version_uid"));
-        knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "IMPORTED_VERSION", "branch"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "IMPORTED_VERSION", "canonical_form"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "extension"));
         knownDifferences.add(new ModelDifference(ModelDifferenceType.PROPERTY_MISSING_IN_BMM, "", "OBJECT_VERSION_ID", "root"));


### PR DESCRIPTION
## Problem

The ReflectionModelInfoLookup uses reflection (with the reflections library) to get information from fields and methods. For methods, it uses the first get-method of a given name to determine the property information.

However, the reflection library can return multiple get-methods with the same name in case of inheritance, e.g. for DvDate both [DvDate.getMagnitude](https://github.com/openEHR/archie/blob/339f4b671840e65cb32e12a48cf20007e9d348ee/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDate.java#L97-L102) and [DvQuantified.getMagnitude](https://github.com/openEHR/archie/blob/339f4b671840e65cb32e12a48cf20007e9d348ee/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantified.java#L59). The first of these methods returned by `ReflectionUtils.getAllMethods` will be used for the information in the ReflectionModelInfoLookup.

With the pending update of the reflections library from 0.9 to 0.10 the return other of that method is apparently changed, causing the information in the ReflectionModelInfoLookup to be changed.

### Affected classes
The ArchieAOMInfoLookup doesn't seem to be affected.

In the ArchieRMInfoLookup the following information is affected (as far as I have seen):
* The `computed`, `getMethod` and `setMethod` of the `magnitude` property of DV_DATE, DV_DATE_TIME and DV_TIME.
* The `getMethod`, `type` and `typeInCollection` of the `magnitude` property of DV_PROPORTION.
* The `getMethod` of the `is_branch`, `lifecycle_state`, `preceding_version_uid` and `uid` properties of IMPORTED_VERSION.
* IMPORTED_VERSION had both a `branch` (incorrect) and `is_branch` property because of a missing annotation on the ImportedVersion.isBranch method.
* The `getMethod` of the `is_branch` property of ORIGINAL_VERSION.

## Solution
This PR changes the ReflectionModelInfoLookup to always use the most specific method for a given name. That is, the method defined with in the most specific class (i.e. from the subclass instead of the super class) and with the most specific return type.

This will make sure always the same method is being used for providing the information in the ReflectionModelInfoLookup, independently of the return order of the `ReflectionUtils.getAllMethods` method.

### Added annotations
The `magnitude` property of DV_DATE, DV_DATE_TIME and DV_TIME has the unique situation that it is a computed property with a setter method. `@RMProperty(value = "magnitude", computed = PropertyType.COMPUTED)` annotations have been added to mark the method as computed correctly.

The `@RMProperty("is_branch")` annotation is added to the ImportedVersion.isBranch method to set the correct name of the RM property. This causes the incorrect `branch` property to be removed from the ArchieRMInfoLookup.

## Urgency
This is blocking the update of the reflections library in #363