### PR TITLE
Don't add SiblingOrder when specialising the first element of an archetype

### DIFF
--- a/tools/src/main/java/com/nedap/archie/diff/LCSOrderingDiff.java
+++ b/tools/src/main/java/com/nedap/archie/diff/LCSOrderingDiff.java
@@ -194,8 +194,8 @@ public class LCSOrderingDiff {
 
         for(int j = i - 1; j >= 0; j--) {
             String otherNodeId = childNodeIds.get(j);
-            if (AOMUtils.getSpecializationDepthFromCode(nodeId) == childSpecializationDepth && // nodeId specialisationDepth (id3.0.0.1 - 3) == specialisationDepth of archetype (rootnode depth), so if parent of specialised nodeId existed in the root archetype
-                    AOMUtils.codeExistsAtLevel(nodeId, childSpecializationDepth-1) && // nodeId was specialised or existed in the direct parent
+            if (AOMUtils.getSpecializationDepthFromCode(nodeId) == childSpecializationDepth &&
+                    AOMUtils.codeExistsAtLevel(nodeId, childSpecializationDepth-1) &&
                     AOMUtils.codeAtLevel(otherNodeId, childSpecializationDepth-1).equals(AOMUtils.codeAtLevel(nodeId, childSpecializationDepth-1))) { //
                 onlyTheSameParentNodeId = true;
                 firstNodeIdWithSameParent = otherNodeId;

--- a/tools/src/main/java/com/nedap/archie/diff/LCSOrderingDiff.java
+++ b/tools/src/main/java/com/nedap/archie/diff/LCSOrderingDiff.java
@@ -128,7 +128,7 @@ public class LCSOrderingDiff {
 
         if(lcs.size() == 0) {
             //If there's no empty LCS, it's not possible to add sibling markers
-        }  else {
+        } else {
             for (int i = 0; i < childNodeIds.size(); i++) {
                 String nodeId = childNodeIds.get(i);
                 if (!nodeIdLCS.contains(nodeId)) {
@@ -192,26 +192,25 @@ public class LCSOrderingDiff {
         boolean onlyTheSameParentNodeId = false;
         String firstNodeIdWithSameParent = null;
 
-        for(int j = i - 1; j>= 0; j--) {
-
+        for(int j = i - 1; j >= 0; j--) {
             String otherNodeId = childNodeIds.get(j);
-            if(AOMUtils.getSpecializationDepthFromCode(nodeId) == childSpecializationDepth &&
-                    AOMUtils.codeExistsAtLevel(nodeId, childSpecializationDepth-1) &&
-                    AOMUtils.codeAtLevel(otherNodeId, childSpecializationDepth-1).equals(AOMUtils.codeAtLevel(nodeId, childSpecializationDepth-1))) {
+            if (AOMUtils.getSpecializationDepthFromCode(nodeId) == childSpecializationDepth && // nodeId specialisationDepth (id3.0.0.1 - 3) == specialisationDepth of archetype (rootnode depth), so if parent of specialised nodeId existed in the root archetype
+                    AOMUtils.codeExistsAtLevel(nodeId, childSpecializationDepth-1) && // nodeId was specialised or existed in the direct parent
+                    AOMUtils.codeAtLevel(otherNodeId, childSpecializationDepth-1).equals(AOMUtils.codeAtLevel(nodeId, childSpecializationDepth-1))) { //
                 onlyTheSameParentNodeId = true;
                 firstNodeIdWithSameParent = otherNodeId;
             } else {
-                if (onlyTheSameParentNodeId) {
-                    CObject cObjectInResult = resultAttribute.getChild(nodeId);
-                    SiblingOrder order = DiffUtil.findSiblingOrder(siblingOrders, firstNodeIdWithSameParent);
-                    if(order != null) {
-                        DiffUtil.addSiblingOrder(siblingOrders, order, cObjectInResult);
-                    }
-                    return true;
-                }
-                return false;
+                break;
             }
+        }
 
+        if (onlyTheSameParentNodeId) {
+            CObject cObjectInResult = resultAttribute.getChild(nodeId);
+            SiblingOrder order = DiffUtil.findSiblingOrder(siblingOrders, firstNodeIdWithSameParent);
+            if(order != null) {
+                DiffUtil.addSiblingOrder(siblingOrders, order, cObjectInResult);
+            }
+            return true;
         }
         return false;
     }

--- a/tools/src/main/java/com/nedap/archie/diff/LCSOrderingDiff.java
+++ b/tools/src/main/java/com/nedap/archie/diff/LCSOrderingDiff.java
@@ -196,7 +196,7 @@ public class LCSOrderingDiff {
             String otherNodeId = childNodeIds.get(j);
             if (AOMUtils.getSpecializationDepthFromCode(nodeId) == childSpecializationDepth &&
                     AOMUtils.codeExistsAtLevel(nodeId, childSpecializationDepth-1) &&
-                    AOMUtils.codeAtLevel(otherNodeId, childSpecializationDepth-1).equals(AOMUtils.codeAtLevel(nodeId, childSpecializationDepth-1))) { //
+                    AOMUtils.codeAtLevel(otherNodeId, childSpecializationDepth-1).equals(AOMUtils.codeAtLevel(nodeId, childSpecializationDepth-1))) {
                 onlyTheSameParentNodeId = true;
                 firstNodeIdWithSameParent = otherNodeId;
             } else {

--- a/tools/src/test/java/com/nedap/archie/diff/SiblingOrderDiffTest.java
+++ b/tools/src/test/java/com/nedap/archie/diff/SiblingOrderDiffTest.java
@@ -61,5 +61,10 @@ public class SiblingOrderDiffTest {
         diffTestUtil.test("openEHR-EHR-CLUSTER.order-parent.v1.0.0.adls","openEHR-EHR-CLUSTER.redefinition_at_same_place.v1.0.0.adls");
     }
 
+    @Test
+    public void specialiseFirstElement() throws Exception {
+        diffTestUtil.test("openEHR-EHR-CLUSTER.order-parent.v1.0.0.adls","openEHR-EHR-CLUSTER.specialise_first_element.v1.0.0.adls");
+    }
+
     //The two tricky edge cases in the flattener test are really not interesting here, as the Differentiator will never create such hard to do code
 }

--- a/tools/src/test/resources/com/nedap/archie/diff/specexamples/openEHR-EHR-CLUSTER.lipid_studies_panel.adls
+++ b/tools/src/test/resources/com/nedap/archie/diff/specexamples/openEHR-EHR-CLUSTER.lipid_studies_panel.adls
@@ -13,7 +13,6 @@ description
 definition
     CLUSTER[id1.1] matches {    -- Lipid studies panel
         items matches {
-            after [id3]
             CLUSTER[id3.1] matches {    -- LDL
                 items matches {
                     ELEMENT[id2.1] matches {    -- LDL cholesterol

--- a/tools/src/test/resources/com/nedap/archie/flattener/siblingorder/openEHR-EHR-CLUSTER.specialise_first_element.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/flattener/siblingorder/openEHR-EHR-CLUSTER.specialise_first_element.v1.0.0.adls
@@ -1,0 +1,45 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2; generated)
+    openEHR-EHR-CLUSTER.specialise_first_element.v1.0.0
+
+specialize
+    openEHR-EHR-CLUSTER.order-parent.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	lifecycle_state = <"unmanaged">
+
+definition
+    CLUSTER[id1.1] ∈ {
+        items ∈ {
+            --resulting order: id2, id3, id0.1, id0.2, id4, id0.3, id0.4, id5
+            ELEMENT[id2.1]
+        }
+}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1.1"] = <
+				text = <"cluster">
+				description = <"cluster">
+			>
+			["id0.1"] = <
+                text = <"item 5">
+                description = <"item 5">
+            >
+            ["id0.2"] = <
+                text = <"item 6">
+                description = <"item 6">
+            >
+            ["id0.3"] = <
+                text = <"item 7">
+                description = <"item 7">
+            >
+            ["id0.4"] = <
+                text = <"item 8">
+                description = <"item 8">
+            >
+        >
+	>

--- a/tools/src/test/resources/com/nedap/archie/flattener/siblingorder/openEHR-EHR-CLUSTER.specialise_first_element.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/flattener/siblingorder/openEHR-EHR-CLUSTER.specialise_first_element.v1.0.0.adls
@@ -13,7 +13,6 @@ description
 definition
     CLUSTER[id1.1] ∈ {
         items ∈ {
-            --resulting order: id2, id3, id0.1, id0.2, id4, id0.3, id0.4, id5
             ELEMENT[id2.1]
         }
 }


### PR DESCRIPTION
Example of the bug:

flat parent archetype:
```
CLUSTER
   ELEMENT[id2]
   ELEMENT[id4]
```

flat child archetype:
```
CLUSTER
   ELEMENT[id2]
   ELEMENT[id2.1]
   ELEMENT[id4]
```

Expected differentiated archetype:
```
CLUSTER
   ELEMENT[id2.1]
```

What comes out of the differentiator at the moment:
```
CLUSTER
   after[id2]
   ELEMENT[id2.1]
```

This gives errors when flattening the archetype, and puts the specialised id2.1 element last instead of at the place of the original id2 element.

Problem was in the 'handleDirectlyAfterSameParentNode' method where the parent id code was found, but because the for loop ended, the method still returned 'false', even though there was a parent node that this specialised element could go right after.
