### PR TITLE
Support byte[] attributes in FlatJsonGenerator

### DIFF
--- a/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
+++ b/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
@@ -17,12 +17,7 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAmount;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -301,6 +296,8 @@ public class FlatJsonGenerator {
             } else if (child instanceof TemporalAmount) {
                 //duration or period. now just a toString, should this be a specific formatter?
                 storeValue(result, newPath, child);
+            } else if(child instanceof byte[]) {
+                storeValue(result, newPath, Base64.getEncoder().encodeToString((byte[]) child));
             } else {
                 storeValue(result, newPath, child.toString());
             }

--- a/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
@@ -1,6 +1,7 @@
 package com.nedap.archie.json.flat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.nedap.archie.ArchieLanguageConfiguration;
 import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
@@ -15,6 +16,7 @@ import com.nedap.archie.rm.composition.Observation;
 import com.nedap.archie.rm.datastructures.Cluster;
 import com.nedap.archie.rm.datastructures.Element;
 import com.nedap.archie.rm.datavalues.DvText;
+import com.nedap.archie.rm.datavalues.encapsulated.DvMultimedia;
 import com.nedap.archie.rm.datavalues.quantity.DvCount;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.MetaModels;
@@ -158,6 +160,17 @@ public class FlatJsonGeneratorTest {
         expected.put("/items[id3,4]/value/magnitude", 4L);
 
         assertEquals(expected, stringObjectMap);
+    }
+
+    @Test
+    public void serializeBytes() throws Exception {
+        DvMultimedia dvMultimedia = new DvMultimedia();
+        dvMultimedia.setData(new byte[]{42, 83, 120, -128, 127, 30, -80, 15});
+
+        FlatJsonGenerator flatJsonGenerator = new FlatJsonGenerator(ArchieRMInfoLookup.getInstance(), FlatJsonFormatConfiguration.nedapInternalFormat());
+
+        Map<String, Object> pathsAndValues = flatJsonGenerator.buildPathsAndValues(dvMultimedia);
+        assertEquals("{\"/@type\":\"DV_MULTIMEDIA\",\"/data\":\"KlN4gH8esA8=\"}", new JsonMapper().writeValueAsString(pathsAndValues));
     }
 
     @Test
@@ -307,5 +320,4 @@ public class FlatJsonGeneratorTest {
     private Map<String, Object> createExampleInstance(OperationalTemplate bloodPressureOpt, FlatJsonFormatConfiguration config) throws IOException, DuplicateKeyException {
         return new FlatJsonExampleInstanceGenerator().generateExample(bloodPressureOpt, BuiltinReferenceModels.getMetaModels(), "en", config);
     }
-
 }


### PR DESCRIPTION
fixes #597

Add check for `child instanceof byte[]` in `FlatJsonGenerator.addAttribute` and convert byte to String using Base64 encoding if so. 
