### PR TITLE
Support BMM Indexed Container meta-type, enabling Hash<K,V> structures

### DIFF
--- a/bmm/src/main/java/org/openehr/bmm/core/BmmContainerType.java
+++ b/bmm/src/main/java/org/openehr/bmm/core/BmmContainerType.java
@@ -21,6 +21,8 @@ package org.openehr.bmm.core;
  * Author: Claude Nanjo
  */
 
+import org.openehr.bmm.persistence.validation.BmmDefinitions;
+
 import java.util.List;
 
 /**
@@ -36,7 +38,7 @@ public class BmmContainerType extends BmmType {
     private BmmGenericClass containerType;
 
     /**
-     *
+     * The type of the contained item
      */
     private BmmUnitaryType baseType;
 
@@ -90,7 +92,8 @@ public class BmmContainerType extends BmmType {
      */
     @Override
     public String getTypeName() {
-        return containerType.getName() + "<" + baseType.getTypeName() + ">";
+        return containerType.getName() +
+                BmmDefinitions.GENERIC_LEFT_DELIMITER + baseType.getTypeName() + BmmDefinitions.GENERIC_RIGHT_DELIMITER;
     }
 
     /**

--- a/bmm/src/main/java/org/openehr/bmm/core/BmmIndexedContainerProperty.java
+++ b/bmm/src/main/java/org/openehr/bmm/core/BmmIndexedContainerProperty.java
@@ -10,7 +10,7 @@ public class BmmIndexedContainerProperty extends BmmProperty<BmmIndexedContainer
 
     /**
      * We have to replicate cardinality here from BmmContainerProperty since we are inheriting from
-     * BmmProperty<BmmIndexedContainerType> (which creates correct typing of the 'type' property) not BmmContainerProperty
+     * BmmProperty &lt;BmmIndexedContainerType&gt; (which creates correct typing of the 'type' property) not BmmContainerProperty
      */
     private MultiplicityInterval cardinality;
 

--- a/bmm/src/main/java/org/openehr/bmm/core/BmmIndexedContainerProperty.java
+++ b/bmm/src/main/java/org/openehr/bmm/core/BmmIndexedContainerProperty.java
@@ -1,0 +1,28 @@
+package org.openehr.bmm.core;
+
+import com.nedap.archie.base.MultiplicityInterval;
+
+/**
+ * Subtype of BMM_CONTAINER_PROPERTY that represents an indexed container type based on one of the inbuilt types
+ * Hash &lt;&gt;.
+ */
+public class BmmIndexedContainerProperty extends BmmProperty<BmmIndexedContainerType> {
+
+    /**
+     * We have to replicate cardinality here from BmmContainerProperty since we are inheriting from
+     * BmmProperty<BmmIndexedContainerType> (which creates correct typing of the 'type' property) not BmmContainerProperty
+     */
+    private MultiplicityInterval cardinality;
+
+    public BmmIndexedContainerProperty (String aName, BmmIndexedContainerType aType, String aDocumentation, boolean isMandatoryFlag, boolean isComputedFlag) {
+        super(aName, aType, aDocumentation, isMandatoryFlag, isComputedFlag);
+        cardinality = MultiplicityInterval.createOpen();
+    }
+
+    public MultiplicityInterval getCardinality() {
+        return cardinality;
+    }
+    public void setCardinality(MultiplicityInterval cardinality) {
+        this.cardinality = cardinality;
+    }
+}

--- a/bmm/src/main/java/org/openehr/bmm/core/BmmIndexedContainerType.java
+++ b/bmm/src/main/java/org/openehr/bmm/core/BmmIndexedContainerType.java
@@ -1,0 +1,26 @@
+package org.openehr.bmm.core;
+
+import org.openehr.bmm.persistence.validation.BmmDefinitions;
+
+public class BmmIndexedContainerType extends BmmContainerType {
+
+    /**
+     * The type of the index
+     */
+    private BmmSimpleType indexType;
+    public BmmIndexedContainerType (BmmUnitaryType aBaseType, BmmSimpleType anIndexType, BmmGenericClass aContainerClass) {
+        super (aBaseType, aContainerClass);
+        indexType = anIndexType;
+    }
+    public BmmSimpleType getIndexType() { return indexType; }
+
+    @Override
+    public String getTypeName() {
+        return getContainerType().getName() +
+                BmmDefinitions.GENERIC_LEFT_DELIMITER +
+                indexType.getTypeName() + BmmDefinitions.GENERIC_SEPARATOR +
+                getBaseType().getTypeName() +
+                BmmDefinitions.GENERIC_RIGHT_DELIMITER;
+    }
+
+}

--- a/bmm/src/main/java/org/openehr/bmm/v2/persistence/PBmmIndexedContainerProperty.java
+++ b/bmm/src/main/java/org/openehr/bmm/v2/persistence/PBmmIndexedContainerProperty.java
@@ -1,0 +1,41 @@
+package org.openehr.bmm.v2.persistence;
+
+import com.nedap.archie.base.Interval;
+import com.nedap.archie.base.MultiplicityInterval;
+import org.openehr.bmm.core.*;
+import org.openehr.bmm.v2.validation.converters.BmmClassProcessor;
+
+public class PBmmIndexedContainerProperty extends PBmmProperty<PBmmIndexedContainerType> {
+
+    /**
+     * We have to replicate cardinality here from PBmmContainerProperty since we are inheriting from
+     * PBmmProperty<PBmmIndexedContainerType> (which creates correct typing of typeDef) not PBmmContainerProperty
+     */
+    private Interval<Integer> cardinality;
+
+    public Interval<Integer> getCardinality() {
+        return cardinality;
+    }
+    public void setCardinality(Interval<Integer> cardinality) {
+        this.cardinality = cardinality;
+    }
+    public PBmmIndexedContainerProperty() {
+        super();
+    }
+    @Override
+    public BmmIndexedContainerProperty createBmmProperty(BmmClassProcessor classProcessor, BmmClass bmmClass) {
+        PBmmIndexedContainerType typeRef = getTypeRef();
+        if (typeRef != null) {
+            BmmIndexedContainerType bmmType = (BmmIndexedContainerType) typeRef.createBmmType(classProcessor, bmmClass);
+            BmmIndexedContainerProperty bmmProperty = new BmmIndexedContainerProperty(getName(), bmmType, getDocumentation(), nullToFalse(isMandatory()), nullToFalse(isComputed()));
+            if (getCardinality() != null) {
+                bmmProperty.setCardinality(new MultiplicityInterval(getCardinality()));
+            }
+            populateImBooleans(bmmProperty);
+            return bmmProperty;
+        }
+        throw new RuntimeException("BmmTypeCreate failed for type " + typeRef + " of property "
+                + getName() + " in class " + bmmClass.getName());
+    }
+
+}

--- a/bmm/src/main/java/org/openehr/bmm/v2/persistence/PBmmIndexedContainerType.java
+++ b/bmm/src/main/java/org/openehr/bmm/v2/persistence/PBmmIndexedContainerType.java
@@ -1,0 +1,57 @@
+package org.openehr.bmm.v2.persistence;
+
+import org.openehr.bmm.core.*;
+import org.openehr.bmm.persistence.validation.BmmDefinitions;
+import org.openehr.bmm.v2.validation.converters.BmmClassProcessor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PBmmIndexedContainerType extends PBmmContainerType {
+
+    private String indexType;
+
+    public String getIndexType() {
+        return indexType;
+    }
+
+    public void setIndexType(String indexType) {
+        this.indexType = indexType;
+    }
+
+    @Override
+    public BmmIndexedContainerType createBmmType(BmmClassProcessor processor, BmmClass classDefinition) {
+        BmmClass containerClassDef = processor.getClassDefinition (getContainerType());
+        BmmClass indexClassDef = processor.getClassDefinition (indexType);
+        PBmmUnitaryType containedType = getTypeRef(); //get the actual typeref for conversion
+        if (containerClassDef instanceof BmmGenericClass &&
+                indexClassDef instanceof BmmSimpleClass &&
+                containedType != null)
+        {
+            BmmType containedBmmType = containedType.createBmmType(processor, classDefinition);
+            if (containedBmmType instanceof BmmUnitaryType) {
+                return new BmmIndexedContainerType((BmmUnitaryType) containedBmmType,
+                        ((BmmSimpleClass) indexClassDef).getType(),
+                        (BmmGenericClass) containerClassDef);
+            }
+        }
+
+        throw new RuntimeException("BmmClass " + containerClassDef.getName() + " is not defined in this model or not an indexed container type");
+    }
+    @Override
+    public String asTypeString() {
+        return getContainerType() + BmmDefinitions.GENERIC_LEFT_DELIMITER +
+                indexType + BmmDefinitions.GENERIC_SEPARATOR + getTypeRef().asTypeString() +
+                BmmDefinitions.GENERIC_RIGHT_DELIMITER;
+    }
+    @Override
+    public List<String> flattenedTypeList() {
+        List<String> result = new ArrayList<>();
+        result.add(getContainerType());
+        result.add(indexType);
+        if (getTypeRef() != null) {
+            result.addAll(getTypeRef().flattenedTypeList());
+        }
+        return result;
+    }
+}

--- a/bmm/src/main/java/org/openehr/bmm/v2/persistence/jackson/BmmTypeNaming.java
+++ b/bmm/src/main/java/org/openehr/bmm/v2/persistence/jackson/BmmTypeNaming.java
@@ -25,6 +25,7 @@ public class BmmTypeNaming extends ClassNameIdResolver {
         put("BMM_INCLUDE_SPEC", BmmIncludeSpec.class).
         put("P_BMM_CLASS", PBmmClass.class).
         put("P_BMM_CONTAINER_PROPERTY", PBmmContainerProperty.class).
+            put("P_BMM_INDEXED_CONTAINER_PROPERTY", PBmmIndexedContainerProperty.class).
         put("P_BMM_ENUMERATION", PBmmEnumeration.class).
         put("P_BMM_ENUMERATION_STRING", PBmmEnumerationString.class).
         put("P_BMM_ENUMERATION_INTEGER", PBmmEnumerationInteger.class).
@@ -33,6 +34,7 @@ public class BmmTypeNaming extends ClassNameIdResolver {
         put("P_BMM_GENERIC_TYPE", PBmmGenericType.class).
         put("P_BMM_OPEN_TYPE", PBmmOpenType.class).
         put("P_BMM_CONTAINER_TYPE", PBmmContainerType.class).
+            put("P_BMM_INDEXED_CONTAINER_TYPE", PBmmIndexedContainerType.class).
         put("P_BMM_PACKAGE", PBmmPackage.class).
         put("P_BMM_PROPERTY", PBmmProperty.class).
         put("P_BMM_SCHEMA", PBmmSchema.class).

--- a/bmm/src/test/java/org/openehr/bmm/v2/persistence/converters/BmmParseRoundtripTest.java
+++ b/bmm/src/test/java/org/openehr/bmm/v2/persistence/converters/BmmParseRoundtripTest.java
@@ -32,6 +32,7 @@ public class BmmParseRoundtripTest {
         parseRoundTrip("/openehr/openehr_primitive_types_102.bmm");
         parseRoundTrip("/openehr/openehr_rm_102.bmm");
         parseRoundTrip("/openehr/openehr_structures_102.bmm");
+        parseRoundTrip("/openehr/openehr_base_110.bmm");
     }
 
     public void parseRoundTrip(String name) throws Exception {

--- a/bmm/src/test/resources/openehr/openehr_base_110.bmm
+++ b/bmm/src/test/resources/openehr/openehr_base_110.bmm
@@ -590,27 +590,28 @@ class_definitions = <
 		properties = <
 			["original_language"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"original_language">
-				type_ref = <
-					type = <"Terminology_code">
-					value_constraint = <"openEHR::languages">
-				>
+				type = <"Terminology_code">
 				is_mandatory = <True>
 			>
 			["is_controlled"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"is_controlled">
 				type = <"Boolean">
 			>
-			["translations"] = (P_BMM_CONTAINER_PROPERTY) <
-				name = <"translations">
-				type_def = <
-					container_type = <"List">
-					type = <"TRANSLATION_DETAILS">
-				>
-				cardinality = <|>=1|>
-			>
+            ["translations"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                name = <"translations">
+                type_def = <
+                   container_type = <"Hash">
+                   index_type = <"String">
+                   type = <"TRANSLATION_DETAILS">
+                >
+            >
 			["description"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"description">
 				type = <"RESOURCE_DESCRIPTION">
+			>
+			["annotations"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"annotations">
+				type = <"RESOURCE_ANNOTATIONS">
 			>
 		>
 	>
@@ -621,45 +622,53 @@ class_definitions = <
 		properties = <
 			["language"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"language">
-				type_ref = <
-					type = <"Terminology_code">
-					value_constraint = <"openEHR::languages">
-				>
+				type = <"Terminology_code">
 				is_mandatory = <True>
 			>
-			["author"] = (P_BMM_GENERIC_PROPERTY) <
-				name = <"author">
-				type_def = <
-					root_type = <"Hash">
-					generic_parameters = <"String", "String">
-				>
+			["author"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                name = <"author">
+                type_def = <
+                   container_type = <"Hash">
+                   index_type = <"String">
+                   type = <"String">
+                >
 				is_mandatory = <True>
 			>
 			["accreditation"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"accreditation">
 				type = <"String">
 			>
-			["other_details"] = (P_BMM_GENERIC_PROPERTY) <
-				name = <"other_details">
-				type_def = <
-					root_type = <"Hash">
-					generic_parameters = <"String", "String">
-				>
+			["version_last_translated"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"version_last_translated">
+				type = <"String">
+			>
+			["other_details"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                 name = <"other_details">
+                 type_def = <
+                     container_type = <"Hash">
+                     index_type = <"String">
+                     type = <"String">
+                 >
 			>
 		>
 	>
 
 	["RESOURCE_DESCRIPTION"] = <
 		name = <"RESOURCE_DESCRIPTION">
-		ancestors = <"Any", ...>
+		ancestors = <"Any">
 		properties = <
-			["original_author"] = (P_BMM_GENERIC_PROPERTY) <
-				name = <"original_author">
-				type_def = <
-					root_type = <"Hash">
-					generic_parameters = <"String", "String">
-				>
+			["original_author"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                name = <"original_author">
+                type_def = <
+                    container_type = <"Hash">
+                    index_type = <"String">
+                    type = <"String">
+                >
 				is_mandatory = <True>
+			>
+			["original_namespace"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"original_namespace">
+				type = <"String">
 			>
 			["other_contributors"] = (P_BMM_CONTAINER_PROPERTY) <
 				name = <"other_contributors">
@@ -668,6 +677,22 @@ class_definitions = <
 					type = <"String">
 				>
 				cardinality = <|>=0|>
+			>
+			["custodian_namespace"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"custodian_namespace">
+				type = <"String">
+			>
+			["custodian_organisation"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"custodian_organisation">
+				type = <"String">
+			>
+			["copyright"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"copyright">
+				type = <"String">
+			>
+			["licence"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"licence">
+				type = <"String">
 			>
 			["lifecycle_state"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"lifecycle_state">
@@ -678,26 +703,51 @@ class_definitions = <
 				name = <"resource_package_uri">
 				type = <"String">
 			>
-			["other_details"] = (P_BMM_GENERIC_PROPERTY) <
-				name = <"other_details">
-				type_def = <
-					root_type = <"Hash">
-					generic_parameters = <"String", "String">
-				>
+			["ip_acknowledgements"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                name = <"ip_acknowledgements">
+                type_def = <
+                    container_type = <"Hash">
+                    index_type = <"String">
+                    type = <"String">
+                >
+			>
+
+			["references"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                 name = <"references">
+                 type_def = <
+                     container_type = <"Hash">
+                     index_type = <"String">
+                     type = <"String">
+                 >
+			>
+			["conversion_details"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+               name = <"conversion_details">
+               type_def = <
+                   container_type = <"Hash">
+                   index_type = <"String">
+                   type = <"String">
+               >
+			>
+			["other_details"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                 name = <"other_details">
+                 type_def = <
+                     container_type = <"Hash">
+                     index_type = <"String">
+                     type = <"String">
+                 >
 			>
 			["parent_resource"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"parent_resource">
 				type = <"AUTHORED_RESOURCE">
 				is_mandatory = <True>
 			>
-			["details"] = (P_BMM_CONTAINER_PROPERTY) <
-				name = <"details">
-				type_def = <
-					container_type = <"List">
-					type = <"RESOURCE_DESCRIPTION_ITEM">
-				>
-				is_mandatory = <True>
-				cardinality = <|>=1|>
+			["details"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                name = <"details">
+                type_def = <
+                    container_type = <"Hash">
+                    index_type = <"String">
+                    type = <"RESOURCE_DESCRIPTION_ITEM">
+                >
 			>
 		>
 	>
@@ -708,10 +758,7 @@ class_definitions = <
 		properties = <
 			["language"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"language">
-				type_ref = <
-					type = <"Terminology_code">
-					value_constraint = <"openEHR::languages">
-				>
+				type = <"Terminology_code">
 				is_mandatory = <True>
 			>
 			["purpose"] = (P_BMM_SINGLE_PROPERTY) <
@@ -735,28 +782,21 @@ class_definitions = <
 				name = <"misuse">
 				type = <"String">
 			>
-			["copyright"] = (P_BMM_SINGLE_PROPERTY) <
-				name = <"copyright">
-				type = <"String">
+            ["original_resource_uri"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                name = <"original_resource_uri">
+                type_def = <
+                    container_type = <"Hash">
+                    index_type = <"String">
+                    type = <"String">
+                >
 			>
-			["original_resource_uri"] = (P_BMM_CONTAINER_PROPERTY) <
-				name = <"original_resource_uri">
-				type_def = <
-					container_type = <"List">
-					type_def = (P_BMM_GENERIC_TYPE) <
-						root_type = <"Hash">
-						generic_parameters = <"String", "String">
-					>
-				>
-				cardinality = <|>=0|>
-			>
-			["other_details"] = (P_BMM_GENERIC_PROPERTY) <
+			["other_details"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
 				name = <"other_details">
-				type_def = <
-					root_type = <"Hash">
-					generic_parameters = <"String", "String">
-				>
-				is_mandatory = <True>
+                type_def = <
+                    container_type = <"Hash">
+                    index_type = <"String">
+                    type = <"String">
+                >
 			>
 		>
 	>

--- a/bmm/src/test/resources/openehr/openehr_base_110.bmm
+++ b/bmm/src/test/resources/openehr/openehr_base_110.bmm
@@ -78,7 +78,7 @@ packages = <
 			>
 			["resource"] = <
 				name = <"resource">
-				classes = <"AUTHORED_RESOURCE", "TRANSLATION_DETAILS", "RESOURCE_DESCRIPTION", "RESOURCE_DESCRIPTION_ITEM">
+				classes = <"AUTHORED_RESOURCE", "TRANSLATION_DETAILS", "RESOURCE_DESCRIPTION", "RESOURCE_DESCRIPTION_ITEM", "RESOURCE_ANNOTATIONS">
 			>
 		>
 	>
@@ -782,14 +782,14 @@ class_definitions = <
 				name = <"misuse">
 				type = <"String">
 			>
-            ["original_resource_uri"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+            ["original_resource_uri"] = (P_BMM_GENERIC_PROPERTY) <
                 name = <"original_resource_uri">
                 type_def = <
-                    container_type = <"Hash">
-                    index_type = <"String">
-                    type = <"String">
+                    root_type = <"Hash">
+                    generic_parameters = <"String", "String">
                 >
-			>
+                is_mandatory = <True>
+            >
 			["other_details"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
 				name = <"other_details">
                 type_def = <
@@ -801,4 +801,34 @@ class_definitions = <
 		>
 	>
 
+	["RESOURCE_ANNOTATIONS"] = <
+		name = <"RESOURCE_ANNOTATIONS">
+		ancestors = <"Any">
+		properties = <
+			["documentation"] = (P_BMM_GENERIC_PROPERTY) <
+				name = <"documentation">
+				type_def = <
+					root_type = <"Hash">
+                    generic_parameter_defs = <
+                        ["K"] = (P_BMM_SIMPLE_TYPE) <
+							type = <"String">
+						>
+                        ["V"] = (P_BMM_GENERIC_TYPE) <
+                            root_type = <"Hash">
+							generic_parameter_defs = <
+								["K"] = (P_BMM_SIMPLE_TYPE) <
+									type = <"String">
+								>
+								["V"] = (P_BMM_GENERIC_TYPE) <
+									root_type = <"Hash">
+									generic_parameters = <"String", "String">
+								>
+							>
+                        >
+                    >
+				>
+				is_mandatory = <True>
+			>
+		>
+	>
 >

--- a/bmm/src/test/resources/testbmm/TestBmm1.bmm
+++ b/bmm/src/test/resources/testbmm/TestBmm1.bmm
@@ -283,6 +283,20 @@ class_definitions = <
         >
     >
 
+    ["TypeWithHashMap"] = <
+        name = <"TypeWithHashMap">
+        properties = <
+            ["employees"] = (P_BMM_INDEXED_CONTAINER_PROPERTY) <
+                name = <"employees">
+                type_def = <
+                    container_type = <"Hash">
+                    index_type = <"String">
+                    type = <"Party">
+                >
+            >
+        >
+    >
+
     ["ProportionKind"] = (P_BMM_ENUMERATION_INTEGER) <
         name = <"ProportionKind">
         ancestors = <"Integer", ...>


### PR DESCRIPTION
BmmParseRoundTrip tests pass.
This allows the properties of type Hash<K,V>, which are common in openEHR and other RMs to be correctly represented, rather than using the current generic workaround. This approach enables the type of such properties to be more naturally represented and interrogated, and the BMM files are more comprehensible. This also fills a hole in Archie's conformance to the published BMM and P_BMM specifications.
Note: only the BMM / PBMM test version of openehr_base_1.1.0 schema was changed; not the one used in the main part of Archie.