### PR TITLE
Deprecate logical path support

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
+++ b/aom/src/main/java/com/nedap/archie/aom/ArchetypeConstraint.java
@@ -52,8 +52,13 @@ public abstract class ArchetypeConstraint extends ArchetypeModelObject {
         //setter hack for jackson, unfortunately
     }
 
+    /**
+     * @deprecated This functionality will be removed.
+     */
+    @Deprecated
     public abstract String getLogicalPath();
 
+    @Deprecated
     private void setLogicalPath(String path){
         //setter hack for jackson, unfortunately
     }

--- a/aom/src/main/java/com/nedap/archie/aom/CAttribute.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CAttribute.java
@@ -146,6 +146,10 @@ public class CAttribute extends ArchetypeConstraint {
         return null;
     }
 
+    /**
+     * @deprecated This functionality will be removed.
+     */
+    @Deprecated
     public CObject getChildByMeaning(String meaning) {
         meaning = meaning.toLowerCase();
         for(CObject child:children) {

--- a/aom/src/main/java/com/nedap/archie/aom/CAttribute.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CAttribute.java
@@ -330,6 +330,7 @@ public class CAttribute extends ArchetypeConstraint {
         return (CObject) super.getParent();
     }
 
+    @Deprecated
     public String getLogicalPath() {
         String path = "/" + rmAttributeName;
         if(getParent() != null) {

--- a/aom/src/main/java/com/nedap/archie/aom/CObject.java
+++ b/aom/src/main/java/com/nedap/archie/aom/CObject.java
@@ -160,6 +160,7 @@ public abstract class CObject extends ArchetypeConstraint {
         return null;
     }
 
+    @Deprecated
     private String getLogicalPathMeaning() {
         if(nodeId == null) {
             return null;
@@ -176,7 +177,7 @@ public abstract class CObject extends ArchetypeConstraint {
         return meaning;
     }
 
-
+    @Deprecated
     public String getLogicalPath() {
         //TODO: this can cause name clashes. Solve them!
         //TODO: the text can contain []-characters. Replace them?

--- a/aom/src/main/java/com/nedap/archie/query/AOMPathQuery.java
+++ b/aom/src/main/java/com/nedap/archie/query/AOMPathQuery.java
@@ -9,6 +9,8 @@ import com.nedap.archie.aom.CComplexObjectProxy;
 import com.nedap.archie.aom.CObject;
 import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.paths.PathUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +29,7 @@ import java.util.stream.Collectors;
  * Created by pieter.bos on 19/10/15.
  */
 public class AOMPathQuery {
+    private static final Logger logger = LoggerFactory.getLogger(AOMPathQuery.class);
 
     private final List<PathSegment> pathSegments;
 
@@ -208,7 +211,11 @@ public class AOMPathQuery {
             int index = pathSegment.getIndex() - 1;
             return index < attribute.getChildren().size() ? attribute.getChildren().get(index) : null;
         } else if (pathSegment.getNodeId() != null) {
-            return attribute.getChildByMeaning(pathSegment.getNodeId());//TODO: the ANTLR grammar removes all whitespace. what to do here?
+            CObject match = attribute.getChildByMeaning(pathSegment.getNodeId());//TODO: the ANTLR grammar removes all whitespace. what to do here?
+            if(match != null) {
+                logger.warn("Deprecation: Matching on object name is deprecated and will be removed. Use node id instead.");
+            }
+            return match;
         } else {
             return attribute;
         }

--- a/base/src/main/java/com/nedap/archie/ArchieLanguageConfiguration.java
+++ b/base/src/main/java/com/nedap/archie/ArchieLanguageConfiguration.java
@@ -5,17 +5,21 @@ package com.nedap.archie;
  */
 public class ArchieLanguageConfiguration {
 
+    @Deprecated
     private static ThreadLocal<String> currentLogicalPathLanguage = new ThreadLocal<>();
     private static ThreadLocal<String> currentMeaningAndDescriptionLanguage = new ThreadLocal<>();
 
     private static String DEFAULT_MEANING_DESCRIPTION_LANGUAGE = "en";
+    @Deprecated
     private static String DEFAULT_LOGICAL_PATH_LANGUAGE = "en";
 
 
     /**
      * The language for use in logical paths
      * @return The language for use in logical paths
+     * @deprecated This functionality will be removed.
      */
+    @Deprecated
     public static String getLogicalPathLanguage() {
         String language = currentLogicalPathLanguage.get();
         if(language == null) {
@@ -41,6 +45,10 @@ public class ArchieLanguageConfiguration {
         DEFAULT_MEANING_DESCRIPTION_LANGUAGE = defaultLanguage;
     }
 
+    /**
+     * @deprecated This functionality will be removed.
+     */
+    @Deprecated
     public static void setDefaultLogicalPathLanguage(String defaultLanguage) {
         DEFAULT_LOGICAL_PATH_LANGUAGE = defaultLanguage;
     }
@@ -49,7 +57,9 @@ public class ArchieLanguageConfiguration {
     /**
      * Override the language used in logical paths, on a thread local basis
      * @param language The language the use
+     * @deprecated This functionality will be removed.
      */
+    @Deprecated
     public static void setThreadLocalLogicalPathLanguage(String language) {
         currentLogicalPathLanguage.set(language);
     }

--- a/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
+++ b/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
@@ -7,6 +7,8 @@ import com.nedap.archie.definitions.AdlCodeDefinitions;
 import com.nedap.archie.paths.PathSegment;
 import com.nedap.archie.rminfo.ModelInfoLookup;
 import com.nedap.archie.rminfo.RMAttributeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -26,6 +28,7 @@ import java.util.List;
  * Created by pieter.bos on 19/10/15.
  */
 public class RMPathQuery {
+    private static final Logger logger = LoggerFactory.getLogger(RMPathQuery.class);
 
     private List<PathSegment> pathSegments = new ArrayList<>();
     private final boolean matchSpecialisedNodes;
@@ -280,6 +283,7 @@ public class RMPathQuery {
                 }
             } else {
                 if(equalsName(lookup.getNameFromRMObject(object), segment.getNodeId())) {
+                    logger.warn("Deprecation: Matching on object name is deprecated and will be removed. Use node id instead.");
                     result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, archetypeNodeId)));
                 }
             }
@@ -320,6 +324,7 @@ public class RMPathQuery {
                 }
             } else {
                 if(equalsName(lookup.getNameFromRMObject(o), segment.getNodeId())) {
+                    logger.warn("Deprecation: Matching on object name is deprecated and will be removed. Use node id instead.");
                     return o;
                 }
             }

--- a/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
+++ b/tools/src/main/java/com/nedap/archie/rmobjectvalidator/RMObjectValidationMessage.java
@@ -12,6 +12,7 @@ public class RMObjectValidationMessage {
 
     private String archetypePath;
     private String path;
+    @Deprecated
     private String humanReadableArchetypePath;
     private String message;
     private String archetypeId;
@@ -34,6 +35,15 @@ public class RMObjectValidationMessage {
 
 
     // Constructors with attribute assignment
+    public RMObjectValidationMessage(String path, String archetypeId, String archetypePath, String message, RMObjectValidationMessageType type) {
+        this(path, archetypeId, archetypePath, null, message, type);
+    }
+
+    /**
+     * @deprecated humanPath will be removed. Use {@link #RMObjectValidationMessage(String, String, String, String,
+     * RMObjectValidationMessageType)} instead.
+     */
+    @Deprecated
     public RMObjectValidationMessage(String path, String archetypeId, String archetypePath, String humanPath, String message, RMObjectValidationMessageType type) {
         this.path = path;
         this.archetypeId = archetypeId;
@@ -95,7 +105,9 @@ public class RMObjectValidationMessage {
     /**
      * Get the human readable path in the archetype that this validation refers to - used to retrieve the constraint that was used to generate this error
      * @return the human readablepath of the constraint that was used to generate this error in the archetype
+     * @deprecated This functionality will be removed.
      */
+    @Deprecated
     public String getHumanReadableArchetypePath() {
         return humanReadableArchetypePath;
     }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/DummyRulesPrimitiveObjectParent.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/DummyRulesPrimitiveObjectParent.java
@@ -29,6 +29,7 @@ public class DummyRulesPrimitiveObjectParent extends CAttribute {
     }
 
     @Override
+    @Deprecated
     public String getLogicalPath() {
         return getPath();
     }

--- a/tools/src/test/java/com/nedap/archie/adlparser/PathTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/PathTest.java
@@ -60,6 +60,7 @@ public class PathTest {
 
 
     @Test
+    @Deprecated
     public void logicalPath() {
         CObject object = archetype.getDefinition()
                 .getAttribute("context").getChild("id11")

--- a/tools/src/test/java/com/nedap/archie/aom/CObjectTest.java
+++ b/tools/src/test/java/com/nedap/archie/aom/CObjectTest.java
@@ -25,21 +25,24 @@ public class CObjectTest {
     }
 
     @Test
-    public void definitionMeaningAndLogicalPath() {
+    public void definitionMeaning() {
         assertEquals("Prescription", archetype.getDefinition().getMeaning());
         assertEquals("A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.", archetype.getDefinition().getDescription());
 
         CObject qualitification = archetype.getDefinition().itemAtPath("/context[id11]/other_context[id2]/items[id3]");
 
-        assertEquals("/context[id11]/other_context[id2]/items[Qualification]", qualitification.getLogicalPath());
-
         ArchieLanguageConfiguration.setThreadLocalDescriptiongAndMeaningLanguage("nl");
 
         assertEquals("Recept", archetype.getDefinition().getMeaning());
         assertEquals("Een document waarmee uitgifte van een of meerdere medicijnen of hulpmiddel wordt geautoriseerd.", archetype.getDefinition().getDescription());
+    }
+
+    @Test
+    @Deprecated
+    public void logicalPath() {
+        CObject qualitification = archetype.getDefinition().itemAtPath("/context[id11]/other_context[id2]/items[id3]");
 
         assertEquals("/context[id11]/other_context[id2]/items[Qualification]", qualitification.getLogicalPath());
-
 
         ArchieLanguageConfiguration.setThreadLocalLogicalPathLanguage("nl");
 


### PR DESCRIPTION
Deprecate support for logical paths. This functionality is implemented inconsistently, depends on ThreadLocal variables and isn't part of the openEHR specification (yet?).

These parts are deprecated and will be removed in the future:
* The method getLogicalPath in ArchetypeConstraint and its descendants. 
* The method getHumanReadableArchetypePath in RMObjectValidationMessage, and constructors that set the HumanReadableArchetypePath
* The related setting in ArchieLanguageConfiguration, i.e. the methods getLogicalPathLanguage, setDefaultLogicalPathLanguage and setThreadLocalLogicalPathLanguage
* Matching on RM object name in RMPathQuery queries.
* Matching on term meaning in AOMPathQuery queries, and the related CAttribute.getChildByMeaning method.
