### PR TITLE
Fix setting default occurrences in ADL 1.4 conversion

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14DefaultMultiplicitiesSetter.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14DefaultMultiplicitiesSetter.java
@@ -5,6 +5,8 @@ import com.nedap.archie.aom.CAttribute;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.base.Cardinality;
 import com.nedap.archie.base.MultiplicityInterval;
+import com.nedap.archie.rminfo.MetaModel;
+import com.nedap.archie.rminfo.MetaModels;
 
 /**
  * Sets the default occurrences, cardinality and existence with ADL 1.4 rules, if not explicitly set
@@ -13,7 +15,14 @@ import com.nedap.archie.base.MultiplicityInterval;
  */
 public class ADL14DefaultMultiplicitiesSetter {
 
+    private final MetaModels metaModels;
+
+    public ADL14DefaultMultiplicitiesSetter(MetaModels metaModels) {
+        this.metaModels = metaModels;
+    }
+
     public void setDefaults(Archetype archetype) {
+        metaModels.selectModel(archetype);
         correctItemsCardinality(archetype.getDefinition());
     }
 
@@ -30,7 +39,8 @@ public class ADL14DefaultMultiplicitiesSetter {
                 attribute.setExistence(new MultiplicityInterval(1, 1));
             }*/
             for(CObject child:attribute.getChildren()) {
-                if(child.getOccurrences() == null) {
+                if(child.getOccurrences() == null &&
+                        metaModels.isMultiple(cObject.getRmTypeName(), attribute.getRmAttributeName())) {
                     child.setOccurrences(new MultiplicityInterval(1, 1));
                 }
                 correctItemsCardinality(child);

--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14DefaultMultiplicitiesSetter.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14DefaultMultiplicitiesSetter.java
@@ -1,0 +1,41 @@
+package com.nedap.archie.adl14;
+
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CAttribute;
+import com.nedap.archie.aom.CObject;
+import com.nedap.archie.base.Cardinality;
+import com.nedap.archie.base.MultiplicityInterval;
+
+/**
+ * Sets the default occurrences, cardinality and existence with ADL 1.4 rules, if not explicitly set
+ * in a given Archetype. Useful for conversion to ADL 2, where the default values are different, and
+ * it is good to start with the correct values already present
+ */
+public class ADL14DefaultMultiplicitiesSetter {
+
+    public void setDefaults(Archetype archetype) {
+        correctItemsCardinality(archetype.getDefinition());
+    }
+
+    private void correctItemsCardinality(CObject cObject) {
+        for(CAttribute attribute:cObject.getAttributes()) {
+            // according to the specification, the following lines must be added.
+            // however, in practice this is not followed, and adding it would
+            // lead to more problems
+          /*
+           if(attribute.getCardinality() == null) {
+                attribute.setCardinality(new Cardinality(0, 1));
+            }
+            if(attribute.getExistence() == null) {
+                attribute.setExistence(new MultiplicityInterval(1, 1));
+            }*/
+            for(CObject child:attribute.getChildren()) {
+                if(child.getOccurrences() == null) {
+                    child.setOccurrences(new MultiplicityInterval(1, 1));
+                }
+                correctItemsCardinality(child);
+            }
+        }
+
+    }
+}

--- a/aom/src/main/java/com/nedap/archie/adl14/ADL14DefaultMultiplicitiesSetter.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL14DefaultMultiplicitiesSetter.java
@@ -9,9 +9,13 @@ import com.nedap.archie.rminfo.MetaModel;
 import com.nedap.archie.rminfo.MetaModels;
 
 /**
- * Sets the default occurrences, cardinality and existence with ADL 1.4 rules, if not explicitly set
- * in a given Archetype. Useful for conversion to ADL 2, where the default values are different, and
- * it is good to start with the correct values already present
+ * Sets the default occurrences with ADL 1.4 rules, if not explicitly set in a given Archetype.
+ * Useful for conversion to ADL 2, where the default values are different, and it is good to start
+ * with the correct values already present.
+ *
+ * Cardinality and existence are also specified to have a default value. However, this is not used
+ * in practice (source, several openEHR community members). Adding that to the conversion would
+ * lead to problems. So these are left out.
  */
 public class ADL14DefaultMultiplicitiesSetter {
 
@@ -23,10 +27,10 @@ public class ADL14DefaultMultiplicitiesSetter {
 
     public void setDefaults(Archetype archetype) {
         metaModels.selectModel(archetype);
-        correctItemsCardinality(archetype.getDefinition());
+        correctItemsMultiplicities(archetype.getDefinition());
     }
 
-    private void correctItemsCardinality(CObject cObject) {
+    private void correctItemsMultiplicities(CObject cObject) {
         for(CAttribute attribute:cObject.getAttributes()) {
             // according to the specification, the following lines must be added.
             // however, in practice this is not followed, and adding it would
@@ -43,7 +47,7 @@ public class ADL14DefaultMultiplicitiesSetter {
                         metaModels.isMultiple(cObject.getRmTypeName(), attribute.getRmAttributeName())) {
                     child.setOccurrences(new MultiplicityInterval(1, 1));
                 }
-                correctItemsCardinality(child);
+                correctItemsMultiplicities(child);
             }
         }
 

--- a/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
+++ b/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
@@ -124,6 +124,7 @@ public class ADL14Converter {
         new ADL14DescriptionConverter().convert(convertedArchetype);
         setCorrectVersions(convertedArchetype);
         convertHeader(convertedArchetype);
+        addDefaultOccurrencesCardinalityExistence(convertedArchetype);
 
 
         ADL2ConversionResult result = new ADL2ConversionResult(convertedArchetype);
@@ -155,6 +156,10 @@ public class ADL14Converter {
                 convertedArchetype.setBuildUid(null);
             }
         }
+    }
+
+    private void addDefaultOccurrencesCardinalityExistence(Archetype convertedArchetype) {
+        new ADL14DefaultMultiplicitiesSetter().setDefaults(convertedArchetype);
     }
 
     private void moveOidToMetadata(Archetype convertedArchetype, String oid, String oidFieldName) {

--- a/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
+++ b/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
@@ -124,7 +124,7 @@ public class ADL14Converter {
         new ADL14DescriptionConverter().convert(convertedArchetype);
         setCorrectVersions(convertedArchetype);
         convertHeader(convertedArchetype);
-        addDefaultOccurrencesCardinalityExistence(convertedArchetype);
+        addDefaultMultiplicities(convertedArchetype);
 
 
         ADL2ConversionResult result = new ADL2ConversionResult(convertedArchetype);
@@ -158,7 +158,7 @@ public class ADL14Converter {
         }
     }
 
-    private void addDefaultOccurrencesCardinalityExistence(Archetype convertedArchetype) {
+    private void addDefaultMultiplicities(Archetype convertedArchetype) {
         new ADL14DefaultMultiplicitiesSetter(metaModels).setDefaults(convertedArchetype);
     }
 

--- a/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
+++ b/tools/src/main/java/com/nedap/archie/adl14/ADL14Converter.java
@@ -159,7 +159,7 @@ public class ADL14Converter {
     }
 
     private void addDefaultOccurrencesCardinalityExistence(Archetype convertedArchetype) {
-        new ADL14DefaultMultiplicitiesSetter().setDefaults(convertedArchetype);
+        new ADL14DefaultMultiplicitiesSetter(metaModels).setDefaults(convertedArchetype);
     }
 
     private void moveOidToMetadata(Archetype convertedArchetype, String oid, String oidFieldName) {

--- a/tools/src/test/java/com/nedap/archie/adl14/ADL14DefaultOccurrencesConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/ADL14DefaultOccurrencesConversionTest.java
@@ -3,6 +3,7 @@ package com.nedap.archie.adl14;
 import com.google.common.collect.Lists;
 import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CAttribute;
 import com.nedap.archie.aom.CComplexObject;
 import com.nedap.archie.base.MultiplicityInterval;
 import com.nedap.archie.serializer.adl.ADLArchetypeSerializer;
@@ -14,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class ADL14DefaultOccurrencesConversionTest {
 
@@ -28,8 +30,17 @@ public class ADL14DefaultOccurrencesConversionTest {
             ADL2ConversionResultList result = converter.convert(Lists.newArrayList(parsed));
             System.out.println(ADLArchetypeSerializer.serialize(result.getConversionResults().get(0).getArchetype()));
             Archetype converted = result.getConversionResults().get(0).getArchetype();
+            CAttribute evaluationData = converted.itemAtPath("/data");
+            //these two should NOT be mandated if left empty in the CKM
+            assertNull(evaluationData.getCardinality());
+            assertNull(evaluationData.getExistence());
+
             CComplexObject goalName = converted.itemAtPath("/data[id2]/items[id3]");
+            //was null in ADL 1.4. Should be set to 1..1 by default during conversion
             assertEquals(new MultiplicityInterval(1, 1), goalName.getOccurrences());
+            CComplexObject goalNameValueText = converted.itemAtPath("/data[id2]/items[id3]/value[1]");
+            //was null in ADL 1.4. Because parent is single valued, this should be left null
+            assertNull(goalNameValueText.getOccurrences());
         }
     }
 }

--- a/tools/src/test/java/com/nedap/archie/adl14/ADL14DefaultOccurrencesConversionTest.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/ADL14DefaultOccurrencesConversionTest.java
@@ -1,0 +1,35 @@
+package com.nedap.archie.adl14;
+
+import com.google.common.collect.Lists;
+import com.nedap.archie.adlparser.ADLParseException;
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CComplexObject;
+import com.nedap.archie.base.MultiplicityInterval;
+import com.nedap.archie.serializer.adl.ADLArchetypeSerializer;
+import com.nedap.archie.testutil.TestUtil;
+import org.junit.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class ADL14DefaultOccurrencesConversionTest {
+
+    @Test
+    public void testDefaultOccurrencesConversion() throws Exception {
+        ADL14ConversionConfiguration conversionConfiguration = ConversionConfigForTest.getConfig();
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), conversionConfiguration);
+        //apply the first conversion and store the log. It has created an at code to bind to [openehr::124], used in a DV_QUANTITY.property
+        try (InputStream stream = getClass().getResourceAsStream("/adl14/entry/evaluation/openEHR-EHR-EVALUATION.goal.v1.adl")) {
+            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            Archetype parsed = parser.parse(stream, conversionConfiguration);
+            ADL2ConversionResultList result = converter.convert(Lists.newArrayList(parsed));
+            System.out.println(ADLArchetypeSerializer.serialize(result.getConversionResults().get(0).getArchetype()));
+            Archetype converted = result.getConversionResults().get(0).getArchetype();
+            CComplexObject goalName = converted.itemAtPath("/data[id2]/items[id3]");
+            assertEquals(new MultiplicityInterval(1, 1), goalName.getOccurrences());
+        }
+    }
+}


### PR DESCRIPTION
The Archie ADL 1.4 conversion handled a missing occurrences constraint in an ADL 1.4 archetype just as in ADL 2. That means it often will be optional.

However, in ADL 1.4 a missing occurrences constraint is actually meant to be `{1..1}`. Source: https://specifications.openehr.org/releases/AM/latest/ADL1.4.html#_occurrences . This causes some conversion errors. 

Cardinality and existence are also specified to have a default value. However, this is not used in practice (source, several openEHR community members). Adding that to the conversion would lead to problems. So these are left out in this change.