### PR TITLE
Bump ubuntu version in Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Java
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 blocks:
   - name: Gradle
     task:


### PR DESCRIPTION
Previously, Semaphore used Ubuntu version 18.04, which is not supported anymore:
![image](https://github.com/openEHR/archie/assets/47526389/4b88e21b-6338-46f0-a9a6-461f5848a356)

Using a newer version of Ubuntu fixes this.