### PR TITLE
OPENEHR-954: Remove BOM from 'openehr_proc_task_planning' bmm files

### DIFF
--- a/referencemodels/src/main/resources/bmm/openEHR/components/PROC/Release-1.0.0/openehr_proc_task_planning_100.bmm
+++ b/referencemodels/src/main/resources/bmm/openEHR/components/PROC/Release-1.0.0/openehr_proc_task_planning_100.bmm
@@ -1,4 +1,4 @@
-﻿-- 
+-- 
 -- 	component:   openEHR Reference Model (RM)
 -- 	description: openEHR PROC component schema. This file format is based on the BMM specification
 --  				http://www.openehr.org/releases/BASE/latest/docs/bmm/bmm.html

--- a/referencemodels/src/main/resources/bmm/openEHR/components/PROC/Release-1.5.0/openehr_proc_task_planning_150.bmm
+++ b/referencemodels/src/main/resources/bmm/openEHR/components/PROC/Release-1.5.0/openehr_proc_task_planning_150.bmm
@@ -1,4 +1,4 @@
-﻿-- 
+-- 
 -- 	component:   openEHR Reference Model (RM)
 -- 	description: openEHR PROC component schema. This file format is based on the BMM specification
 --  				http://www.openehr.org/releases/BASE/latest/docs/bmm/bmm.html

--- a/referencemodels/src/main/resources/bmm/openEHR/components/PROC/Release-1.6.0/openehr_proc_task_planning_160.bmm
+++ b/referencemodels/src/main/resources/bmm/openEHR/components/PROC/Release-1.6.0/openehr_proc_task_planning_160.bmm
@@ -1,4 +1,4 @@
-﻿-- 
+-- 
 -- 	component:   openEHR Reference Model (RM)
 -- 	description: openEHR PROC component schema. This file format is based on the BMM specification
 --  				http://www.openehr.org/releases/BASE/latest/docs/bmm/bmm.html

--- a/referencemodels/src/main/resources/bmm/openEHR/components/PROC/latest/openehr_proc_task_planning_110.bmm
+++ b/referencemodels/src/main/resources/bmm/openEHR/components/PROC/latest/openehr_proc_task_planning_110.bmm
@@ -1,4 +1,4 @@
-﻿-- 
+-- 
 -- 	component:   openEHR Reference Model (RM)
 -- 	description: openEHR PROC component schema. This file format is based on the BMM specification
 --  				http://www.openehr.org/releases/BASE/latest/docs/bmm/bmm.html


### PR DESCRIPTION
Remove BOM from files in `referencemodels/src/main/resources/bmm/openEHR/components/PROC`.
The BOM causes `line 1:0 token recognition error at: ''` messages when parsing the affected `.bmm` files.