### PR TITLE
Add AnnotationDifferentiator

### DIFF
--- a/tools/src/main/java/com/nedap/archie/diff/AnnotationDifferentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/AnnotationDifferentiator.java
@@ -24,7 +24,7 @@ public class AnnotationDifferentiator {
         }
 
         // Remove common entries in the annotations map
-        removeCommonEntriesLvl1(result.getAnnotations().getDocumentation(), flatParent.getAnnotations().getDocumentation());
+        removeCommonEntries(result.getAnnotations().getDocumentation(), flatParent.getAnnotations().getDocumentation());
 
         // If after removing common entries the documentation is empty, just set the annotations to null
         if (result.getAnnotations().getDocumentation().isEmpty()) {
@@ -32,62 +32,21 @@ public class AnnotationDifferentiator {
         }
     }
 
-    private void removeCommonEntriesLvl1(Map<String, Map<String, Map<String, String>>> A,
-                                            Map<String, Map<String, Map<String, String>>> B) {
-        Iterator<Map.Entry<String, Map<String, Map<String, String>>>> iterator = A.entrySet().iterator();
+    private <V> void removeCommonEntries(Map<String, V> subValueA, Map<String, V> subValueB) {
+        Iterator<Map.Entry<String, V>> iterator = subValueA.entrySet().iterator();
 
         while (iterator.hasNext()) {
-            Map.Entry<String, Map<String, Map<String, String>>> entryA = iterator.next();
+            Map.Entry<String, V> entryA = iterator.next();
             String keyA = entryA.getKey();
-            Map<String, Map<String, String>> valueA = entryA.getValue();
-
-            if (B.containsKey(keyA)) {
-                Map<String, Map<String, String>> valueB = B.get(keyA);
-
-                if (valueA.equals(valueB)) {
-                    iterator.remove();
-                } else {
-                    removeCommonEntriesLvl2(valueA, valueB);
-                }
-            }
-        }
-    }
-
-    private void removeCommonEntriesLvl2(Map<String, Map<String, String>> valueA,
-                                            Map<String, Map<String, String>> valueB) {
-        Iterator<Map.Entry<String, Map<String, String>>> iterator = valueA.entrySet().iterator();
-
-        while (iterator.hasNext()) {
-            Map.Entry<String, Map<String, String>> entryA = iterator.next();
-            String keyA = entryA.getKey();
-            Map<String, String> subValueA = entryA.getValue();
-
-            if (valueB.containsKey(keyA)) {
-                Map<String, String> subValueB = valueB.get(keyA);
-
-                if (subValueA.equals(subValueB)) {
-                    iterator.remove();
-                } else {
-                    removeCommonEntriesLvl3(subValueA, subValueB);
-                }
-            }
-        }
-    }
-
-    private void removeCommonEntriesLvl3(Map<String, String> subValueA,
-                                            Map<String, String> subValueB) {
-        Iterator<Map.Entry<String, String>> iterator = subValueA.entrySet().iterator();
-
-        while (iterator.hasNext()) {
-            Map.Entry<String, String> entryA = iterator.next();
-            String keyA = entryA.getKey();
-            String valueA = entryA.getValue();
+            V valueA = entryA.getValue();
 
             if (subValueB.containsKey(keyA)) {
-                String valueB = subValueB.get(keyA);
+                V valueB = subValueB.get(keyA);
 
                 if (valueA.equals(valueB)) {
                     iterator.remove();
+                } else if (valueA instanceof Map && valueB instanceof Map) {
+                    removeCommonEntries((Map<String, V>) valueA, (Map<String, V>) valueB);
                 }
             }
         }

--- a/tools/src/main/java/com/nedap/archie/diff/AnnotationDifferentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/AnnotationDifferentiator.java
@@ -1,0 +1,96 @@
+package com.nedap.archie.diff;
+
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.ResourceAnnotations;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class AnnotationDifferentiator {
+
+    /**
+     * Keeps all annotations in the result, that are not in the flatParent
+     * Remove annotations that can also be found in the parent
+     */
+    public void differentiate(Archetype result, Archetype flatParent) {
+        if (result.getAnnotations() == null) {
+            return;
+        }
+        if (result.getAnnotations().getDocumentation() == null) {
+            result.setAnnotations(null);
+            return;
+        }
+        if (flatParent.getAnnotations() == null || flatParent.getAnnotations().getDocumentation() == null) {
+            return;
+        }
+
+        // Remove common entries in the annotations map
+        removeCommonEntriesLvl1(result.getAnnotations().getDocumentation(), flatParent.getAnnotations().getDocumentation());
+
+        // If after removing common entries the documentation is empty, just set the annotations to null
+        if (result.getAnnotations().getDocumentation().isEmpty()) {
+            result.setAnnotations(null);
+        }
+    }
+
+    private void removeCommonEntriesLvl1(Map<String, Map<String, Map<String, String>>> A,
+                                            Map<String, Map<String, Map<String, String>>> B) {
+        Iterator<Map.Entry<String, Map<String, Map<String, String>>>> iterator = A.entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            Map.Entry<String, Map<String, Map<String, String>>> entryA = iterator.next();
+            String keyA = entryA.getKey();
+            Map<String, Map<String, String>> valueA = entryA.getValue();
+
+            if (B.containsKey(keyA)) {
+                Map<String, Map<String, String>> valueB = B.get(keyA);
+
+                if (valueA.equals(valueB)) {
+                    iterator.remove();
+                } else {
+                    removeCommonEntriesLvl2(valueA, valueB);
+                }
+            }
+        }
+    }
+
+    private void removeCommonEntriesLvl2(Map<String, Map<String, String>> valueA,
+                                            Map<String, Map<String, String>> valueB) {
+        Iterator<Map.Entry<String, Map<String, String>>> iterator = valueA.entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            Map.Entry<String, Map<String, String>> entryA = iterator.next();
+            String keyA = entryA.getKey();
+            Map<String, String> subValueA = entryA.getValue();
+
+            if (valueB.containsKey(keyA)) {
+                Map<String, String> subValueB = valueB.get(keyA);
+
+                if (subValueA.equals(subValueB)) {
+                    iterator.remove();
+                } else {
+                    removeCommonEntriesLvl3(subValueA, subValueB);
+                }
+            }
+        }
+    }
+
+    private void removeCommonEntriesLvl3(Map<String, String> subValueA,
+                                            Map<String, String> subValueB) {
+        Iterator<Map.Entry<String, String>> iterator = subValueA.entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            Map.Entry<String, String> entryA = iterator.next();
+            String keyA = entryA.getKey();
+            String valueA = entryA.getValue();
+
+            if (subValueB.containsKey(keyA)) {
+                String valueB = subValueB.get(keyA);
+
+                if (valueA.equals(valueB)) {
+                    iterator.remove();
+                }
+            }
+        }
+    }
+}

--- a/tools/src/main/java/com/nedap/archie/diff/AnnotationDifferentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/AnnotationDifferentiator.java
@@ -1,7 +1,6 @@
 package com.nedap.archie.diff;
 
 import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.ResourceAnnotations;
 
 import java.util.Iterator;
 import java.util.Map;

--- a/tools/src/main/java/com/nedap/archie/diff/Differentiator.java
+++ b/tools/src/main/java/com/nedap/archie/diff/Differentiator.java
@@ -35,6 +35,7 @@ public class Differentiator {
             new LCSOrderingDiff(metaModels).addSiblingOrder(result, flatChild, flatParent);
         }
         new ConstraintDifferentiator(constraintImposer, flatParent).removeUnspecializedConstraints(result, flatParent);
+        new AnnotationDifferentiator().differentiate(result, flatParent);
 
         new DifferentialPathGenerator().replace(result);
         new TerminologyDifferentiator().differentiate(result);

--- a/tools/src/test/java/com/nedap/archie/diff/AnnotationDifferentiatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/diff/AnnotationDifferentiatorTest.java
@@ -79,6 +79,22 @@ public class AnnotationDifferentiatorTest {
     }
 
     @Test
+    public void changeValueAtLvl3() {
+        // Setup
+        child.getAnnotations().getDocumentation().get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").put("hideHeader", "updated");
+
+        // Test
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNotNull(child.getAnnotations());
+        Map<String, Map<String, Map<String, String>>> annotations = child.getAnnotations().getDocumentation();
+        assertEquals(1, annotations.size());
+        assertEquals(1, annotations.get("nl").size());
+        assertEquals(1, annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").size());
+        assertEquals("updated", annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").get("hideHeader"));
+    }
+
+    @Test
     public void extraAnnotationsAtAllLevelsTest() {
         // Setup
         Map<String, String> pathMap = Map.of("newKey", "newValue");
@@ -98,5 +114,45 @@ public class AnnotationDifferentiatorTest {
         assertEquals(1, annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id5]").size());
         assertEquals(1, annotations.get("en").size());
         assertEquals(1, annotations.get("en").get("/data[id2]/events[id3]/data[id4]/items[id5]").size());
+    }
+
+    @Test
+    public void childHasNoAnnotationsTest() {
+        // Setup
+        child.setAnnotations(null);
+
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNull(child.getAnnotations());
+    }
+
+    @Test
+    public void childHasNoDocumentationTest() {
+        // Setup
+        child.getAnnotations().setDocumentation(null);
+
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNull(child.getAnnotations());
+    }
+
+    @Test
+    public void parentHasNoAnnotationsTest() {
+        // Setup
+        flatParent.setAnnotations(null);
+
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNotNull(child.getAnnotations());
+    }
+
+    @Test
+    public void parentHasNoDocumentationTest() {
+        // Setup
+        flatParent.getAnnotations().setDocumentation(null);
+
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNotNull(child.getAnnotations());
     }
 }

--- a/tools/src/test/java/com/nedap/archie/diff/AnnotationDifferentiatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/diff/AnnotationDifferentiatorTest.java
@@ -1,0 +1,102 @@
+package com.nedap.archie.diff;
+
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.testutil.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class AnnotationDifferentiatorTest {
+
+    private Archetype flatParent;
+    private Archetype child;
+
+    @Before
+    public void setup() throws Exception {
+        flatParent = TestUtil.parseFailOnErrors("/com/nedap/archie/diff/openEHR-EHR-OBSERVATION.basic_annotations.v1.0.0.adls");
+        child = TestUtil.parseFailOnErrors("/com/nedap/archie/diff/openEHR-EHR-OBSERVATION.annotations_specialised_flattened.v1.0.0.adls");
+    }
+
+    @Test
+    public void noAdditionalAnnotationsTest() {
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNull(child.getAnnotations());
+    }
+
+    @Test
+    public void extraAnnotationsAtLevel1Test() {
+        // Setup
+        Map<String, String> pathMap = Map.of("newKey", "newValue");
+        Map<String, Map<String, String>> languageMap = Map.of("/data[id2]/events[id3]/data[id4]/items[id5]", pathMap);
+        child.getAnnotations().getDocumentation().put("en", languageMap);
+
+        // Test
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNotNull(child.getAnnotations());
+        Map<String, Map<String, Map<String, String>>> annotations = child.getAnnotations().getDocumentation();
+        assertEquals(1, annotations.size());
+        assertEquals(1, annotations.get("en").size());
+        assertEquals(1, annotations.get("en").get("/data[id2]/events[id3]/data[id4]/items[id5]").size());
+        assertEquals("newValue", annotations.get("en").get("/data[id2]/events[id3]/data[id4]/items[id5]").get("newKey"));
+    }
+
+    @Test
+    public void extraAnnotationsAtLevel2Test() {
+        // Setup
+        Map<String, String> pathMap = Map.of("newKey", "newValue");
+        child.getAnnotations().getDocumentation().get("nl").put("/data[id2]/events[id3]/data[id4]/items[id5]", pathMap);
+
+        // Test
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNotNull(child.getAnnotations());
+        Map<String, Map<String, Map<String, String>>> annotations = child.getAnnotations().getDocumentation();
+        assertEquals(1, annotations.size());
+        assertEquals(1, annotations.get("nl").size());
+        assertEquals(1, annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id5]").size());
+        assertEquals("newValue", annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id5]").get("newKey"));
+    }
+
+    @Test
+    public void extraAnnotationsAtLevel3Test() {
+        // Setup
+        child.getAnnotations().getDocumentation().get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").put("newKey", "newValue");
+
+        // Test
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNotNull(child.getAnnotations());
+        Map<String, Map<String, Map<String, String>>> annotations = child.getAnnotations().getDocumentation();
+        assertEquals(1, annotations.size());
+        assertEquals(1, annotations.get("nl").size());
+        assertEquals(1, annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").size());
+        assertEquals("newValue", annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").get("newKey"));
+    }
+
+    @Test
+    public void extraAnnotationsAtAllLevelsTest() {
+        // Setup
+        Map<String, String> pathMap = Map.of("newKey", "newValue");
+        Map<String, Map<String, String>> languageMap = Map.of("/data[id2]/events[id3]/data[id4]/items[id5]", pathMap);
+        child.getAnnotations().getDocumentation().put("en", languageMap);
+        child.getAnnotations().getDocumentation().get("nl").put("/data[id2]/events[id3]/data[id4]/items[id5]", pathMap);
+        child.getAnnotations().getDocumentation().get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").put("newKey", "newValue");
+
+        // Test
+        new AnnotationDifferentiator().differentiate(child, flatParent);
+
+        assertNotNull(child.getAnnotations());
+        Map<String, Map<String, Map<String, String>>> annotations = child.getAnnotations().getDocumentation();
+        assertEquals(2, annotations.size());
+        assertEquals(2, annotations.get("nl").size());
+        assertEquals(1, annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]").size());
+        assertEquals(1, annotations.get("nl").get("/data[id2]/events[id3]/data[id4]/items[id5]").size());
+        assertEquals(1, annotations.get("en").size());
+        assertEquals(1, annotations.get("en").get("/data[id2]/events[id3]/data[id4]/items[id5]").size());
+    }
+}

--- a/tools/src/test/resources/com/nedap/archie/diff/openEHR-EHR-OBSERVATION.annotations_specialised_flattened.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/diff/openEHR-EHR-OBSERVATION.annotations_specialised_flattened.v1.0.0.adls
@@ -1,0 +1,90 @@
+archetype (adl_version=2.0.5; rm_release=1.1.0; generated)
+    openEHR-EHR-OBSERVATION.annotations_specialised_flattened.v1.0.0
+
+specialize
+    openEHR-EHR-OBSERVATION.basic_annotations.v1
+
+language
+    original_language = <[ISO_639-1::nl]>
+
+description
+    original_author = <
+        ["name"] = <"vera.prinsen">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["nl"] = <
+            language = <[ISO-639_1::nl]>
+            purpose = <"">
+        >
+    >
+
+definition
+    OBSERVATION[id1.1] matches {    -- Annotations Specialised
+        data matches {
+            HISTORY[id2] matches {
+                events matches {
+                    POINT_EVENT[id3] matches {    -- Point event
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items matches {
+                                    ELEMENT[id5] occurrences matches {0..1} matches {    -- Text
+                                        value matches {
+                                            DV_TEXT[id6]
+                                        }
+                                    }
+                                    ELEMENT[id7] occurrences matches {0..1} matches {    -- Likert
+                                        value matches {
+                                            DV_COUNT[id8] matches {
+                                                magnitude matches {|0..10|}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["nl"] = <
+            ["id1"] = <
+                text = <"Basic Annotations">
+                description = <"">
+                code = <"id1">
+            >
+            ["id3"] = <
+                text = <"Point event">
+                description = <"Point event">
+            >
+            ["id5"] = <
+                text = <"Text">
+                description = <"">
+            >
+            ["id7"] = <
+                text = <"Likert">
+                description = <"">
+            >
+            ["id1.1"] = <
+                text = <"Annotations Specialised">
+                description = <"">
+                code = <"id1">
+            >
+        >
+    >
+
+annotations
+    documentation = <
+        ["nl"] = <
+            ["/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]"] = <
+                ["likertUpperBoundText"] = <"max">
+                ["likertLowerBoundText"] = <"min">
+                ["hideHeader"] = <"yes">
+                ["type"] = <"Likert">
+            >
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/diff/openEHR-EHR-OBSERVATION.basic_annotations.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/diff/openEHR-EHR-OBSERVATION.basic_annotations.v1.0.0.adls
@@ -1,0 +1,82 @@
+archetype (adl_version=2.0.5; rm_release=1.1.0)
+    openEHR-EHR-OBSERVATION.basic_annotations.v1.0.0
+
+language
+    original_language = <[ISO_639-1::nl]>
+
+description
+    original_author = <
+        ["name"] = <"vera.prinsen">
+    >
+    lifecycle_state = <"DRAFT">
+    details = <
+        ["nl"] = <
+            language = <[ISO-639_1::nl]>
+            purpose = <"">
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- Basic Annotations
+        data matches {
+            HISTORY[id2] matches {
+                events matches {
+                    POINT_EVENT[id3] matches {    -- Point event
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items matches {
+                                    ELEMENT[id5] occurrences matches {0..1} matches {    -- Text
+                                        value matches {
+                                            DV_TEXT[id6] 
+                                        }
+                                    }
+                                    ELEMENT[id7] occurrences matches {0..1} matches {    -- Likert
+                                        value matches {
+                                            DV_COUNT[id8] matches {
+                                                magnitude matches {|0..10|}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["nl"] = <
+            ["id1"] = <
+                text = <"Basic Annotations">
+                description = <"">
+                code = <"id1">
+            >
+            ["id3"] = <
+                text = <"Point event">
+                description = <"Point event">
+            >
+            ["id5"] = <
+                text = <"Text">
+                description = <"">
+            >
+            ["id7"] = <
+                text = <"Likert">
+                description = <"">
+            >
+        >
+    >
+
+annotations
+    documentation = <
+        ["nl"] = <
+            ["/data[id2]/events[id3]/data[id4]/items[id7]/value[id8]"] = <
+                ["likertUpperBoundText"] = <"max">
+                ["likertLowerBoundText"] = <"min">
+                ["hideHeader"] = <"yes">
+                ["type"] = <"Likert">
+            >
+        >
+    >


### PR DESCRIPTION
Fixes #608 

Differentiating archetypes does not yet differentiate the annotations, resulting in all annotations of the parents being in the child archetype.

With this AnnotationDifferentiator, the entries in the annotations that are also in the parent are now removed from the annotations in the child archetype.