### PR TITLE
Fix groupIds of TermCodes

### DIFF
--- a/openehr-terminology/src/main/java/com/nedap/archie/terminology/MultiLanguageTerm.java
+++ b/openehr-terminology/src/main/java/com/nedap/archie/terminology/MultiLanguageTerm.java
@@ -35,7 +35,7 @@ class MultiLanguageTerm {
         if(termCode != null) {
             //sometimes terms occur twice. They mean the same, but are in two groups.
             //todo: properly implement groups
-            termCode.getGroupIds().add(code.getGroupName());
+            termCode.getGroupIds().addAll(code.getGroupIds());
         } else {
             termCodesByLanguage.put(code.getLanguage(), code);
         }

--- a/openehr-terminology/src/main/resources/openEHR_RM/fullTermFile.json
+++ b/openehr-terminology/src/main/resources/openEHR_RM/fullTermFile.json
@@ -670,7 +670,7 @@
               "codeString" : "523",
               "description" : "remoção",
               "groupName" : "tipo de auditoria de modificação",
-              "groupIds" : [ "audit change type", "estado de ciclo de vida de versão" ]
+              "groupIds" : [ "audit change type", "version lifecycle state" ]
             }
           }
         },
@@ -722,7 +722,7 @@
               "codeString" : "253",
               "description" : "不明",
               "groupName" : "監査変更種別",
-              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
+              "groupIds" : [ "audit change type", "participation function", "subject relationships", "null flavours" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -730,7 +730,7 @@
               "codeString" : "253",
               "description" : "desconhecido",
               "groupName" : "tipo de auditoria de modificação",
-              "groupIds" : [ "audit change type", "função de participação", "relacionamento de sujeito", "null flavours" ]
+              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
             }
           }
         },
@@ -4600,7 +4600,7 @@
               "codeString" : "532",
               "description" : "completo",
               "groupName" : "estado de ciclo de vida de versão",
-              "groupIds" : [ "estados de instrução", "version lifecycle state" ]
+              "groupIds" : [ "instruction states", "version lifecycle state" ]
             }
           }
         },
@@ -15416,7 +15416,7 @@
               "codeString" : "523",
               "description" : "remoção",
               "groupName" : "tipo de auditoria de modificação",
-              "groupIds" : [ "audit change type", "estado de ciclo de vida de versão" ]
+              "groupIds" : [ "audit change type", "version lifecycle state" ]
             }
           }
         },
@@ -15468,7 +15468,7 @@
               "codeString" : "253",
               "description" : "不明",
               "groupName" : "監査変更種別",
-              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
+              "groupIds" : [ "audit change type", "participation function", "subject relationships", "null flavours" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -15476,7 +15476,7 @@
               "codeString" : "253",
               "description" : "desconhecido",
               "groupName" : "tipo de auditoria de modificação",
-              "groupIds" : [ "audit change type", "função de participação", "relacionamento de sujeito", "null flavours" ]
+              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
             }
           }
         },
@@ -19346,7 +19346,7 @@
               "codeString" : "532",
               "description" : "completo",
               "groupName" : "estado de ciclo de vida de versão",
-              "groupIds" : [ "estados de instrução", "version lifecycle state" ]
+              "groupIds" : [ "instruction states", "version lifecycle state" ]
             }
           }
         },


### PR DESCRIPTION
For TermCodes belonging to multiple groups, the groupIds attribute contained a mixture of group ids and group names. This changes it to the actual group ids.

Regenerated fullTermFile.json according to [the README](https://github.com/openEHR/archie/blob/0f48e8e752647625c113f09c90e92e2f6c8df2d9/openehr-terminology/README.md)