### PR TITLE
Add pathsConstrainedToValueSets to the EvaluationResult

### DIFF
--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/EvaluationResult.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/EvaluationResult.java
@@ -28,7 +28,7 @@ public class EvaluationResult {
 
     public List<String> getPathsThatMustExist() {
         List<String> result = new ArrayList<>();
-        for(AssertionResult assertionResult:assertionResults) {
+        for (AssertionResult assertionResult : assertionResults) {
             result.addAll(assertionResult.getPathsThatMustExist());
         }
         return result;
@@ -36,7 +36,7 @@ public class EvaluationResult {
 
     public List<String> getPathsThatMustNotExist() {
         List<String> result = new ArrayList<>();
-        for(AssertionResult assertionResult:assertionResults) {
+        for (AssertionResult assertionResult : assertionResults) {
             result.addAll(assertionResult.getPathsThatMustNotExist());
 
         }
@@ -45,7 +45,7 @@ public class EvaluationResult {
 
     public Map<String, Value<?>> getSetPathValues() {
         Map<String, Value<?>> result = new LinkedHashMap<>();
-        for(AssertionResult assertionResult:assertionResults) {
+        for (AssertionResult assertionResult : assertionResults) {
             result.putAll(assertionResult.getSetPathValues());
         }
         return result;

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/EvaluationResult.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/EvaluationResult.java
@@ -50,4 +50,12 @@ public class EvaluationResult {
         }
         return result;
     }
+
+    public Map<String, String> getPathsConstrainedToValueSets() {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (AssertionResult assertionResult : assertionResults) {
+            result.putAll(assertionResult.getPathsConstrainedToValueSets());
+        }
+        return result;
+    }
 }

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/ParsedRulesEvaluationTest.java
@@ -736,6 +736,9 @@ public abstract class ParsedRulesEvaluationTest {
         AssertionResult assertionResult = result.getAssertionResults().get(0);
         assertTrue("The given validation rule should pass", assertionResult.getResult());
         assertEquals("ac3", assertionResult.getPathsConstrainedToValueSets().get("/items[id2, 1]/items[id2]/value/defining_code"));
+        assertEquals(2, result.getPathsConstrainedToValueSets().size());
+        assertEquals("ac3", result.getPathsConstrainedToValueSets().get("/items[id2, 1]/items[id2]/value/defining_code"));
+        assertEquals("ac3", result.getPathsConstrainedToValueSets().get("/items[id2, 1]/items[id6]/value/defining_code"));
 
         //incorrect case next
         codedText.setDefiningCode(new CodePhrase(new TerminologyId("local"), "at26"));//wrong code!

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_valueset.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/matches_valueset.adls
@@ -29,11 +29,17 @@ definition
                     DV_CODED_TEXT[id3]
                 }
             }
+            ELEMENT[id6] occurrences matches {1} matches {
+                value matches {
+                    DV_CODED_TEXT[id7]
+                }
+            }
         }
     }
 
 rules
     /items[id2]/value/defining_code matches {[ac3]}
+    /items[id6]/value/defining_code matches {[ac3]}
 
 terminology
     term_definitions = <
@@ -58,7 +64,10 @@ terminology
                  text = <"value 2">
                  description = <"value 2">
             >
-
+            ["id6"] = <
+                 text = <"element 2">
+                 description = <"element 2">
+            >
         >
     >
     value_sets = <


### PR DESCRIPTION
The 'pathsConstrainedtoValueSets' was missing from the EvaluationResult like the 'pathsThatMustNotExist' etc. are in the EvaluationResult. This is now added to the total result.