### PR TITLE
Deprecate RMObjectValidationException

### DIFF
--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationException.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationException.java
@@ -4,7 +4,10 @@ package com.nedap.archie.rmobjectvalidator;
  * Exception to indicate RM Object validation has failed
  * <p>
  * Created by pieter.bos on 01/09/15.
+ *
+ * @deprecated This exception is unused and will be removed.
  */
+@Deprecated
 public class RMObjectValidationException extends Exception {
 
     private String path;

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
@@ -43,6 +43,10 @@ public class RMObjectValidationMessage {
         this.type = type;
     }
 
+    /**
+     * @deprecated The RMObjectValidationException class will be removed.
+     */
+    @Deprecated
     public RMObjectValidationMessage(RMObjectValidationException e) {
         this.path = e.getPath();
         this.humanReadableArchetypePath = e.getHumanPath();


### PR DESCRIPTION
Deprecate RMObjectValidationException. The RMObjectValidationException class is unused and will be removed.