### PR TITLE
Fix Rule evaluation for ArchetypeSlots

### DIFF
--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionsFixer.java
@@ -110,7 +110,7 @@ public class AssertionsFixer {
                 Object object = parents.get(0);
 
                 Object newEmptyObject = null;
-                if (constraint instanceof CComplexObject) {
+                if (constraint instanceof CComplexObject || constraint instanceof ArchetypeSlot) {
                     newEmptyObject = rmObjectCreator.create(constraint);
                 } else {
                     newEmptyObject = constructEmptySimpleObject(newLastPathSegment, object, newEmptyObject);
@@ -160,7 +160,7 @@ public class AssertionsFixer {
                 if(!constraintsHasNoComplexObjects(((CAttribute) constraint).getChildren())) {
                     return false;
                 }
-            } else if(constraint instanceof CComplexObject) {
+            } else if(constraint instanceof CComplexObject || constraint instanceof ArchetypeSlot) {
                 return false;
             }
         }

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.rules.evaluation;
 
 import com.nedap.archie.ArchieLanguageConfiguration;
+import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
 import com.nedap.archie.creation.RMObjectCreator;
@@ -17,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openehr.referencemodels.BuiltinReferenceModels;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
@@ -188,6 +190,24 @@ public class FixableAssertionsCheckerTest {
             assertTrue(result.getResult());
         }
 
+    }
+
+    @Test
+    public void constructArchetypeSlot() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("construct_archetype_slot.adls"));
+        RuleEvaluation<Locatable> ruleEvaluation = getRuleEvaluation();
+
+        // Construct the rmObject, containing an empty ArchetypeSlot
+        Locatable root = rmObjectCreator.create(archetype.getDefinition());
+
+        // Evaluate the rmObject and its rules.
+        EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+
+        // Assert the evaluation result, it should contain the element that has to be set to a specific value.
+        assertEquals(1, evaluate.getSetPathValues().size());
+        assertEquals(
+                "/openEHR-EHR-CLUSTER\\.some_archetype_option_a.v(\\d+\\.\\d+\\.\\d+)/",
+                evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id14]/items[id19]/archetype_details/archetype_id/value").getValue());
     }
 
     private RuleEvaluation<Locatable> getRuleEvaluation() {

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/construct_archetype_slot.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/construct_archetype_slot.adls
@@ -62,10 +62,3 @@ terminology
             >
         >
     >
-
-    value_sets = <
-        ["ac1"] = <
-            id = <"ac1">
-            members = <"at1", "at14">
-        >
-    >

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/construct_archetype_slot.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/construct_archetype_slot.adls
@@ -1,0 +1,82 @@
+archetype (adl_version=2.0.5; rm_release=1.0.4)
+    openEHR-EHR-OBSERVATION.construct_archetype_slot.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Mathijs Hudepohl">
+    >
+    lifecycle_state = <"published">
+    details = <
+        ["en"] = <
+            language = <[ISO-639_1::en]>
+            purpose = <"Test for rules including an archetype slot">
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches { -- Archetype slot
+        data matches {
+            HISTORY[id2] matches {    -- Observation
+                events matches {
+                    POINT_EVENT[id3] matches {    -- Point event
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items matches {
+                                    CLUSTER[id14] occurrences matches {0..1} matches {    -- Item tree
+                                        items matches {
+                                            ELEMENT[id17] occurrences matches {0..1} matches {    -- Option selection
+                                                value matches {
+                                                    DV_CODED_TEXT[id18] matches {
+                                                        defining_code matches {[ac1]}    -- Valueset for options
+                                                    }
+                                                }
+                                            }
+                                            allow_archetype CLUSTER[id19] occurrences matches {0..1} matches {     -- Cluster
+                                                include
+                                                    archetype_id/value matches {/openEHR-EHR-CLUSTER\.some_archetype_([a-zA-Z0-9])+\.v([\d+\.\d+\.\d+])*/}
+                                                exclude
+                                                    archetype_id/value matches {/.*/}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+rules
+    /data[id2]/events[id3]/data[id4]/items[id14]/items[id19]/archetype_details/archetype_id/value matches
+        {/openEHR-EHR-CLUSTER\.some_archetype_option_a.v(\d+\.\d+\.\d+)/}
+
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["ac1"] = <
+                text = <"Value set of different available options">
+                description = <"Value set of different available options">
+            >
+            ["at1"] = <
+                text = <"Option A">
+                description = <"Option A">
+            >
+            ["at14"] = <
+                text = <"Option B">
+                description = <"option B">
+            >
+        >
+    >
+
+    value_sets = <
+        ["ac1"] = <
+            id = <"ac1">
+            members = <"at1", "at14">
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/construct_archetype_slot.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/construct_archetype_slot.adls
@@ -27,13 +27,6 @@ definition
                                 items matches {
                                     CLUSTER[id14] occurrences matches {0..1} matches {    -- Item tree
                                         items matches {
-                                            ELEMENT[id17] occurrences matches {0..1} matches {    -- Option selection
-                                                value matches {
-                                                    DV_CODED_TEXT[id18] matches {
-                                                        defining_code matches {[ac1]}    -- Valueset for options
-                                                    }
-                                                }
-                                            }
                                             allow_archetype CLUSTER[id19] occurrences matches {0..1} matches {     -- Cluster
                                                 include
                                                     archetype_id/value matches {/openEHR-EHR-CLUSTER\.some_archetype_([a-zA-Z0-9])+\.v([\d+\.\d+\.\d+])*/}
@@ -59,10 +52,6 @@ rules
 terminology
     term_definitions = <
         ["en"] = <
-            ["ac1"] = <
-                text = <"Value set of different available options">
-                description = <"Value set of different available options">
-            >
             ["at1"] = <
                 text = <"Option A">
                 description = <"Option A">


### PR DESCRIPTION
An ArchetypeSlot is not completely the same as a ComplexObject. For rule evaluation however, the same logic can be applied in order to correctly evaluate it.