### PR TITLE
Revert slf4j version to 1.7.36

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
 
 
   dependencies {
-    api 'org.slf4j:slf4j-api:2.0.9'
+    api 'org.slf4j:slf4j-api:1.7.36'
 
     api "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
@@ -82,7 +82,7 @@ subprojects {
     api 'org.threeten:threeten-extra:1.7.2'
 
     testImplementation 'junit:junit:4.+'
-    testImplementation 'org.slf4j:slf4j-simple:2.0.9'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 
     api 'com.github.zafarkhaja:java-semver:0.9.0'
 


### PR DESCRIPTION
Reverts #536 and #537 because of breaking changes. Will update in another, perhaps major version.
