### PR TITLE
Update terminology data to release 2.4.0

### DIFF
--- a/openehr-terminology/src/main/java/com/nedap/archie/terminology/OpenEHRTerminologyAccess.java
+++ b/openehr-terminology/src/main/java/com/nedap/archie/terminology/OpenEHRTerminologyAccess.java
@@ -30,6 +30,7 @@ public class OpenEHRTerminologyAccess implements TerminologyAccess {
 
     private static final String[] resourceNames = {
             "/openEHR_RM/en/openehr_terminology.xml",
+            "/openEHR_RM/es/openehr_terminology.xml",
             "/openEHR_RM/ja/openehr_terminology.xml",
             "/openEHR_RM/pt/openehr_terminology.xml",
             "/openEHR_RM/openehr_external_terminologies.xml",

--- a/openehr-terminology/src/main/resources/openEHR_RM/en/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/en/openehr_terminology.xml
@@ -24,11 +24,11 @@
 		<code value="LL"/>
 		<code value="LLL"/>
 	</codeset>
-	<group name="attestation reason">
+	<group name="attestation reason" id="attestation reason">
 		<concept id="240" rubric="signed"/>
 		<concept id="648" rubric="witnessed"/>
 	</group>
-	<group name="audit change type">
+	<group name="audit change type" id="audit change type">
 		<concept id="249" rubric="creation"/>
 		<concept id="250" rubric="amendment"/>
 		<concept id="251" rubric="modification"/>
@@ -37,13 +37,12 @@
 		<concept id="666" rubric="attestation"/>
 		<concept id="253" rubric="unknown"/>
 	</group>
-	<group name="composition category">
+	<group name="composition category" id="composition category">
 		<concept id="431" rubric="persistent"/>
 		<concept id="451" rubric="episodic"/>
 		<concept id="433" rubric="event"/>
 	</group>
-	<!--
-	<group name="MultiMedia">
+	<group name="MultiMedia" id="MultiMedia">
 		<concept id="387" rubric="audio/DVI4" />
 		<concept id="388" rubric="audio/G722" />
 		<concept id="389" rubric="audio/G723" />
@@ -94,8 +93,7 @@
 		<concept id="682" rubric="application/vnd.oasis.opendocument.text" />
 		<concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 	</group>
-	-->
-	<group name="property">
+	<group name="property" id="property">
 		<concept id="339" rubric="Acceleration"/>
 		<concept id="342" rubric="Acceleration, angular"/>
 		<concept id="381" rubric="Amount (Eq)"/>
@@ -173,23 +171,23 @@
 		<concept id="130" rubric="Work"/>
 		<concept id="685" rubric="Refractive power"/>
 	</group>
-	<group name="version lifecycle state">
+	<group name="version lifecycle state" id="version lifecycle state">
 		<concept id="532" rubric="complete"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->
 		<concept id="553" rubric="incomplete"/>
 		<concept id="523" rubric="deleted"/>
 		<concept id="800" rubric="inactive"/>
 		<concept id="801" rubric="abandoned"/>
 	</group>
-	<group name="participation function">
+	<group name="participation function" id="participation function">
 		<concept id="253" rubric="unknown"/>
 	</group>
-	<group name="null flavours">
+	<group name="null flavours" id="null flavours">
 		<concept id="271" rubric="no information"/>
 		<concept id="253" rubric="unknown"/>
 		<concept id="272" rubric="masked"/>
 		<concept id="273" rubric="not applicable"/>
 	</group>
-	<group name="participation mode">
+	<group name="participation mode" id="participation mode">
 		<concept id="193" rubric="not specified"/>
 		<concept id="216" rubric="face-to-face communication"/>
 		<concept id="223" rubric="interpreted face-to-face communication"/>
@@ -223,7 +221,7 @@
 		<concept id="219" rubric="physically present"/>
 		<concept id="220" rubric="physically remote"/>
 	</group>
-	<group name="instruction states">
+	<group name="instruction states" id="instruction states">
 		<concept id="524" rubric="initial"/>
 		<concept id="526" rubric="planned"/>
 		<concept id="527" rubric="postponed"/>
@@ -235,7 +233,7 @@
 		<concept id="532" rubric="completed"/><!-- warning: the rubric for this concept is 'complete' in the 'version lifecycle state' group (known issue, see SPECPR-51) -->
 		<concept id="533" rubric="expired"/>
 	</group>
-	<group name="instruction transitions">
+	<group name="instruction transitions" id="instruction transitions">
 		<concept id="535" rubric="initiate"/>
 		<concept id="536" rubric="plan step"/>
 		<concept id="537" rubric="postpone"/>
@@ -257,7 +255,7 @@
 		<concept id="551" rubric="notify completed"/>
 		<concept id="552" rubric="notify cancelled"/>
 	</group>
-	<group name="subject relationship">
+	<group name="subject relationship" id="subject relationship">
 		<concept id="0" rubric="self"/>
 		<concept id="3" rubric="foetus"/>
 		<concept id="10" rubric="mother"/>
@@ -295,12 +293,12 @@
 		<concept id="25" rubric="step or half brother"/>
 		<concept id="26" rubric="step or half sister"/>
 	</group>
-	<group name="term mapping purpose">
+	<group name="term mapping purpose" id="term mapping purpose">
 		<concept id="669" rubric="public health"/>
 		<concept id="670" rubric="reimbursement"/>
 		<concept id="671" rubric="research study"/>
 	</group>
-	<group name="event math function">
+	<group name="event math function" id="event math function">
 		<concept id="145" rubric="minimum"/>
 		<concept id="144" rubric="maximum"/>
 		<concept id="267" rubric="mode"/>
@@ -313,7 +311,7 @@
 		<concept id="522" rubric="increase"/>
 		<concept id="640" rubric="actual"/>
 	</group>
-	<group name="setting">
+	<group name="setting" id="setting">
 		<concept id="225" rubric="home"/>
 		<concept id="227" rubric="emergency care"/>
 		<concept id="228" rubric="primary medical care"/>
@@ -329,7 +327,7 @@
 		<concept id="802" rubric="mental healthcare"/>
 		<concept id="238" rubric="other care"/>
 	</group>
-	<group name="extract content type">
+	<group name="extract content type" id="extract content type">
 		<concept id="803" rubric="openEHR EHR"/>
 		<concept id="804" rubric="openEHR Demographic"/>
 		<concept id="805" rubric="openEHR synchronisation"/>
@@ -337,12 +335,12 @@
 		<concept id="807" rubric="generic EMR"/>
 		<concept id="808" rubric="other"/>
 	</group>
-	<group name="extract action type">
+	<group name="extract action type" id="extract action type">
 		<concept id="809" rubric="cancel"/>
 		<concept id="810" rubric="resend"/>
 		<concept id="811" rubric="send new"/>
 	</group>
-	<group name="extract update trigger event type">
+	<group name="extract update trigger event type" id="extract update trigger event type">
 		<concept id="812" rubric="any change"/>
 		<concept id="813" rubric="correction"/>
 		<concept id="814" rubric="update"/>

--- a/openehr-terminology/src/main/resources/openEHR_RM/en/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/en/openehr_terminology.xml
@@ -8,7 +8,12 @@
 	</codeset>
 	<codeset issuer="openehr" openehr_id="integrity check algorithms" external_id="openehr_integrity_check_algorithms">
 		<code value="SHA-1"/>
+		<code value="SHA-224"/>
 		<code value="SHA-256"/>
+		<code value="SHA-384"/>
+		<code value="SHA-512"/>
+		<code value="SHA-512/224"/>
+		<code value="SHA-512/256"/>
 	</codeset>
 	<codeset issuer="openehr" openehr_id="normal statuses" external_id="openehr_normal_statuses">
 		<code value="HHH"/>
@@ -19,11 +24,11 @@
 		<code value="LL"/>
 		<code value="LLL"/>
 	</codeset>
-	<group name="attestation reason" id="attestation reason">
+	<group name="attestation reason">
 		<concept id="240" rubric="signed"/>
 		<concept id="648" rubric="witnessed"/>
 	</group>
-	<group name="audit change type" id="audit change type">
+	<group name="audit change type">
 		<concept id="249" rubric="creation"/>
 		<concept id="250" rubric="amendment"/>
 		<concept id="251" rubric="modification"/>
@@ -32,12 +37,13 @@
 		<concept id="666" rubric="attestation"/>
 		<concept id="253" rubric="unknown"/>
 	</group>
-	<group name="composition category" id="composition category">
+	<group name="composition category">
 		<concept id="431" rubric="persistent"/>
-		<concept id="435" rubric="episodic"/>
+		<concept id="451" rubric="episodic"/>
 		<concept id="433" rubric="event"/>
 	</group>
-	<group name="MultiMedia" id="MultiMedia">
+	<!--
+	<group name="MultiMedia">
 		<concept id="387" rubric="audio/DVI4" />
 		<concept id="388" rubric="audio/G722" />
 		<concept id="389" rubric="audio/G723" />
@@ -88,7 +94,8 @@
 		<concept id="682" rubric="application/vnd.oasis.opendocument.text" />
 		<concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 	</group>
-	<group name="property" id="property">
+	-->
+	<group name="property">
 		<concept id="339" rubric="Acceleration"/>
 		<concept id="342" rubric="Acceleration, angular"/>
 		<concept id="381" rubric="Amount (Eq)"/>
@@ -99,12 +106,12 @@
 		<concept id="119" rubric="Concentration"/>
 		<concept id="350" rubric="Density"/>
 		<concept id="362" rubric="Diffusion coefficient"/>
-		<concept id="501" rubric="Electrical capacitance"/>
-		<concept id="498" rubric="Electrical charge"/>
-		<concept id="502" rubric="Electrical conductance"/>
-		<concept id="334" rubric="Electrical current"/>
-		<concept id="377" rubric="Electrical field strength"/>
-		<concept id="655" rubric="Electrical potential time"/>
+		<concept id="501" rubric="Electric capacitance"/>
+		<concept id="498" rubric="Electric charge"/>
+		<concept id="502" rubric="Electric conductance"/>
+		<concept id="334" rubric="Electric current"/>
+		<concept id="377" rubric="Electric field strength"/>
+		<concept id="655" rubric="Electric potential"/>
 		<concept id="121" rubric="Energy"/>
 		<concept id="366" rubric="Energy density"/>
 		<concept id="508" rubric="Energy dose"/>
@@ -166,21 +173,23 @@
 		<concept id="130" rubric="Work"/>
 		<concept id="685" rubric="Refractive power"/>
 	</group>
-	<group name="version lifecycle state" id="version lifecycle state">
-		<concept id="532" rubric="complete"/>
+	<group name="version lifecycle state">
+		<concept id="532" rubric="complete"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->
 		<concept id="553" rubric="incomplete"/>
 		<concept id="523" rubric="deleted"/>
+		<concept id="800" rubric="inactive"/>
+		<concept id="801" rubric="abandoned"/>
 	</group>
-	<group name="participation function" id="participation function">
+	<group name="participation function">
 		<concept id="253" rubric="unknown"/>
 	</group>
-	<group name="null flavours" id="null flavours">
+	<group name="null flavours">
 		<concept id="271" rubric="no information"/>
 		<concept id="253" rubric="unknown"/>
 		<concept id="272" rubric="masked"/>
 		<concept id="273" rubric="not applicable"/>
 	</group>
-	<group name="participation mode" id="participation mode">
+	<group name="participation mode">
 		<concept id="193" rubric="not specified"/>
 		<concept id="216" rubric="face-to-face communication"/>
 		<concept id="223" rubric="interpreted face-to-face communication"/>
@@ -214,7 +223,7 @@
 		<concept id="219" rubric="physically present"/>
 		<concept id="220" rubric="physically remote"/>
 	</group>
-	<group name="instruction states" id="instruction states">
+	<group name="instruction states">
 		<concept id="524" rubric="initial"/>
 		<concept id="526" rubric="planned"/>
 		<concept id="527" rubric="postponed"/>
@@ -223,10 +232,10 @@
 		<concept id="245" rubric="active"/>
 		<concept id="530" rubric="suspended"/>
 		<concept id="531" rubric="aborted"/>
-		<concept id="532" rubric="completed"/>
+		<concept id="532" rubric="completed"/><!-- warning: the rubric for this concept is 'complete' in the 'version lifecycle state' group (known issue, see SPECPR-51) -->
 		<concept id="533" rubric="expired"/>
 	</group>
-	<group name="instruction transitions" id="instruction transitions">
+	<group name="instruction transitions">
 		<concept id="535" rubric="initiate"/>
 		<concept id="536" rubric="plan step"/>
 		<concept id="537" rubric="postpone"/>
@@ -248,7 +257,7 @@
 		<concept id="551" rubric="notify completed"/>
 		<concept id="552" rubric="notify cancelled"/>
 	</group>
-	<group name="subject relationship" id="subject relationship">
+	<group name="subject relationship">
 		<concept id="0" rubric="self"/>
 		<concept id="3" rubric="foetus"/>
 		<concept id="10" rubric="mother"/>
@@ -286,12 +295,12 @@
 		<concept id="25" rubric="step or half brother"/>
 		<concept id="26" rubric="step or half sister"/>
 	</group>
-	<group name="term mapping purpose" id="term mapping purpose">
+	<group name="term mapping purpose">
 		<concept id="669" rubric="public health"/>
 		<concept id="670" rubric="reimbursement"/>
 		<concept id="671" rubric="research study"/>
 	</group>
-	<group name="event math function" id="event math function">
+	<group name="event math function">
 		<concept id="145" rubric="minimum"/>
 		<concept id="144" rubric="maximum"/>
 		<concept id="267" rubric="mode"/>
@@ -304,7 +313,7 @@
 		<concept id="522" rubric="increase"/>
 		<concept id="640" rubric="actual"/>
 	</group>
-	<group name="setting" id="setting">
+	<group name="setting">
 		<concept id="225" rubric="home"/>
 		<concept id="227" rubric="emergency care"/>
 		<concept id="228" rubric="primary medical care"/>
@@ -317,6 +326,25 @@
 		<concept id="235" rubric="complementary health care"/>
 		<concept id="236" rubric="dental care"/>
 		<concept id="237" rubric="nursing home care"/>
+		<concept id="802" rubric="mental healthcare"/>
 		<concept id="238" rubric="other care"/>
+	</group>
+	<group name="extract content type">
+		<concept id="803" rubric="openEHR EHR"/>
+		<concept id="804" rubric="openEHR Demographic"/>
+		<concept id="805" rubric="openEHR synchronisation"/>
+		<concept id="806" rubric="openEHR generic"/>
+		<concept id="807" rubric="generic EMR"/>
+		<concept id="808" rubric="other"/>
+	</group>
+	<group name="extract action type">
+		<concept id="809" rubric="cancel"/>
+		<concept id="810" rubric="resend"/>
+		<concept id="811" rubric="send new"/>
+	</group>
+	<group name="extract update trigger event type">
+		<concept id="812" rubric="any change"/>
+		<concept id="813" rubric="correction"/>
+		<concept id="814" rubric="update"/>
 	</group>
 </terminology>

--- a/openehr-terminology/src/main/resources/openEHR_RM/es/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/es/openehr_terminology.xml
@@ -24,11 +24,11 @@
         <code value="LL"/>
         <code value="LLL"/>
     </codeset>
-    <group name="attestation reason">
+    <group name="attestation reason" id="attestation reason">
         <concept id="240" rubric="firmado"/>
         <concept id="648" rubric="testigo"/>
     </group>
-    <group name="audit change type">
+    <group name="audit change type" id="audit change type">
         <concept id="249" rubric="creación"/>
         <concept id="250" rubric="enmienda"/>
         <concept id="251" rubric="modificación"/>
@@ -37,13 +37,12 @@
         <concept id="666" rubric="testimonio"/>
         <concept id="253" rubric="desconocido"/>
     </group>
-    <group name="composition category">
+    <group name="composition category" id="composition category">
         <concept id="431" rubric="persistente"/>
         <concept id="451" rubric="episódico"/>
         <concept id="433" rubric="evento"/>
     </group>
-    <!--
-    <group name="MultiMedia">
+    <group name="MultiMedia" id="MultiMedia">
         <concept id="387" rubric="audio/DVI4" />
         <concept id="388" rubric="audio/G722" />
         <concept id="389" rubric="audio/G723" />
@@ -94,8 +93,7 @@
         <concept id="682" rubric="application/vnd.oasis.opendocument.text" />
         <concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
     </group>
-    -->
-    <group name="property">
+    <group name="property" id="property">
         <concept id="339" rubric="Aceleración"/>
         <concept id="342" rubric="Aceleración, angular"/>
         <concept id="381" rubric="Cantidad (equivalente)"/>
@@ -173,23 +171,23 @@
         <concept id="130" rubric="Trabajo"/>
         <concept id="685" rubric="Poder refractivo"/>
     </group>
-    <group name="version lifecycle state">
+    <group name="version lifecycle state" id="version lifecycle state">
         <concept id="532" rubric="completo"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->
         <concept id="553" rubric="incompleto"/>
         <concept id="523" rubric="eliminado"/>
         <concept id="800" rubric="*inactive(en)"/>
         <concept id="801" rubric="*abandoned(en)"/>
     </group>
-    <group name="participation function">
+    <group name="participation function" id="participation function">
         <concept id="253" rubric="desconocido"/>
     </group>
-    <group name="null flavours">
+    <group name="null flavours" id="null flavours">
         <concept id="271" rubric="sin información"/>
         <concept id="253" rubric="desconocido"/>
         <concept id="272" rubric="oculto"/>
         <concept id="273" rubric="no aplica"/>
     </group>
-    <group name="participation mode">
+    <group name="participation mode" id="participation mode">
         <concept id="193" rubric="no especificado"/>
         <concept id="216" rubric="comunicación cara a cara"/>
         <concept id="223" rubric="comunicación cara a cara interpretada"/>
@@ -223,7 +221,7 @@
         <concept id="219" rubric="físicamente presente"/>
         <concept id="220" rubric="físicamente remoto"/>
     </group>
-    <group name="instruction states">
+    <group name="instruction states" id="instruction states">
         <concept id="524" rubric="inicial"/>
         <concept id="526" rubric="planificado"/>
         <concept id="527" rubric="postpuesto"/>
@@ -235,7 +233,7 @@
         <concept id="532" rubric="completado"/><!-- warning: the rubric for this concept is 'complete' in the 'version lifecycle state' group (known issue, see SPECPR-51) -->
         <concept id="533" rubric="expirado"/>
     </group>
-    <group name="instruction transitions">
+    <group name="instruction transitions" id="instruction transitions">
         <concept id="535" rubric="iniciar"/>
         <concept id="536" rubric="paso del plan"/>
         <concept id="537" rubric="postponer"/>
@@ -257,7 +255,7 @@
         <concept id="551" rubric="notificar completado"/>
         <concept id="552" rubric="notificar cancelado"/>
     </group>
-    <group name="subject relationship">
+    <group name="subject relationship" id="subject relationship">
         <concept id="0" rubric="sí mismo"/>
         <concept id="3" rubric="feto"/>
         <concept id="10" rubric="madre"/>
@@ -295,12 +293,12 @@
         <concept id="25" rubric="hermanastro o medio hermano"/>
         <concept id="26" rubric="hermanastra o media hermana"/>
     </group>
-    <group name="term mapping purpose">
+    <group name="term mapping purpose" id="term mapping purpose">
         <concept id="669" rubric="salud pública"/>
         <concept id="670" rubric="reembolso"/>
         <concept id="671" rubric="investigación"/>
     </group>
-    <group name="event math function">
+    <group name="event math function" id="event math function">
         <concept id="145" rubric="mínimo"/>
         <concept id="144" rubric="máximo"/>
         <concept id="267" rubric="modo"/>
@@ -313,7 +311,7 @@
         <concept id="522" rubric="incremento"/>
         <concept id="640" rubric="real"/>
     </group>
-    <group name="setting">
+    <group name="setting" id="setting">
         <concept id="225" rubric="hogar"/>
         <concept id="227" rubric="atención de emergencia"/>
         <concept id="228" rubric="atención médica primaria"/>
@@ -329,7 +327,7 @@
         <concept id="802" rubric="*mental healthcare(en)"/>
         <concept id="238" rubric="otros cuidados"/>
     </group>
-    <group name="extract content type">
+    <group name="extract content type" id="extract content type">
         <concept id="803" rubric="*openEHR EHR(en)"/>
         <concept id="804" rubric="*openEHR Demographic(en)"/>
         <concept id="805" rubric="*openEHR synchronisation(en)"/>
@@ -337,12 +335,12 @@
         <concept id="807" rubric="*generic EMR(en)"/>
         <concept id="808" rubric="*other(en)"/>
     </group>
-    <group name="extract action type">
+    <group name="extract action type" id="extract action type">
         <concept id="809" rubric="*cancel(en)"/>
         <concept id="810" rubric="*resend(en)"/>
         <concept id="811" rubric="*send new(en)"/>
     </group>
-    <group name="extract update trigger event type">
+    <group name="extract update trigger event type" id="extract update trigger event type">
         <concept id="812" rubric="*any change(en)"/>
         <concept id="813" rubric="*correction(en)"/>
         <concept id="814" rubric="*update(en)"/>

--- a/openehr-terminology/src/main/resources/openEHR_RM/es/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/es/openehr_terminology.xml
@@ -1,0 +1,350 @@
+<terminology name="openehr" language="es">
+    <codeset issuer="openehr" openehr_id="compression algorithms" external_id="openehr_compression_algorithms">
+		<code value="compress"/>
+		<code value="deflate"/>
+        <code value="gzip"/>
+        <code value="zlib"/>
+		<code value="other"/>
+    </codeset>
+    <codeset issuer="openehr" openehr_id="integrity check algorithms" external_id="openehr_integrity_check_algorithms">
+        <code value="SHA-1"/>
+		<code value="SHA-224"/>
+        <code value="SHA-256"/>
+		<code value="SHA-384"/>
+		<code value="SHA-512"/>
+		<code value="SHA-512/224"/>
+		<code value="SHA-512/256"/>
+    </codeset>
+    <codeset issuer="openehr" openehr_id="normal statuses" external_id="openehr_normal_statuses">
+        <code value="HHH"/>
+        <code value="HH"/>
+        <code value="H"/>
+        <code value="N"/>
+        <code value="L"/>
+        <code value="LL"/>
+        <code value="LLL"/>
+    </codeset>
+    <group name="attestation reason">
+        <concept id="240" rubric="firmado"/>
+        <concept id="648" rubric="testigo"/>
+    </group>
+    <group name="audit change type">
+        <concept id="249" rubric="creación"/>
+        <concept id="250" rubric="enmienda"/>
+        <concept id="251" rubric="modificación"/>
+        <concept id="252" rubric="síntesis"/>
+        <concept id="523" rubric="eliminado"/>
+        <concept id="666" rubric="testimonio"/>
+        <concept id="253" rubric="desconocido"/>
+    </group>
+    <group name="composition category">
+        <concept id="431" rubric="persistente"/>
+        <concept id="451" rubric="episódico"/>
+        <concept id="433" rubric="evento"/>
+    </group>
+    <!--
+    <group name="MultiMedia">
+        <concept id="387" rubric="audio/DVI4" />
+        <concept id="388" rubric="audio/G722" />
+        <concept id="389" rubric="audio/G723" />
+        <concept id="390" rubric="audio/G726-16" />
+        <concept id="391" rubric="audio/G726-24" />
+        <concept id="392" rubric="audio/G726-32" />
+        <concept id="393" rubric="audio/G726-40" />
+        <concept id="394" rubric="audio/G728" />
+        <concept id="395" rubric="audio/L8" />
+        <concept id="396" rubric="audio/L16" />
+        <concept id="397" rubric="audio/LPC" />
+        <concept id="398" rubric="audio/G729" />
+        <concept id="399" rubric="audio/G729D" />
+        <concept id="400" rubric="audio/G729E" />
+        <concept id="401" rubric="video/BT656" />
+        <concept id="402" rubric="video/CelB" />
+        <concept id="403" rubric="video/JPEG" />
+        <concept id="404" rubric="video/H261" />
+        <concept id="405" rubric="video/H263" />
+        <concept id="406" rubric="video/H263-1998" />
+        <concept id="407" rubric="video/H263-2000" />
+        <concept id="408" rubric="video/MPV" />
+        <concept id="409" rubric="audio/mpeg" />
+        <concept id="410" rubric="audio/mpeg4-generic" />
+        <concept id="411" rubric="audio/L20" />
+        <concept id="412" rubric="audio/L24" />
+        <concept id="413" rubric="audio/telephone-evento" />
+        <concept id="414" rubric="video/quicktime" />
+        <concept id="415" rubric="text/calendar" />
+        <concept id="416" rubric="text/directory" />
+        <concept id="417" rubric="text/html" />
+        <concept id="418" rubric="text/plain" />
+        <concept id="419" rubric="text/rtf" />
+        <concept id="420" rubric="text/sgml" />
+        <concept id="421" rubric="text/tab-separated-values" />
+        <concept id="422" rubric="text/uri-list" />
+        <concept id="423" rubric="text/xml" />
+        <concept id="424" rubric="text/xml-external-parsed-entity" />
+        <concept id="425" rubric="image/cgm" />
+        <concept id="426" rubric="image/gif" />
+        <concept id="427" rubric="image/png" />
+        <concept id="428" rubric="image/tiff" />
+        <concept id="429" rubric="image/jpeg" />
+        <concept id="517" rubric="application/msword" />
+        <concept id="518" rubric="application/pdf" />
+        <concept id="519" rubric="application/rtf" />
+        <concept id="637" rubric="application/dicom" />
+        <concept id="682" rubric="application/vnd.oasis.opendocument.text" />
+        <concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+    </group>
+    -->
+    <group name="property">
+        <concept id="339" rubric="Aceleración"/>
+        <concept id="342" rubric="Aceleración, angular"/>
+        <concept id="381" rubric="Cantidad (equivalente)"/>
+        <concept id="384" rubric="Cantidad (mol)"/>
+        <concept id="497" rubric="Ángulo, plano"/>
+        <concept id="500" rubric="Ángulo, sólido"/>
+        <concept id="335" rubric="Área"/>
+        <concept id="119" rubric="Concentración"/>
+        <concept id="350" rubric="Densidad"/>
+        <concept id="362" rubric="Coeficiente de difusión"/>
+        <concept id="501" rubric="Capacidad eléctrica"/>
+        <concept id="498" rubric="Carga eléctrica"/>
+        <concept id="502" rubric="Conductancia eléctrica"/>
+        <concept id="334" rubric="Corriente eléctrica"/>
+        <concept id="377" rubric="Intensidad del campo eléctrico"/>
+        <concept id="655" rubric="Potencial eléctrico"/>
+        <concept id="121" rubric="Energía"/>
+        <concept id="366" rubric="Densidad de energía"/>
+        <concept id="508" rubric="Dosis de energía"/>
+        <concept id="365" rubric="Energía por área"/>
+        <concept id="364" rubric="Energía, lineal"/>
+        <concept id="347" rubric="Caudal, masa"/>
+        <concept id="352" rubric="Caudal, masa/fuerza"/>
+        <concept id="351" rubric="Caudal, amsa/volumen"/>
+        <concept id="126" rubric="Caudal, volumen"/>
+        <concept id="348" rubric="Flujo, masa"/>
+        <concept id="355" rubric="Fuerza"/>
+        <concept id="358" rubric="Fuerza por masa"/>
+        <concept id="357" rubric="Fuerza, cuerpo"/>
+        <concept id="382" rubric="Frecuencia"/>
+        <concept id="586" rubric="Tasa de filtración glomerular"/>
+        <concept id="373" rubric="Coeficiente de transferencia de calor"/>
+        <concept id="505" rubric="Iluminancia"/>
+        <concept id="379" rubric="Inductancia"/>
+        <concept id="122" rubric="Longitud"/>
+        <concept id="499" rubric="Intensidad de luz"/>
+        <concept id="123" rubric="Volumen sonoro"/>
+        <concept id="504" rubric="Flujo luminoso"/>
+        <concept id="378" rubric="Flujo magnético"/>
+        <concept id="503" rubric="Densidad de flujo magnético"/>
+        <concept id="124" rubric="Masa"/>
+        <concept id="385" rubric="Masa (IU)"/>
+        <concept id="445" rubric="Masa (Unidades)"/>
+        <concept id="349" rubric="Masa por área"/>
+        <concept id="344" rubric="Momento de inercia, área"/>
+        <concept id="345" rubric="Momento de inercia, masa"/>
+        <concept id="340" rubric="Impulso"/>
+        <concept id="346" rubric="Impulso, caudal"/>
+        <concept id="343" rubric="Impulso, angular"/>
+        <concept id="363" rubric="Potencia"/>
+        <concept id="369" rubric="Densidad de potencia"/>
+        <concept id="368" rubric="Flujo de potencia"/>
+        <concept id="367" rubric="Potencia, lineal"/>
+        <concept id="125" rubric="Presión"/>
+        <concept id="507" rubric="Proporción"/>
+        <concept id="380" rubric="Real calificado"/>
+        <concept id="506" rubric="Radioactividad"/>
+        <concept id="375" rubric="Resistencia"/>
+        <concept id="370" rubric="Energía específica"/>
+        <concept id="371" rubric="Calor específico, constante de gas"/>
+        <concept id="337" rubric="Superficie específica"/>
+        <concept id="336" rubric="Volumen específico"/>
+        <concept id="354" rubric="Peso específico"/>
+        <concept id="356" rubric="Tensión superficial"/>
+        <concept id="127" rubric="Temperatura"/>
+        <concept id="372" rubric="Conductividad térmica"/>
+        <concept id="128" rubric="Tiempo"/>
+        <concept id="359" rubric="Torque"/>
+        <concept id="338" rubric="Velocidad"/>
+        <concept id="341" rubric="Velocidad, angular"/>
+        <concept id="360" rubric="Velocidad, dinámica"/>
+        <concept id="361" rubric="Velocidad, cinemática"/>
+        <concept id="374" rubric="Voltaje, eléctrico"/>
+        <concept id="129" rubric="Volumen"/>
+        <concept id="130" rubric="Trabajo"/>
+        <concept id="685" rubric="Poder refractivo"/>
+    </group>
+    <group name="version lifecycle state">
+        <concept id="532" rubric="completo"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->
+        <concept id="553" rubric="incompleto"/>
+        <concept id="523" rubric="eliminado"/>
+        <concept id="800" rubric="*inactive(en)"/>
+        <concept id="801" rubric="*abandoned(en)"/>
+    </group>
+    <group name="participation function">
+        <concept id="253" rubric="desconocido"/>
+    </group>
+    <group name="null flavours">
+        <concept id="271" rubric="sin información"/>
+        <concept id="253" rubric="desconocido"/>
+        <concept id="272" rubric="oculto"/>
+        <concept id="273" rubric="no aplica"/>
+    </group>
+    <group name="participation mode">
+        <concept id="193" rubric="no especificado"/>
+        <concept id="216" rubric="comunicación cara a cara"/>
+        <concept id="223" rubric="comunicación cara a cara interpretada"/>
+        <concept id="217" rubric="firma (cara a cara)"/>
+        <concept id="195" rubric="audiovisuales en vivo; video conferencia; video llamada"/>
+        <concept id="198" rubric="video conferencia"/>
+        <concept id="197" rubric="video llamada"/>
+        <concept id="218" rubric="firma sobre video"/>
+        <concept id="224" rubric="comunicación por video interpretada"/>
+        <concept id="194" rubric="audiovisual asíncrona; video grabado"/>
+        <concept id="196" rubric="video grabado"/>
+        <concept id="202" rubric="sólo audio en vivo; teléfono; teléfono de internet; tele-conferencia"/>
+        <concept id="204" rubric="teléfono"/>
+        <concept id="203" rubric="tele-conferencia"/>
+        <concept id="205" rubric="teléfono de internet"/>
+        <concept id="222" rubric="sólo audio interpretado"/>
+        <concept id="199" rubric="sólo audio asíncrono; dictado; correo de voz"/>
+        <concept id="200" rubric="dictado"/>
+        <concept id="201" rubric="correo de voz"/>
+        <concept id="212" rubric="sólo texto en vivo; charla de texto por internet; charla por SMS; nota escrita interactiva"/>
+        <concept id="213" rubric="charla (texto) por internet"/>
+        <concept id="214" rubric="charla por SMS"/>
+        <concept id="215" rubric="nota escrita interactiva"/>
+        <concept id="206" rubric="texto asíncrono; correo electrónico; fax; carta; nota manuscrita; mensaje SMS"/>
+        <concept id="211" rubric="nota manuscrita"/>
+        <concept id="210" rubric="carta impresa/escrita"/>
+        <concept id="207" rubric="correo electrónico"/>
+        <concept id="208" rubric="facsímil/telefax"/>
+        <concept id="221" rubric="texto traducido"/>
+        <concept id="209" rubric="mensajería SMS"/>
+        <concept id="219" rubric="físicamente presente"/>
+        <concept id="220" rubric="físicamente remoto"/>
+    </group>
+    <group name="instruction states">
+        <concept id="524" rubric="inicial"/>
+        <concept id="526" rubric="planificado"/>
+        <concept id="527" rubric="postpuesto"/>
+        <concept id="528" rubric="cancelado"/>
+        <concept id="529" rubric="coordinado"/>
+        <concept id="245" rubric="activo"/>
+        <concept id="530" rubric="suspendido"/>
+        <concept id="531" rubric="abortado"/>
+        <concept id="532" rubric="completado"/><!-- warning: the rubric for this concept is 'complete' in the 'version lifecycle state' group (known issue, see SPECPR-51) -->
+        <concept id="533" rubric="expirado"/>
+    </group>
+    <group name="instruction transitions">
+        <concept id="535" rubric="iniciar"/>
+        <concept id="536" rubric="paso del plan"/>
+        <concept id="537" rubric="postponer"/>
+        <concept id="538" rubric="restaurar"/>
+        <concept id="166" rubric="cancelar"/>
+        <concept id="542" rubric="paso postpuesto"/>
+        <concept id="539" rubric="coordinar"/>
+        <concept id="534" rubric="paso coordinado"/>
+        <concept id="540" rubric="comienzar"/>
+        <concept id="541" rubric="realizar"/>
+        <concept id="543" rubric="paso activo"/>
+        <concept id="544" rubric="suspender"/>
+        <concept id="545" rubric="paso suspendido"/>
+        <concept id="546" rubric="reanudar"/>
+        <concept id="547" rubric="abortar"/>
+        <concept id="548" rubric="terminar"/>
+        <concept id="549" rubric="se acabó el tiempo"/>
+        <concept id="550" rubric="notificar abortado"/>
+        <concept id="551" rubric="notificar completado"/>
+        <concept id="552" rubric="notificar cancelado"/>
+    </group>
+    <group name="subject relationship">
+        <concept id="0" rubric="sí mismo"/>
+        <concept id="3" rubric="feto"/>
+        <concept id="10" rubric="madre"/>
+        <concept id="9" rubric="padre"/>
+        <concept id="6" rubric="donante"/>
+        <concept id="253" rubric="desconocido"/>
+        <concept id="261" rubric="hija adoptiva"/>
+        <concept id="260" rubric="hijo adoptivo"/>
+        <concept id="259" rubric="padre adoptivo"/>
+        <concept id="258" rubric="madre adoptiva"/>
+        <concept id="256" rubric="padre biológico"/>
+        <concept id="255" rubric="madre biológica"/>
+        <concept id="23" rubric="hermano"/>
+        <concept id="28" rubric="niño"/>
+        <concept id="265" rubric="cohabitante"/>
+        <concept id="257" rubric="primo"/>
+        <concept id="29" rubric="hija"/>
+        <concept id="264" rubric="guardián"/>
+        <concept id="39" rubric="tía materna"/>
+        <concept id="8" rubric="abuelo materno"/>
+        <concept id="7" rubric="abuela materna"/>
+        <concept id="38" rubric="tío materno"/>
+        <concept id="189" rubric="neonato"/>
+        <concept id="254" rubric="padre"/>
+        <concept id="22" rubric="compañero/esposo"/>
+        <concept id="41" rubric="tía paterna"/>
+        <concept id="36" rubric="abuelo paterno"/>
+        <concept id="37" rubric="abuela paterna"/>
+        <concept id="40" rubric="tío paterno"/>
+        <concept id="27" rubric="hermano"/>
+        <concept id="24" rubric="hermana"/>
+        <concept id="31" rubric="hijo"/>
+        <concept id="263" rubric="padrastro"/>
+        <concept id="262" rubric="madrastra"/>
+        <concept id="25" rubric="hermanastro o medio hermano"/>
+        <concept id="26" rubric="hermanastra o media hermana"/>
+    </group>
+    <group name="term mapping purpose">
+        <concept id="669" rubric="salud pública"/>
+        <concept id="670" rubric="reembolso"/>
+        <concept id="671" rubric="investigación"/>
+    </group>
+    <group name="event math function">
+        <concept id="145" rubric="mínimo"/>
+        <concept id="144" rubric="máximo"/>
+        <concept id="267" rubric="modo"/>
+        <concept id="268" rubric="mediana"/>
+        <concept id="146" rubric="media"/>
+        <concept id="147" rubric="cambio"/>
+        <concept id="148" rubric="total"/>
+        <concept id="149" rubric="variación"/>
+        <concept id="521" rubric="disminución"/>
+        <concept id="522" rubric="incremento"/>
+        <concept id="640" rubric="real"/>
+    </group>
+    <group name="setting">
+        <concept id="225" rubric="hogar"/>
+        <concept id="227" rubric="atención de emergencia"/>
+        <concept id="228" rubric="atención médica primaria"/>
+        <concept id="229" rubric="atención primaria de enfermería"/>
+        <concept id="230" rubric="atención primaria de trabajadores de la salud"/>
+        <concept id="231" rubric="atención de partera"/>
+        <concept id="232" rubric="atención médica secundaria"/>
+        <concept id="233" rubric="atención secundaria de enfermería"/>
+        <concept id="234" rubric="atención secundaria de trabajadores de la salud"/>
+        <concept id="235" rubric="atención complementaria"/>
+        <concept id="236" rubric="atención dental"/>
+        <concept id="237" rubric="atención en casa de salud"/>
+        <concept id="802" rubric="*mental healthcare(en)"/>
+        <concept id="238" rubric="otros cuidados"/>
+    </group>
+    <group name="extract content type">
+        <concept id="803" rubric="*openEHR EHR(en)"/>
+        <concept id="804" rubric="*openEHR Demographic(en)"/>
+        <concept id="805" rubric="*openEHR synchronisation(en)"/>
+        <concept id="806" rubric="*openEHR generic(en)"/>
+        <concept id="807" rubric="*generic EMR(en)"/>
+        <concept id="808" rubric="*other(en)"/>
+    </group>
+    <group name="extract action type">
+        <concept id="809" rubric="*cancel(en)"/>
+        <concept id="810" rubric="*resend(en)"/>
+        <concept id="811" rubric="*send new(en)"/>
+    </group>
+    <group name="extract update trigger event type">
+        <concept id="812" rubric="*any change(en)"/>
+        <concept id="813" rubric="*correction(en)"/>
+        <concept id="814" rubric="*update(en)"/>
+    </group>
+</terminology>

--- a/openehr-terminology/src/main/resources/openEHR_RM/fullTermFile.json
+++ b/openehr-terminology/src/main/resources/openEHR_RM/fullTermFile.json
@@ -17,6 +17,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
+              "codeString" : "compress",
+              "description" : "compress",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "pt" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "pt",
@@ -39,6 +47,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
+              "codeString" : "deflate",
+              "description" : "deflate",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "pt" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "pt",
@@ -56,6 +72,14 @@
             "en" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "en",
+              "codeString" : "gzip",
+              "description" : "gzip",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
               "codeString" : "gzip",
               "description" : "gzip",
               "groupName" : null,
@@ -91,6 +115,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
+              "codeString" : "zlib",
+              "description" : "zlib",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "ja",
@@ -116,6 +148,14 @@
             "en" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "en",
+              "codeString" : "other",
+              "description" : "other",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
               "codeString" : "other",
               "description" : "other",
               "groupName" : null,
@@ -192,6 +232,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-1",
+              "description" : "SHA-1",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_integrity_check_algorithms",
               "language" : "ja",
@@ -210,6 +258,44 @@
             }
           }
         },
+        "SHA-224" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-224",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "SHA-256" : {
           "terminologyId" : "openehr_integrity_check_algorithms",
           "termId" : "SHA-256",
@@ -217,6 +303,14 @@
             "en" : {
               "terminologyId" : "openehr_integrity_check_algorithms",
               "language" : "en",
+              "codeString" : "SHA-256",
+              "description" : "SHA-256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
               "codeString" : "SHA-256",
               "description" : "SHA-256",
               "groupName" : null,
@@ -235,6 +329,158 @@
               "language" : "pt",
               "codeString" : "SHA-256",
               "description" : "SHA-256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-384" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-384",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-512" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-512",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-512/224" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-512/224",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-512/256" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-512/256",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -254,6 +500,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "HHH",
+              "description" : "HHH",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "HHH",
               "description" : "HHH",
               "groupName" : null,
@@ -289,6 +543,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
+              "codeString" : "HH",
+              "description" : "HH",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "ja",
@@ -314,6 +576,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "H",
+              "description" : "H",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "H",
               "description" : "H",
               "groupName" : null,
@@ -349,6 +619,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
+              "codeString" : "N",
+              "description" : "N",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "ja",
@@ -374,6 +652,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "L",
+              "description" : "L",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "L",
               "description" : "L",
               "groupName" : null,
@@ -409,6 +695,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
+              "codeString" : "LL",
+              "description" : "LL",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "ja",
@@ -434,6 +728,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "LLL",
+              "description" : "LLL",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "LLL",
               "description" : "LLL",
               "groupName" : null,
@@ -476,6 +778,14 @@
               "groupName" : "attestation reason",
               "groupIds" : [ "attestation reason" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "240",
+              "description" : "firmado",
+              "groupName" : "attestation reason",
+              "groupIds" : [ "attestation reason" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -503,6 +813,14 @@
               "language" : "en",
               "codeString" : "648",
               "description" : "witnessed",
+              "groupName" : "attestation reason",
+              "groupIds" : [ "attestation reason" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "648",
+              "description" : "testigo",
               "groupName" : "attestation reason",
               "groupIds" : [ "attestation reason" ]
             },
@@ -536,6 +854,14 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "249",
+              "description" : "creación",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -563,6 +889,14 @@
               "language" : "en",
               "codeString" : "250",
               "description" : "amendment",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "250",
+              "description" : "enmienda",
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
@@ -596,6 +930,14 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "251",
+              "description" : "modificación",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -623,6 +965,14 @@
               "language" : "en",
               "codeString" : "252",
               "description" : "synthesis",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "252",
+              "description" : "síntesis",
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
@@ -656,6 +1006,14 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type", "version lifecycle state" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "523",
+              "description" : "eliminado",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type", "version lifecycle state" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -683,6 +1041,14 @@
               "language" : "en",
               "codeString" : "666",
               "description" : "attestation",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "666",
+              "description" : "testimonio",
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
@@ -716,13 +1082,21 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "253",
+              "description" : "desconocido",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "253",
               "description" : "不明",
               "groupName" : "監査変更種別",
-              "groupIds" : [ "audit change type", "participation function", "subject relationships", "null flavours" ]
+              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -746,6 +1120,14 @@
               "groupName" : "composition category",
               "groupIds" : [ "composition category" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "431",
+              "description" : "persistente",
+              "groupName" : "composition category",
+              "groupIds" : [ "composition category" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -764,22 +1146,30 @@
             }
           }
         },
-        "435" : {
+        "451" : {
           "terminologyId" : "openehr",
-          "termId" : "435",
+          "termId" : "451",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
-              "codeString" : "435",
+              "codeString" : "451",
               "description" : "episodic",
+              "groupName" : "composition category",
+              "groupIds" : [ "composition category" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "451",
+              "description" : "episódico",
               "groupName" : "composition category",
               "groupIds" : [ "composition category" ]
             },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
-              "codeString" : "435",
+              "codeString" : "451",
               "description" : "*episodic(en)",
               "groupName" : "コンポジションカテゴリ",
               "groupIds" : [ "composition category" ]
@@ -787,7 +1177,7 @@
             "pt" : {
               "terminologyId" : "openehr",
               "language" : "pt",
-              "codeString" : "435",
+              "codeString" : "451",
               "description" : "*episodic(en)",
               "groupName" : "categoria de composição",
               "groupIds" : [ "composition category" ]
@@ -803,6 +1193,14 @@
               "language" : "en",
               "codeString" : "433",
               "description" : "event",
+              "groupName" : "composition category",
+              "groupIds" : [ "composition category" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "433",
+              "description" : "evento",
               "groupName" : "composition category",
               "groupIds" : [ "composition category" ]
             },
@@ -831,6 +1229,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "387",
+              "description" : "audio/DVI4",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "387",
               "description" : "audio/DVI4",
               "groupName" : "MultiMedia",
@@ -866,6 +1272,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "388",
+              "description" : "audio/G722",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -891,6 +1305,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "389",
+              "description" : "audio/G723",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "389",
               "description" : "audio/G723",
               "groupName" : "MultiMedia",
@@ -926,6 +1348,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "390",
+              "description" : "audio/G726-16",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -951,6 +1381,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "391",
+              "description" : "audio/G726-24",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "391",
               "description" : "audio/G726-24",
               "groupName" : "MultiMedia",
@@ -986,6 +1424,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "392",
+              "description" : "audio/G726-32",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1011,6 +1457,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "393",
+              "description" : "audio/G726-40",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "393",
               "description" : "audio/G726-40",
               "groupName" : "MultiMedia",
@@ -1046,6 +1500,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "394",
+              "description" : "audio/G728",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1071,6 +1533,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "395",
+              "description" : "audio/L8",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "395",
               "description" : "audio/L8",
               "groupName" : "MultiMedia",
@@ -1106,6 +1576,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "396",
+              "description" : "audio/L16",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1131,6 +1609,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "397",
+              "description" : "audio/LPC",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "397",
               "description" : "audio/LPC",
               "groupName" : "MultiMedia",
@@ -1166,6 +1652,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "398",
+              "description" : "audio/G729",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1191,6 +1685,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "399",
+              "description" : "audio/G729D",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "399",
               "description" : "audio/G729D",
               "groupName" : "MultiMedia",
@@ -1226,6 +1728,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "400",
+              "description" : "audio/G729E",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1251,6 +1761,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "401",
+              "description" : "video/BT656",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "401",
               "description" : "video/BT656",
               "groupName" : "MultiMedia",
@@ -1286,6 +1804,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "402",
+              "description" : "video/CelB",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1311,6 +1837,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "403",
+              "description" : "video/JPEG",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "403",
               "description" : "video/JPEG",
               "groupName" : "MultiMedia",
@@ -1346,6 +1880,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "404",
+              "description" : "video/H261",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1371,6 +1913,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "405",
+              "description" : "video/H263",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "405",
               "description" : "video/H263",
               "groupName" : "MultiMedia",
@@ -1406,6 +1956,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "406",
+              "description" : "video/H263-1998",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1431,6 +1989,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "407",
+              "description" : "video/H263-2000",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "407",
               "description" : "video/H263-2000",
               "groupName" : "MultiMedia",
@@ -1466,6 +2032,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "408",
+              "description" : "video/MPV",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1491,6 +2065,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "409",
+              "description" : "audio/mpeg",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "409",
               "description" : "audio/mpeg",
               "groupName" : "MultiMedia",
@@ -1526,6 +2108,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "410",
+              "description" : "audio/mpeg4-generic",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1551,6 +2141,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "411",
+              "description" : "audio/L20",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "411",
               "description" : "audio/L20",
               "groupName" : "MultiMedia",
@@ -1586,6 +2184,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "412",
+              "description" : "audio/L24",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1616,6 +2222,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "413",
+              "description" : "audio/telephone-evento",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1641,6 +2255,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "414",
+              "description" : "video/quicktime",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "414",
               "description" : "video/quicktime",
               "groupName" : "MultiMedia",
@@ -1676,6 +2298,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "415",
+              "description" : "text/calendar",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1701,6 +2331,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "416",
+              "description" : "text/directory",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "416",
               "description" : "text/directory",
               "groupName" : "MultiMedia",
@@ -1736,6 +2374,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "417",
+              "description" : "text/html",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1761,6 +2407,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "418",
+              "description" : "text/plain",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "418",
               "description" : "text/plain",
               "groupName" : "MultiMedia",
@@ -1796,6 +2450,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "419",
+              "description" : "text/rtf",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1821,6 +2483,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "420",
+              "description" : "text/sgml",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "420",
               "description" : "text/sgml",
               "groupName" : "MultiMedia",
@@ -1856,6 +2526,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "421",
+              "description" : "text/tab-separated-values",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1881,6 +2559,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "422",
+              "description" : "text/uri-list",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "422",
               "description" : "text/uri-list",
               "groupName" : "MultiMedia",
@@ -1916,6 +2602,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "423",
+              "description" : "text/xml",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -1941,6 +2635,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "424",
+              "description" : "text/xml-external-parsed-entity",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "424",
               "description" : "text/xml-external-parsed-entity",
               "groupName" : "MultiMedia",
@@ -1976,6 +2678,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "425",
+              "description" : "image/cgm",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2001,6 +2711,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "426",
+              "description" : "image/gif",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "426",
               "description" : "image/gif",
               "groupName" : "MultiMedia",
@@ -2036,6 +2754,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "427",
+              "description" : "image/png",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2061,6 +2787,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "428",
+              "description" : "image/tiff",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "428",
               "description" : "image/tiff",
               "groupName" : "MultiMedia",
@@ -2096,6 +2830,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "429",
+              "description" : "image/jpeg",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2121,6 +2863,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "517",
+              "description" : "application/msword",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "517",
               "description" : "application/msword",
               "groupName" : "MultiMedia",
@@ -2156,6 +2906,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "518",
+              "description" : "application/pdf",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2181,6 +2939,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "519",
+              "description" : "application/rtf",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "519",
               "description" : "application/rtf",
               "groupName" : "MultiMedia",
@@ -2216,6 +2982,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "637",
+              "description" : "application/dicom",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2241,6 +3015,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "682",
+              "description" : "application/vnd.oasis.opendocument.text",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "682",
               "description" : "application/vnd.oasis.opendocument.text",
               "groupName" : "MultiMedia",
@@ -2276,6 +3058,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "683",
+              "description" : "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2303,6 +3093,14 @@
               "language" : "en",
               "codeString" : "339",
               "description" : "Acceleration",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "339",
+              "description" : "Aceleración",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2336,6 +3134,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "342",
+              "description" : "Aceleración, angular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2363,6 +3169,14 @@
               "language" : "en",
               "codeString" : "381",
               "description" : "Amount (Eq)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "381",
+              "description" : "Cantidad (equivalente)",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2396,6 +3210,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "384",
+              "description" : "Cantidad (mol)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2423,6 +3245,14 @@
               "language" : "en",
               "codeString" : "497",
               "description" : "Angle, plane",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "497",
+              "description" : "Ángulo, plano",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2456,6 +3286,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "500",
+              "description" : "Ángulo, sólido",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2483,6 +3321,14 @@
               "language" : "en",
               "codeString" : "335",
               "description" : "Area",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "335",
+              "description" : "Área",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2516,6 +3362,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "119",
+              "description" : "Concentración",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2543,6 +3397,14 @@
               "language" : "en",
               "codeString" : "350",
               "description" : "Density",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "350",
+              "description" : "Densidad",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2576,6 +3438,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "362",
+              "description" : "Coeficiente de difusión",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2602,7 +3472,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "501",
-              "description" : "Electrical capacitance",
+              "description" : "Electric capacitance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "501",
+              "description" : "Capacidad eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2632,7 +3510,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "498",
-              "description" : "Electrical charge",
+              "description" : "Electric charge",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "498",
+              "description" : "Carga eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2662,7 +3548,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "502",
-              "description" : "Electrical conductance",
+              "description" : "Electric conductance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "502",
+              "description" : "Conductancia eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2692,7 +3586,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "334",
-              "description" : "Electrical current",
+              "description" : "Electric current",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "334",
+              "description" : "Corriente eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2722,7 +3624,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "377",
-              "description" : "Electrical field strength",
+              "description" : "Electric field strength",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "377",
+              "description" : "Intensidad del campo eléctrico",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2752,7 +3662,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "655",
-              "description" : "Electrical potential time",
+              "description" : "Electric potential",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "655",
+              "description" : "Potencial eléctrico",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2786,6 +3704,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "121",
+              "description" : "Energía",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2813,6 +3739,14 @@
               "language" : "en",
               "codeString" : "366",
               "description" : "Energy density",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "366",
+              "description" : "Densidad de energía",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2846,6 +3780,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "508",
+              "description" : "Dosis de energía",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2873,6 +3815,14 @@
               "language" : "en",
               "codeString" : "365",
               "description" : "Energy per area",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "365",
+              "description" : "Energía por área",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2906,6 +3856,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "364",
+              "description" : "Energía, lineal",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2933,6 +3891,14 @@
               "language" : "en",
               "codeString" : "347",
               "description" : "Flow rate, mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "347",
+              "description" : "Caudal, masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -2966,6 +3932,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "352",
+              "description" : "Caudal, masa/fuerza",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -2993,6 +3967,14 @@
               "language" : "en",
               "codeString" : "351",
               "description" : "Flow rate, mass/volume",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "351",
+              "description" : "Caudal, amsa/volumen",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3026,6 +4008,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "126",
+              "description" : "Caudal, volumen",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3053,6 +4043,14 @@
               "language" : "en",
               "codeString" : "348",
               "description" : "Flux, mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "348",
+              "description" : "Flujo, masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3086,6 +4084,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "355",
+              "description" : "Fuerza",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3113,6 +4119,14 @@
               "language" : "en",
               "codeString" : "358",
               "description" : "Force per mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "358",
+              "description" : "Fuerza por masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3146,6 +4160,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "357",
+              "description" : "Fuerza, cuerpo",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3173,6 +4195,14 @@
               "language" : "en",
               "codeString" : "382",
               "description" : "Frequency",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "382",
+              "description" : "Frecuencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3206,6 +4236,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "586",
+              "description" : "Tasa de filtración glomerular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3233,6 +4271,14 @@
               "language" : "en",
               "codeString" : "373",
               "description" : "Heat transfer coefficient",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "373",
+              "description" : "Coeficiente de transferencia de calor",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3266,6 +4312,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "505",
+              "description" : "Iluminancia",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3293,6 +4347,14 @@
               "language" : "en",
               "codeString" : "379",
               "description" : "Inductance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "379",
+              "description" : "Inductancia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3326,6 +4388,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "122",
+              "description" : "Longitud",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3353,6 +4423,14 @@
               "language" : "en",
               "codeString" : "499",
               "description" : "Light intensity",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "499",
+              "description" : "Intensidad de luz",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3386,6 +4464,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "123",
+              "description" : "Volumen sonoro",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3413,6 +4499,14 @@
               "language" : "en",
               "codeString" : "504",
               "description" : "Luminous flux",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "504",
+              "description" : "Flujo luminoso",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3446,6 +4540,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "378",
+              "description" : "Flujo magnético",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3473,6 +4575,14 @@
               "language" : "en",
               "codeString" : "503",
               "description" : "Magnetic flux density",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "503",
+              "description" : "Densidad de flujo magnético",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3506,6 +4616,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "124",
+              "description" : "Masa",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3533,6 +4651,14 @@
               "language" : "en",
               "codeString" : "385",
               "description" : "Mass (IU)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "385",
+              "description" : "Masa (IU)",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3566,6 +4692,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "445",
+              "description" : "Masa (Unidades)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3593,6 +4727,14 @@
               "language" : "en",
               "codeString" : "349",
               "description" : "Mass per area",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "349",
+              "description" : "Masa por área",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3626,6 +4768,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "344",
+              "description" : "Momento de inercia, área",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3653,6 +4803,14 @@
               "language" : "en",
               "codeString" : "345",
               "description" : "Moment inertia, mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "345",
+              "description" : "Momento de inercia, masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3686,6 +4844,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "340",
+              "description" : "Impulso",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3713,6 +4879,14 @@
               "language" : "en",
               "codeString" : "346",
               "description" : "Momentum, flow rate",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "346",
+              "description" : "Impulso, caudal",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3746,6 +4920,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "343",
+              "description" : "Impulso, angular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3773,6 +4955,14 @@
               "language" : "en",
               "codeString" : "363",
               "description" : "Power",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "363",
+              "description" : "Potencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3806,6 +4996,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "369",
+              "description" : "Densidad de potencia",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3833,6 +5031,14 @@
               "language" : "en",
               "codeString" : "368",
               "description" : "Power flux",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "368",
+              "description" : "Flujo de potencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3866,6 +5072,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "367",
+              "description" : "Potencia, lineal",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3893,6 +5107,14 @@
               "language" : "en",
               "codeString" : "125",
               "description" : "Pressure",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "125",
+              "description" : "Presión",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3926,6 +5148,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "507",
+              "description" : "Proporción",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -3953,6 +5183,14 @@
               "language" : "en",
               "codeString" : "380",
               "description" : "Qualified real",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "380",
+              "description" : "Real calificado",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -3986,6 +5224,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "506",
+              "description" : "Radioactividad",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4013,6 +5259,14 @@
               "language" : "en",
               "codeString" : "375",
               "description" : "Resistance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "375",
+              "description" : "Resistencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4046,6 +5300,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "370",
+              "description" : "Energía específica",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4073,6 +5335,14 @@
               "language" : "en",
               "codeString" : "371",
               "description" : "Specific heat, gas constant",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "371",
+              "description" : "Calor específico, constante de gas",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4106,6 +5376,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "337",
+              "description" : "Superficie específica",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4133,6 +5411,14 @@
               "language" : "en",
               "codeString" : "336",
               "description" : "Specific volume",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "336",
+              "description" : "Volumen específico",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4166,6 +5452,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "354",
+              "description" : "Peso específico",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4193,6 +5487,14 @@
               "language" : "en",
               "codeString" : "356",
               "description" : "Surface tension",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "356",
+              "description" : "Tensión superficial",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4226,6 +5528,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "127",
+              "description" : "Temperatura",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4253,6 +5563,14 @@
               "language" : "en",
               "codeString" : "372",
               "description" : "Thermal conductivity",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "372",
+              "description" : "Conductividad térmica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4286,6 +5604,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "128",
+              "description" : "Tiempo",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4311,6 +5637,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "359",
+              "description" : "Torque",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "359",
               "description" : "Torque",
               "groupName" : "property",
@@ -4346,6 +5680,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "338",
+              "description" : "Velocidad",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4373,6 +5715,14 @@
               "language" : "en",
               "codeString" : "341",
               "description" : "Velocity, angular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "341",
+              "description" : "Velocidad, angular",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4406,6 +5756,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "360",
+              "description" : "Velocidad, dinámica",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4433,6 +5791,14 @@
               "language" : "en",
               "codeString" : "361",
               "description" : "Velocity, kinematic",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "361",
+              "description" : "Velocidad, cinemática",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4466,6 +5832,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "374",
+              "description" : "Voltaje, eléctrico",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4493,6 +5867,14 @@
               "language" : "en",
               "codeString" : "129",
               "description" : "Volume",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "129",
+              "description" : "Volumen",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4526,6 +5908,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "130",
+              "description" : "Trabajo",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4553,6 +5943,14 @@
               "language" : "en",
               "codeString" : "685",
               "description" : "Refractive power",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "685",
+              "description" : "Poder refractivo",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -4586,6 +5984,14 @@
               "groupName" : "version lifecycle state",
               "groupIds" : [ "instruction states", "version lifecycle state" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "532",
+              "description" : "completo",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "instruction states", "version lifecycle state" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4616,6 +6022,14 @@
               "groupName" : "version lifecycle state",
               "groupIds" : [ "version lifecycle state" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "553",
+              "description" : "incompleto",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4634,6 +6048,82 @@
             }
           }
         },
+        "800" : {
+          "terminologyId" : "openehr",
+          "termId" : "800",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "800",
+              "description" : "inactive",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "800",
+              "description" : "*inactive(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "800",
+              "description" : "*inactive(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "800",
+              "description" : "*inactive(en)",
+              "groupName" : "estado de ciclo de vida de versão",
+              "groupIds" : [ "version lifecycle state" ]
+            }
+          }
+        },
+        "801" : {
+          "terminologyId" : "openehr",
+          "termId" : "801",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "801",
+              "description" : "abandoned",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "801",
+              "description" : "*abandoned(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "801",
+              "description" : "*abandoned(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "801",
+              "description" : "*abandoned(en)",
+              "groupName" : "estado de ciclo de vida de versão",
+              "groupIds" : [ "version lifecycle state" ]
+            }
+          }
+        },
         "271" : {
           "terminologyId" : "openehr",
           "termId" : "271",
@@ -4643,6 +6133,14 @@
               "language" : "en",
               "codeString" : "271",
               "description" : "no information",
+              "groupName" : "null flavours",
+              "groupIds" : [ "null flavours" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "271",
+              "description" : "sin información",
               "groupName" : "null flavours",
               "groupIds" : [ "null flavours" ]
             },
@@ -4676,6 +6174,14 @@
               "groupName" : "null flavours",
               "groupIds" : [ "null flavours" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "272",
+              "description" : "oculto",
+              "groupName" : "null flavours",
+              "groupIds" : [ "null flavours" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4703,6 +6209,14 @@
               "language" : "en",
               "codeString" : "273",
               "description" : "not applicable",
+              "groupName" : "null flavours",
+              "groupIds" : [ "null flavours" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "273",
+              "description" : "no aplica",
               "groupName" : "null flavours",
               "groupIds" : [ "null flavours" ]
             },
@@ -4736,6 +6250,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "193",
+              "description" : "no especificado",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4763,6 +6285,14 @@
               "language" : "en",
               "codeString" : "216",
               "description" : "face-to-face communication",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "216",
+              "description" : "comunicación cara a cara",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -4796,6 +6326,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "223",
+              "description" : "comunicación cara a cara interpretada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4823,6 +6361,14 @@
               "language" : "en",
               "codeString" : "217",
               "description" : "signing (face-to-face)",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "217",
+              "description" : "firma (cara a cara)",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -4856,6 +6402,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "195",
+              "description" : "audiovisuales en vivo; video conferencia; video llamada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4883,6 +6437,14 @@
               "language" : "en",
               "codeString" : "198",
               "description" : "videoconferencing",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "198",
+              "description" : "video conferencia",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -4916,6 +6478,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "197",
+              "description" : "video llamada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -4943,6 +6513,14 @@
               "language" : "en",
               "codeString" : "218",
               "description" : "signing over video",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "218",
+              "description" : "firma sobre video",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -4976,6 +6554,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "224",
+              "description" : "comunicación por video interpretada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5003,6 +6589,14 @@
               "language" : "en",
               "codeString" : "194",
               "description" : "asynchronous audiovisual; recorded video",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "194",
+              "description" : "audiovisual asíncrona; video grabado",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5036,6 +6630,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "196",
+              "description" : "video grabado",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5063,6 +6665,14 @@
               "language" : "en",
               "codeString" : "202",
               "description" : "live audio-only; telephone; internet phone; teleconference",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "202",
+              "description" : "sólo audio en vivo; teléfono; teléfono de internet; tele-conferencia",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5096,6 +6706,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "204",
+              "description" : "teléfono",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5123,6 +6741,14 @@
               "language" : "en",
               "codeString" : "203",
               "description" : "teleconference",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "203",
+              "description" : "tele-conferencia",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5156,6 +6782,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "205",
+              "description" : "teléfono de internet",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5183,6 +6817,14 @@
               "language" : "en",
               "codeString" : "222",
               "description" : "interpreted audio-only",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "222",
+              "description" : "sólo audio interpretado",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5216,6 +6858,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "199",
+              "description" : "sólo audio asíncrono; dictado; correo de voz",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5243,6 +6893,14 @@
               "language" : "en",
               "codeString" : "200",
               "description" : "dictated",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "200",
+              "description" : "dictado",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5276,6 +6934,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "201",
+              "description" : "correo de voz",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5303,6 +6969,14 @@
               "language" : "en",
               "codeString" : "212",
               "description" : "live text-only; internet chat; SMS chat; interactive written note",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "212",
+              "description" : "sólo texto en vivo; charla de texto por internet; charla por SMS; nota escrita interactiva",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5336,6 +7010,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "213",
+              "description" : "charla (texto) por internet",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5363,6 +7045,14 @@
               "language" : "en",
               "codeString" : "214",
               "description" : "SMS chat",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "214",
+              "description" : "charla por SMS",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5396,6 +7086,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "215",
+              "description" : "nota escrita interactiva",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5423,6 +7121,14 @@
               "language" : "en",
               "codeString" : "206",
               "description" : "asynchronous text; email; fax; letter; handwritten note; SMS message",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "206",
+              "description" : "texto asíncrono; correo electrónico; fax; carta; nota manuscrita; mensaje SMS",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5456,6 +7162,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "211",
+              "description" : "nota manuscrita",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5483,6 +7197,14 @@
               "language" : "en",
               "codeString" : "210",
               "description" : "printed/typed letter",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "210",
+              "description" : "carta impresa/escrita",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5516,6 +7238,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "207",
+              "description" : "correo electrónico",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5543,6 +7273,14 @@
               "language" : "en",
               "codeString" : "208",
               "description" : "facsimile/telefax",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "208",
+              "description" : "facsímil/telefax",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5576,6 +7314,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "221",
+              "description" : "texto traducido",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5603,6 +7349,14 @@
               "language" : "en",
               "codeString" : "209",
               "description" : "SMS message",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "209",
+              "description" : "mensajería SMS",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5636,6 +7390,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "219",
+              "description" : "físicamente presente",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5663,6 +7425,14 @@
               "language" : "en",
               "codeString" : "220",
               "description" : "physically remote",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "220",
+              "description" : "físicamente remoto",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -5696,6 +7466,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "524",
+              "description" : "inicial",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5723,6 +7501,14 @@
               "language" : "en",
               "codeString" : "526",
               "description" : "planned",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "526",
+              "description" : "planificado",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -5756,6 +7542,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "527",
+              "description" : "postpuesto",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5783,6 +7577,14 @@
               "language" : "en",
               "codeString" : "528",
               "description" : "cancelled",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "528",
+              "description" : "cancelado",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -5816,6 +7618,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "529",
+              "description" : "coordinado",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5843,6 +7653,14 @@
               "language" : "en",
               "codeString" : "245",
               "description" : "active",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "245",
+              "description" : "activo",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -5876,6 +7694,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "530",
+              "description" : "suspendido",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5903,6 +7729,14 @@
               "language" : "en",
               "codeString" : "531",
               "description" : "aborted",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "531",
+              "description" : "abortado",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -5936,6 +7770,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "533",
+              "description" : "expirado",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -5966,13 +7808,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "535",
+              "description" : "iniciar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "535",
               "description" : "新しく始める",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -5996,13 +7846,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "536",
+              "description" : "paso del plan",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "536",
               "description" : "ステップを計画する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6026,13 +7884,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "537",
+              "description" : "postponer",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "537",
               "description" : "延期する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6056,13 +7922,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "538",
+              "description" : "restaurar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "538",
               "description" : "元に戻す",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6086,13 +7960,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "166",
+              "description" : "cancelar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "166",
               "description" : "キャンセルする",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6116,13 +7998,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "542",
+              "description" : "paso postpuesto",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "542",
               "description" : "延期されたステップ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6146,13 +8036,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "539",
+              "description" : "coordinar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "539",
               "description" : "計画する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6176,13 +8074,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "534",
+              "description" : "paso coordinado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "534",
               "description" : "*scheduled step(en)",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6206,13 +8112,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "540",
+              "description" : "comienzar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "540",
               "description" : "開始する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6236,13 +8150,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "541",
+              "description" : "realizar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "541",
               "description" : "実施する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6266,13 +8188,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "543",
+              "description" : "paso activo",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "543",
               "description" : "実行中のステップ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6296,13 +8226,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "544",
+              "description" : "suspender",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "544",
               "description" : "中断する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6326,13 +8264,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "545",
+              "description" : "paso suspendido",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "545",
               "description" : "中断されたステップ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6356,13 +8302,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "546",
+              "description" : "reanudar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "546",
               "description" : "再開する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6386,13 +8340,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "547",
+              "description" : "abortar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "547",
               "description" : "中断する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6416,13 +8378,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "548",
+              "description" : "terminar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "548",
               "description" : "完了する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6446,13 +8416,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "549",
+              "description" : "se acabó el tiempo",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "549",
               "description" : "時間切れ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6476,13 +8454,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "550",
+              "description" : "notificar abortado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "550",
               "description" : "中断を知らせる",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6506,13 +8492,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "551",
+              "description" : "notificar completado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "551",
               "description" : "完了を知らせる",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6536,13 +8530,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "552",
+              "description" : "notificar cancelado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "552",
               "description" : "キャンセルを知らせる",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6566,13 +8568,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "0",
+              "description" : "sí mismo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "0",
               "description" : "自己",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6596,13 +8606,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "3",
+              "description" : "feto",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "3",
               "description" : "胎児",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6626,13 +8644,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "10",
+              "description" : "madre",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "10",
               "description" : "母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6656,13 +8682,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "9",
+              "description" : "padre",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "9",
               "description" : "父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6686,13 +8720,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "6",
+              "description" : "donante",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "6",
               "description" : "ドナー",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6716,13 +8758,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "261",
+              "description" : "hija adoptiva",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "261",
               "description" : "養女",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6746,13 +8796,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "260",
+              "description" : "hijo adoptivo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "260",
               "description" : "養子",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6776,13 +8834,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "259",
+              "description" : "padre adoptivo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "259",
               "description" : "養父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6806,13 +8872,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "258",
+              "description" : "madre adoptiva",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "258",
               "description" : "養母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6836,13 +8910,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "256",
+              "description" : "padre biológico",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "256",
               "description" : "生物学上の父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6866,13 +8948,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "255",
+              "description" : "madre biológica",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "255",
               "description" : "生物学上の母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6896,13 +8986,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "23",
+              "description" : "hermano",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "23",
               "description" : "兄弟",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6926,13 +9024,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "28",
+              "description" : "niño",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "28",
               "description" : "子",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6956,13 +9062,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "265",
+              "description" : "cohabitante",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "265",
               "description" : "同居者",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -6986,13 +9100,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "257",
+              "description" : "primo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "257",
               "description" : "従兄弟",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7016,13 +9138,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "29",
+              "description" : "hija",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "29",
               "description" : "娘",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7046,13 +9176,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "264",
+              "description" : "guardián",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "264",
               "description" : "保護者",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7076,13 +9214,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "39",
+              "description" : "tía materna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "39",
               "description" : "母方の叔母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7106,13 +9252,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "8",
+              "description" : "abuelo materno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "8",
               "description" : "母方",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7136,13 +9290,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "7",
+              "description" : "abuela materna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "7",
               "description" : "母型の",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7166,13 +9328,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "38",
+              "description" : "tío materno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "38",
               "description" : "母型の叔父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7196,13 +9366,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "189",
+              "description" : "neonato",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "189",
               "description" : "新生児",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7226,13 +9404,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "254",
+              "description" : "padre",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "254",
               "description" : "親",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7256,13 +9442,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "22",
+              "description" : "compañero/esposo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "22",
               "description" : "配偶者",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7286,13 +9480,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "41",
+              "description" : "tía paterna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "41",
               "description" : "父方の叔母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7316,13 +9518,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "36",
+              "description" : "abuelo paterno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "36",
               "description" : "父方の祖母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7346,13 +9556,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "37",
+              "description" : "abuela paterna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "37",
               "description" : "父方の祖-",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7376,13 +9594,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "40",
+              "description" : "tío paterno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "40",
               "description" : "父方の叔父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7406,13 +9632,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "27",
+              "description" : "hermano",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "27",
               "description" : "同胞",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7436,13 +9670,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "24",
+              "description" : "hermana",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "24",
               "description" : "姉妹",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7466,13 +9708,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "31",
+              "description" : "hijo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "31",
               "description" : "息子",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7496,13 +9746,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "263",
+              "description" : "padrastro",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "263",
               "description" : "義父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7526,13 +9784,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "262",
+              "description" : "madrastra",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "262",
               "description" : "義母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7556,13 +9822,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "25",
+              "description" : "hermanastro o medio hermano",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "25",
               "description" : "義理あるいは異父母兄弟",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7586,13 +9860,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "26",
+              "description" : "hermanastra o media hermana",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "26",
               "description" : "義理あるいは異父母姉妹",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -7613,6 +9895,14 @@
               "language" : "en",
               "codeString" : "669",
               "description" : "public health",
+              "groupName" : "term mapping purpose",
+              "groupIds" : [ "term mapping purpose" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "669",
+              "description" : "salud pública",
               "groupName" : "term mapping purpose",
               "groupIds" : [ "term mapping purpose" ]
             },
@@ -7646,6 +9936,14 @@
               "groupName" : "term mapping purpose",
               "groupIds" : [ "term mapping purpose" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "670",
+              "description" : "reembolso",
+              "groupName" : "term mapping purpose",
+              "groupIds" : [ "term mapping purpose" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -7673,6 +9971,14 @@
               "language" : "en",
               "codeString" : "671",
               "description" : "research study",
+              "groupName" : "term mapping purpose",
+              "groupIds" : [ "term mapping purpose" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "671",
+              "description" : "investigación",
               "groupName" : "term mapping purpose",
               "groupIds" : [ "term mapping purpose" ]
             },
@@ -7706,6 +10012,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "145",
+              "description" : "mínimo",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -7733,6 +10047,14 @@
               "language" : "en",
               "codeString" : "144",
               "description" : "maximum",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "144",
+              "description" : "máximo",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -7766,6 +10088,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "267",
+              "description" : "modo",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -7793,6 +10123,14 @@
               "language" : "en",
               "codeString" : "268",
               "description" : "median",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "268",
+              "description" : "mediana",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -7826,6 +10164,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "146",
+              "description" : "media",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -7856,6 +10202,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "147",
+              "description" : "cambio",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -7881,6 +10235,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "148",
+              "description" : "total",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "148",
               "description" : "total",
               "groupName" : "event math function",
@@ -7916,6 +10278,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "149",
+              "description" : "variación",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -7943,6 +10313,14 @@
               "language" : "en",
               "codeString" : "521",
               "description" : "decrease",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "521",
+              "description" : "disminución",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -7976,6 +10354,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "522",
+              "description" : "incremento",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8003,6 +10389,14 @@
               "language" : "en",
               "codeString" : "640",
               "description" : "actual",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "640",
+              "description" : "real",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -8036,6 +10430,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "225",
+              "description" : "hogar",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8063,6 +10465,14 @@
               "language" : "en",
               "codeString" : "227",
               "description" : "emergency care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "227",
+              "description" : "atención de emergencia",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -8096,6 +10506,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "228",
+              "description" : "atención médica primaria",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8123,6 +10541,14 @@
               "language" : "en",
               "codeString" : "229",
               "description" : "primary nursing care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "229",
+              "description" : "atención primaria de enfermería",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -8156,6 +10582,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "230",
+              "description" : "atención primaria de trabajadores de la salud",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8183,6 +10617,14 @@
               "language" : "en",
               "codeString" : "231",
               "description" : "midwifery care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "231",
+              "description" : "atención de partera",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -8216,6 +10658,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "232",
+              "description" : "atención médica secundaria",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8243,6 +10693,14 @@
               "language" : "en",
               "codeString" : "233",
               "description" : "secondary nursing care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "233",
+              "description" : "atención secundaria de enfermería",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -8276,6 +10734,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "234",
+              "description" : "atención secundaria de trabajadores de la salud",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8303,6 +10769,14 @@
               "language" : "en",
               "codeString" : "235",
               "description" : "complementary health care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "235",
+              "description" : "atención complementaria",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -8336,6 +10810,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "236",
+              "description" : "atención dental",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8366,6 +10848,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "237",
+              "description" : "atención en casa de salud",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -8384,6 +10874,44 @@
             }
           }
         },
+        "802" : {
+          "terminologyId" : "openehr",
+          "termId" : "802",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "802",
+              "description" : "mental healthcare",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "802",
+              "description" : "*mental healthcare(en)",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "802",
+              "description" : "*mental healthcare(en)",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "802",
+              "description" : "*mental healthcare(en)",
+              "groupName" : "configuração",
+              "groupIds" : [ "setting" ]
+            }
+          }
+        },
         "238" : {
           "terminologyId" : "openehr",
           "termId" : "238",
@@ -8393,6 +10921,14 @@
               "language" : "en",
               "codeString" : "238",
               "description" : "other care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "238",
+              "description" : "otros cuidados",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -8411,6 +10947,462 @@
               "description" : "outro cuidado",
               "groupName" : "configuração",
               "groupIds" : [ "setting" ]
+            }
+          }
+        },
+        "803" : {
+          "terminologyId" : "openehr",
+          "termId" : "803",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "803",
+              "description" : "openEHR EHR",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "803",
+              "description" : "*openEHR EHR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "803",
+              "description" : "*openEHR EHR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "803",
+              "description" : "*openEHR EHR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "804" : {
+          "terminologyId" : "openehr",
+          "termId" : "804",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "804",
+              "description" : "openEHR Demographic",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "804",
+              "description" : "*openEHR Demographic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "804",
+              "description" : "*openEHR Demographic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "804",
+              "description" : "*openEHR Demographic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "805" : {
+          "terminologyId" : "openehr",
+          "termId" : "805",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "805",
+              "description" : "openEHR synchronisation",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "805",
+              "description" : "*openEHR synchronisation(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "805",
+              "description" : "*openEHR synchronisation(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "805",
+              "description" : "*openEHR synchronisation(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "806" : {
+          "terminologyId" : "openehr",
+          "termId" : "806",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "806",
+              "description" : "openEHR generic",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "806",
+              "description" : "*openEHR generic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "806",
+              "description" : "*openEHR generic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "806",
+              "description" : "*openEHR generic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "807" : {
+          "terminologyId" : "openehr",
+          "termId" : "807",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "807",
+              "description" : "generic EMR",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "807",
+              "description" : "*generic EMR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "807",
+              "description" : "*generic EMR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "807",
+              "description" : "*generic EMR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "808" : {
+          "terminologyId" : "openehr",
+          "termId" : "808",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "808",
+              "description" : "other",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "808",
+              "description" : "*other(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "808",
+              "description" : "*other(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "808",
+              "description" : "*other(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "809" : {
+          "terminologyId" : "openehr",
+          "termId" : "809",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "809",
+              "description" : "cancel",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "809",
+              "description" : "*cancel(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "809",
+              "description" : "*cancel(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "809",
+              "description" : "*cancel(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            }
+          }
+        },
+        "810" : {
+          "terminologyId" : "openehr",
+          "termId" : "810",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "810",
+              "description" : "resend",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "810",
+              "description" : "*resend(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "810",
+              "description" : "*resend(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "810",
+              "description" : "*resend(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            }
+          }
+        },
+        "811" : {
+          "terminologyId" : "openehr",
+          "termId" : "811",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "811",
+              "description" : "send new",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "811",
+              "description" : "*send new(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "811",
+              "description" : "*send new(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "811",
+              "description" : "*send new(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            }
+          }
+        },
+        "812" : {
+          "terminologyId" : "openehr",
+          "termId" : "812",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "812",
+              "description" : "any change",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "812",
+              "description" : "*any change(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "812",
+              "description" : "*any change(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "812",
+              "description" : "*any change(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            }
+          }
+        },
+        "813" : {
+          "terminologyId" : "openehr",
+          "termId" : "813",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "813",
+              "description" : "correction",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "813",
+              "description" : "*correction(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "813",
+              "description" : "*correction(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "813",
+              "description" : "*correction(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            }
+          }
+        },
+        "814" : {
+          "terminologyId" : "openehr",
+          "termId" : "814",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "814",
+              "description" : "update",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "814",
+              "description" : "*update(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "814",
+              "description" : "*update(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "814",
+              "description" : "*update(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
             }
           }
         }
@@ -8799,6 +11791,20 @@
             }
           }
         },
+        "BQ" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "BQ",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "BQ",
+              "description" : "BONAIRE, SINT EUSTATIUS AND SABA",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "BA" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "BA",
@@ -9205,6 +12211,20 @@
             }
           }
         },
+        "CW" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "CW",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "CW",
+              "description" : "CURAÇAO",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "CY" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "CY",
@@ -9368,6 +12388,20 @@
               "language" : "en",
               "codeString" : "EE",
               "description" : "ESTONIA",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SZ" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "SZ",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "SZ",
+              "description" : "ESWATINI",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -10165,7 +13199,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "LY",
-              "description" : "LIBYAN ARAB JAMAHIRIYA",
+              "description" : "LIBYA",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -10222,20 +13256,6 @@
               "language" : "en",
               "codeString" : "MO",
               "description" : "MACAO",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
-        "MK" : {
-          "terminologyId" : "ISO_3166-1",
-          "termId" : "MK",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "ISO_3166-1",
-              "language" : "en",
-              "codeString" : "MK",
-              "description" : "MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -10599,7 +13619,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "AN",
-              "description" : "NETHERLANDS ANTILLES",
+              "description" : "NETHERLANDS ANTILLES - DEPRECATED",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -10703,6 +13723,20 @@
             }
           }
         },
+        "MK" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "MK",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "MK",
+              "description" : "NORTH MACEDONIA",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "MP" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "MP",
@@ -10781,7 +13815,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "PS",
-              "description" : "PALESTINIAN TERRITORY, OCCUPIED",
+              "description" : "PALESTINIAN, STATE OF",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -10935,7 +13969,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "RE",
-              "description" : "REUNION",
+              "description" : "RÉUNION",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11005,7 +14039,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "SH",
-              "description" : "SAINT HELENA",
+              "description" : "SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11047,7 +14081,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "MF",
-              "description" : "SAINT MARTIN",
+              "description" : "SAINT MARTIN (FRENCH PART)",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11207,6 +14241,20 @@
             }
           }
         },
+        "SX" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "SX",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "SX",
+              "description" : "SINT MAARTEN (DUTCH PART)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "SK" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "SK",
@@ -11291,6 +14339,20 @@
             }
           }
         },
+        "SS" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "SS",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "SS",
+              "description" : "SOUTH SUDAN",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ES" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "ES",
@@ -11356,20 +14418,6 @@
               "language" : "en",
               "codeString" : "SJ",
               "description" : "SVALBARD AND JAN MAYEN",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
-        "SZ" : {
-          "terminologyId" : "ISO_3166-1",
-          "termId" : "SZ",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "ISO_3166-1",
-              "language" : "en",
-              "codeString" : "SZ",
-              "description" : "SWAZILAND",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11565,7 +14613,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "TR",
-              "description" : "TURKEY",
+              "description" : "TÜRKIYE",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11663,7 +14711,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "GB",
-              "description" : "UNITED KINGDOM",
+              "description" : "UNITED KINGDOM OF GREAT BRITAIN AND NORTHERN IRELAND",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11677,7 +14725,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "US",
-              "description" : "UNITED STATES",
+              "description" : "UNITED STATES OF AMERICA",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11747,7 +14795,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "VE",
-              "description" : "VENEZUELA",
+              "description" : "VENEZUELA, BOLIVARIAN REPUBLIC OF",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11886,6 +14934,34 @@
             }
           }
         },
+        "ISO_8859-1:1987" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "ISO_8859-1:1987",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "ISO_8859-1:1987",
+              "description" : "ISO_8859-1:1987",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ISO-8859-2" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "ISO-8859-2",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "ISO-8859-2",
+              "description" : "ISO-8859-2",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ISO_8859-3:1988" : {
           "terminologyId" : "IANA_character-sets",
           "termId" : "ISO_8859-3:1988",
@@ -11895,6 +14971,48 @@
               "language" : "en",
               "codeString" : "ISO_8859-3:1988",
               "description" : "ISO_8859-3:1988",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ISO-8859-15" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "ISO-8859-15",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "ISO-8859-15",
+              "description" : "ISO-8859-15",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "US-ASCII" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "US-ASCII",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "US-ASCII",
+              "description" : "US-ASCII",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "UTF-7" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "UTF-7",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "UTF-7",
+              "description" : "UTF-7",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11914,15 +15032,15 @@
             }
           }
         },
-        "UTF-7" : {
+        "UTF-16" : {
           "terminologyId" : "IANA_character-sets",
-          "termId" : "UTF-7",
+          "termId" : "UTF-16",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "IANA_character-sets",
               "language" : "en",
-              "codeString" : "UTF-7",
-              "description" : "UTF-7",
+              "codeString" : "UTF-16",
+              "description" : "UTF-16",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -11951,20 +15069,6 @@
               "language" : "en",
               "codeString" : "UTF-16LE",
               "description" : "UTF-16LE",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
-        "UTF-16" : {
-          "terminologyId" : "IANA_character-sets",
-          "termId" : "UTF-16",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "IANA_character-sets",
-              "language" : "en",
-              "codeString" : "UTF-16",
-              "description" : "UTF-16",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12011,20 +15115,6 @@
               "groupIds" : [ null ]
             }
           }
-        },
-        "ISO_8859-1:1987" : {
-          "terminologyId" : "IANA_character-sets",
-          "termId" : "ISO_8859-1:1987",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "IANA_character-sets",
-              "language" : "en",
-              "codeString" : "ISO_8859-1:1987",
-              "description" : "ISO_8859-1:1987",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
         }
       }
     },
@@ -12061,6 +15151,20 @@
             }
           }
         },
+        "ak" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ak",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ak",
+              "description" : "Akan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "sq" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "sq",
@@ -12070,6 +15174,34 @@
               "language" : "en",
               "codeString" : "sq",
               "description" : "Albanian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "am" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "am",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "am",
+              "description" : "Amharic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ar" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ar",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ar",
+              "description" : "Arabic",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12299,6 +15431,76 @@
             }
           }
         },
+        "an" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "an",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "an",
+              "description" : "Aragonese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "hy" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "hy",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "hy",
+              "description" : "Armenian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "as" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "as",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "as",
+              "description" : "Assamese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "av" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "av",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "av",
+              "description" : "Avaric, Avar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ay" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ay",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ay",
+              "description" : "Aymara",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "az" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "az",
@@ -12307,7 +15509,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "az",
-              "description" : "Azerbaijani",
+              "description" : "Azerbaijani, Azeri",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bm" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bm",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bm",
+              "description" : "Bambara",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ba" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ba",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ba",
+              "description" : "Bashkir",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12327,20 +15557,6 @@
             }
           }
         },
-        "bg" : {
-          "terminologyId" : "ISO_639-1",
-          "termId" : "bg",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "ISO_639-1",
-              "language" : "en",
-              "codeString" : "bg",
-              "description" : "Bulgarian",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
         "be" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "be",
@@ -12355,6 +15571,90 @@
             }
           }
         },
+        "bn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bn",
+              "description" : "Bengali, Bangla",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bi" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bi",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bi",
+              "description" : "Bislama",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bs" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bs",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bs",
+              "description" : "Bosnian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "br" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "br",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "br",
+              "description" : "Breton",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bg",
+              "description" : "Bulgarian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "my" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "my",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "my",
+              "description" : "Burmese, Myanmar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ca" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ca",
@@ -12363,7 +15663,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "ca",
-              "description" : "Catalan",
+              "description" : "Catalan, Valencian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ch" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ch",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ch",
+              "description" : "Chamorro",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ce" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ce",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ce",
+              "description" : "Chechen",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ny" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ny",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ny",
+              "description" : "Chichewa, Chewa, Nyanja",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12439,6 +15781,76 @@
             }
           }
         },
+        "zh-mo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "zh-mo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "zh-mo",
+              "description" : "Chinese (Macau)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "cv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "cv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "cv",
+              "description" : "Chuvash",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kw",
+              "description" : "Cornish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "co" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "co",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "co",
+              "description" : "Corsican",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "cr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "cr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "cr",
+              "description" : "Cree",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "hr" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "hr",
@@ -12448,6 +15860,20 @@
               "language" : "en",
               "codeString" : "hr",
               "description" : "Croatian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "hr-ba" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "hr-ba",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "hr-ba",
+              "description" : "Croatian (Bosnia and Herzegovina)",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12481,6 +15907,20 @@
             }
           }
         },
+        "dv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "dv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "dv",
+              "description" : "Divehi, Dhivehi, Maldivian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "nl" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "nl",
@@ -12489,7 +15929,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "nl",
-              "description" : "Dutch (Standard)",
+              "description" : "Dutch",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12504,6 +15944,20 @@
               "language" : "en",
               "codeString" : "nl-be",
               "description" : "Dutch (Belgium)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "dz" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "dz",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "dz",
+              "description" : "Dzongkha",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12635,6 +16089,20 @@
             }
           }
         },
+        "en-cb" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "en-cb",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "en-cb",
+              "description" : "English (Caribbean)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "en-bz" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "en-bz",
@@ -12657,7 +16125,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "en-tt",
-              "description" : "English (Trinidad)",
+              "description" : "English (Trinidad and Tobago)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "en-ph" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "en-ph",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "en-ph",
+              "description" : "English (Republic of the Philippines)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "en-zw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "en-zw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "en-zw",
+              "description" : "English (Zimbabwe)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "eo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "eo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "eo",
+              "description" : "Esperanto",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12677,6 +16187,20 @@
             }
           }
         },
+        "ee" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ee",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ee",
+              "description" : "Ewe",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "fo" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "fo",
@@ -12685,21 +16209,21 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "fo",
-              "description" : "Faeroese",
+              "description" : "Faroese",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "fa" : {
+        "fj" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "fa",
+          "termId" : "fj",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "fa",
-              "description" : "Farsi",
+              "codeString" : "fj",
+              "description" : "Fijian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12727,7 +16251,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "fr",
-              "description" : "French (Standard)",
+              "description" : "French",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12789,6 +16313,48 @@
             }
           }
         },
+        "fr-mc" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "fr-mc",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "fr-mc",
+              "description" : "French (Principality of Monaco)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "fy" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "fy",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "fy",
+              "description" : "Frisian, Western Frisian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ff" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ff",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ff",
+              "description" : "Fulah, Fulani",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "gd" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "gd",
@@ -12797,7 +16363,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "gd",
-              "description" : "Gaelic (Scotland)",
+              "description" : "Gaelic, Scottish Gaelic",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12817,6 +16383,48 @@
             }
           }
         },
+        "gl" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gl",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gl",
+              "description" : "Galician",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "lg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lg",
+              "description" : "Ganda",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ka" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ka",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ka",
+              "description" : "Georgian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "de" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "de",
@@ -12825,7 +16433,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "de",
-              "description" : "German (Standard)",
+              "description" : "German",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12901,6 +16509,76 @@
             }
           }
         },
+        "kl" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kl",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kl",
+              "description" : "Kalaallisut, Greenlandic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "gn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gn",
+              "description" : "Guarani",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "gu" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gu",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gu",
+              "description" : "Gujarati",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ht" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ht",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ht",
+              "description" : "Haitian, Haitian Creole",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ha" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ha",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ha",
+              "description" : "Hausa",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "he" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "he",
@@ -12915,6 +16593,20 @@
             }
           }
         },
+        "hz" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "hz",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "hz",
+              "description" : "Herero",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "hi" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "hi",
@@ -12924,6 +16616,20 @@
               "language" : "en",
               "codeString" : "hi",
               "description" : "Hindi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ho" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ho",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ho",
+              "description" : "Hiri Motu, Pidgin Motu",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -12957,6 +16663,20 @@
             }
           }
         },
+        "ig" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ig",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ig",
+              "description" : "Igbo",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "id" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "id",
@@ -12971,6 +16691,48 @@
             }
           }
         },
+        "iu" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "iu",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "iu",
+              "description" : "Inuktitut",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ik" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ik",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ik",
+              "description" : "Inupiaq",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ga" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ga",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ga",
+              "description" : "Irish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "it" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "it",
@@ -12979,7 +16741,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "it",
-              "description" : "Italian (Standard)",
+              "description" : "Italian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13013,6 +16775,62 @@
             }
           }
         },
+        "jv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "jv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "jv",
+              "description" : "Javanese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kn",
+              "description" : "Kannada",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kr",
+              "description" : "Kanuri",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ks" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ks",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ks",
+              "description" : "Kashmiri",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "kk" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "kk",
@@ -13021,7 +16839,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "kk",
-              "description" : "Kasakh",
+              "description" : "Kazakh",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13035,7 +16853,77 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "km",
-              "description" : "Central Khmer",
+              "description" : "Central Khmer, Cambodian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ki" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ki",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ki",
+              "description" : "Kikuyu, Gikuyu",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "rw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "rw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "rw",
+              "description" : "Kinyarwanda",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ky" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ky",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ky",
+              "description" : "Kirghiz, Kyrgyz",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kv",
+              "description" : "Komi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kg",
+              "description" : "Kongo",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13055,6 +16943,62 @@
             }
           }
         },
+        "kj" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kj",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kj",
+              "description" : "Kuanyama, Kwanyama",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ku" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ku",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ku",
+              "description" : "Kurdish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "lo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lo",
+              "description" : "Lao",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "la" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "la",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "la",
+              "description" : "Latin",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "lv" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "lv",
@@ -13064,6 +17008,34 @@
               "language" : "en",
               "codeString" : "lv",
               "description" : "Latvian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "li" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "li",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "li",
+              "description" : "Limburgan, Limburger, Limburgish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ln" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ln",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ln",
+              "description" : "Lingala",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13083,6 +17055,34 @@
             }
           }
         },
+        "lu" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lu",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lu",
+              "description" : "Luba-Katanga, Luba-Shaba",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "lb" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lb",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lb",
+              "description" : "Luxembourgish, Letzeburgesch",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "mk" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "mk",
@@ -13091,7 +17091,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "mk",
-              "description" : "FYRO Macedonian ms Malaysian",
+              "description" : "Macedonian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mg",
+              "description" : "Malagasy",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ms" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ms",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ms",
+              "description" : "Malay",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ml" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ml",
+              "description" : "Malayalam",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13106,6 +17148,160 @@
               "language" : "en",
               "codeString" : "mt",
               "description" : "Maltese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "gv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gv",
+              "description" : "Manx",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mi" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mi",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mi",
+              "description" : "Maori",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mr",
+              "description" : "Marathi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mh" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mh",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mh",
+              "description" : "Marshallese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mn",
+              "description" : "Mongolian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "na" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "na",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "na",
+              "description" : "Nauru, Nauruan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "nv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "nv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "nv",
+              "description" : "Navajo, Navaho",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "nd" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "nd",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "nd",
+              "description" : "North Ndebele",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "nr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "nr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "nr",
+              "description" : "South Ndebele",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ng" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ng",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ng",
+              "description" : "Ndonga",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ne" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ne",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ne",
+              "description" : "Nepali",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13139,6 +17335,118 @@
             }
           }
         },
+        "ii" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ii",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ii",
+              "description" : "Sichuan Yi, Nuosu, Northern Yi, Liangshan Yi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "oc" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "oc",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "oc",
+              "description" : "Occitan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "oj" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "oj",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "oj",
+              "description" : "Ojibwa, Ojibwe",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "or" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "or",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "or",
+              "description" : "Oriya, Odia",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "om" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "om",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "om",
+              "description" : "Oromo",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "os" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "os",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "os",
+              "description" : "Ossetian, Ossetic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ps" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ps",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ps",
+              "description" : "Pashto, Pushto",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "fa" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "fa",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "fa",
+              "description" : "Persian, Farsi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "pl" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "pl",
@@ -13148,6 +17456,20 @@
               "language" : "en",
               "codeString" : "pl",
               "description" : "Polish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "pt" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "pt",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "pt",
+              "description" : "Portuguese",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13175,35 +17497,77 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "pt-pt",
-              "description" : "Portuguese (Portugal)",
+              "description" : "Portuguese (Portugal) - DEPRECATED",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "pt" : {
+        "pa" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "pt",
+          "termId" : "pa",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "pt",
-              "description" : "Portuguese",
+              "codeString" : "pa",
+              "description" : "Punjabi, Panjabi",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "rm" : {
+        "qu" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "rm",
+          "termId" : "qu",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "rm",
-              "description" : "Rhaeto-Romanic",
+              "codeString" : "qu",
+              "description" : "Quechua",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "qu-bo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "qu-bo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "qu-bo",
+              "description" : "Quechua (Bolivia)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "qu-ec" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "qu-ec",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "qu-ec",
+              "description" : "Quechua (Ecuador)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "qu-pe" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "qu-pe",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "qu-pe",
+              "description" : "Quechua (Peru)",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13237,6 +17601,34 @@
             }
           }
         },
+        "rm" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "rm",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "rm",
+              "description" : "Romansh, Rhaeto-Romanic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "rn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "rn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "rn",
+              "description" : "Rundi, Kirundi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ru" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ru",
@@ -13265,6 +17657,20 @@
             }
           }
         },
+        "se" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "se",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "se",
+              "description" : "Northern Sami",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "sz" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "sz",
@@ -13273,7 +17679,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sz",
-              "description" : "Sami (Lappish)",
+              "description" : "Sami (Lappish) - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sm" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sm",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sm",
+              "description" : "Samoan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sg",
+              "description" : "Sango",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sc" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sc",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sc",
+              "description" : "Sardinian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13287,7 +17735,77 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sr",
-              "description" : "Serbian (Cyrillic)",
+              "description" : "Serbian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sr-ba" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sr-ba",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sr-ba",
+              "description" : "Serbian (Bosnia and Herzegovina)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sb" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sb",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sb",
+              "description" : "Serbian - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sn",
+              "description" : "Shona",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sd" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sd",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sd",
+              "description" : "Sindhi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "si" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "si",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "si",
+              "description" : "Sinhala, Sinhalese",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13315,35 +17833,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sl",
-              "description" : "Slovenian",
+              "description" : "Slovenian, Slovene",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "si" : {
+        "so" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "si",
+          "termId" : "so",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "si",
-              "description" : "Sinhala",
+              "codeString" : "so",
+              "description" : "Somali",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "sb" : {
+        "st" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "sb",
+          "termId" : "st",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "sb",
-              "description" : "Serbian",
+              "codeString" : "st",
+              "description" : "Southern Sotho, Sesotho, Sutu",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13357,7 +17875,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "es",
-              "description" : "Spanish (Spain ? Traditional)",
+              "description" : "Spanish, Castilian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13615,6 +18133,20 @@
             }
           }
         },
+        "su" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "su",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "su",
+              "description" : "Sundanese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "sx" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "sx",
@@ -13623,7 +18155,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sx",
-              "description" : "Sutu",
+              "description" : "Sutu - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sw",
+              "description" : "Swahili",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ss" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ss",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ss",
+              "description" : "Swati, Swazi",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13657,6 +18217,90 @@
             }
           }
         },
+        "tl" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tl",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tl",
+              "description" : "Tagalog",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ty" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ty",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ty",
+              "description" : "Tahitian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "tg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tg",
+              "description" : "Tajik",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ta" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ta",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ta",
+              "description" : "Tamil",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "tt" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tt",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tt",
+              "description" : "Tatar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "te" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "te",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "te",
+              "description" : "Telugu",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "th" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "th",
@@ -13666,6 +18310,48 @@
               "language" : "en",
               "codeString" : "th",
               "description" : "Thai",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bo",
+              "description" : "Tibetan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ti" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ti",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ti",
+              "description" : "Tigrinya",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "to" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "to",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "to",
+              "description" : "Tonga, Tongan",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13713,6 +18399,48 @@
             }
           }
         },
+        "tk" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tk",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tk",
+              "description" : "Turkmen",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "tw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tw",
+              "description" : "Twi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ug" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ug",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ug",
+              "description" : "Uighur, Uyghur",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "uk" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "uk",
@@ -13741,6 +18469,20 @@
             }
           }
         },
+        "uz" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "uz",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "uz",
+              "description" : "Uzbek",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ve" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ve",
@@ -13764,6 +18506,20 @@
               "language" : "en",
               "codeString" : "vi",
               "description" : "Vietnamese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "wa" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "wa",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "wa",
+              "description" : "Walloon",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -13811,6 +18567,20 @@
             }
           }
         },
+        "wo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "wo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "wo",
+              "description" : "Wolof",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "xh" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "xh",
@@ -13825,6 +18595,20 @@
             }
           }
         },
+        "yi" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "yi",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "yi",
+              "description" : "Yiddish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ji" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ji",
@@ -13833,7 +18617,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "ji",
-              "description" : "Yiddish",
+              "description" : "Yiddish - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "yo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "yo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "yo",
+              "description" : "Yoruba",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "za" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "za",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "za",
+              "description" : "Zhuang, Chuang",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -14154,6 +18966,20 @@
             }
           }
         },
+        "video/H264" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/H264",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/H264",
+              "description" : "video/H264",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "video/MPV" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "video/MPV",
@@ -14163,6 +18989,48 @@
               "language" : "en",
               "codeString" : "video/MPV",
               "description" : "video/MPV",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "video/mp4" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/mp4",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/mp4",
+              "description" : "video/mp4",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "video/ogg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/ogg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/ogg",
+              "description" : "video/ogg",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "video/mpeg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/mpeg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/mpeg",
+              "description" : "video/mpeg",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -14196,6 +19064,20 @@
             }
           }
         },
+        "audio/mpeg3" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/mpeg3",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/mpeg3",
+              "description" : "audio/mpeg3",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "audio/mpeg4-generic" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "audio/mpeg4-generic",
@@ -14205,6 +19087,20 @@
               "language" : "en",
               "codeString" : "audio/mpeg4-generic",
               "description" : "audio/mpeg4-generic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "audio/mp4" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/mp4",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/mp4",
+              "description" : "audio/mp4",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -14247,6 +19143,34 @@
               "language" : "en",
               "codeString" : "audio/telephone-event",
               "description" : "audio/telephone-event",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "audio/ogg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/ogg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/ogg",
+              "description" : "audio/ogg",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "audio/vorbis" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/vorbis",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/vorbis",
+              "description" : "audio/vorbis",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -14434,6 +19358,34 @@
             }
           }
         },
+        "image/avif" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/avif",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/avif",
+              "description" : "image/avif",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "image/bmp" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/bmp",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/bmp",
+              "description" : "image/bmp",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "image/cgm" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "image/cgm",
@@ -14504,6 +19456,132 @@
             }
           }
         },
+        "image/jp2" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/jp2",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/jp2",
+              "description" : "image/jp2",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "image/svg+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/svg+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/svg+xml",
+              "description" : "image/svg+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/cda+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/cda+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/cda+xml",
+              "description" : "application/cda+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/EDIFACT" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/EDIFACT",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/EDIFACT",
+              "description" : "application/EDIFACT",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/fhir+json" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/fhir+json",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/fhir+json",
+              "description" : "application/fhir+json",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/fhir+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/fhir+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/fhir+xml",
+              "description" : "application/fhir+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/hl7v2+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/hl7v2+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/hl7v2+xml",
+              "description" : "application/hl7v2+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/gzip" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/gzip",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/gzip",
+              "description" : "application/gzip",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/json" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/json",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/json",
+              "description" : "application/json",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "application/msword" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "application/msword",
@@ -14560,6 +19638,244 @@
             }
           }
         },
+        "application/dicom+json" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/dicom+json",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/dicom+json",
+              "description" : "application/dicom+json",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/dicom+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/dicom+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/dicom+xml",
+              "description" : "application/dicom+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/octet-stream" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/octet-stream",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/octet-stream",
+              "description" : "application/octet-stream",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/ogg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/ogg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/ogg",
+              "description" : "application/ogg",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.base" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.base",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.base",
+              "description" : "application/vnd.oasis.opendocument.base",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.chart" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.chart",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.chart",
+              "description" : "application/vnd.oasis.opendocument.chart",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.chart-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.chart-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.chart-template",
+              "description" : "application/vnd.oasis.opendocument.chart-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.formula" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.formula",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.formula",
+              "description" : "application/vnd.oasis.opendocument.formula",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.formula-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.formula-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.formula-template",
+              "description" : "application/vnd.oasis.opendocument.formula-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.graphics" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.graphics",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.graphics",
+              "description" : "application/vnd.oasis.opendocument.graphics",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.graphics-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.graphics-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.graphics-template",
+              "description" : "application/vnd.oasis.opendocument.graphics-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.image" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.image",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.image",
+              "description" : "application/vnd.oasis.opendocument.image",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.image-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.image-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.image-template",
+              "description" : "application/vnd.oasis.opendocument.image-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.presentation" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.presentation",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.presentation",
+              "description" : "application/vnd.oasis.opendocument.presentation",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.presentation-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.presentation-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.presentation-template",
+              "description" : "application/vnd.oasis.opendocument.presentation-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.spreadsheet" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.spreadsheet",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.spreadsheet",
+              "description" : "application/vnd.oasis.opendocument.spreadsheet",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.spreadsheet-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.spreadsheet-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.spreadsheet-template",
+              "description" : "application/vnd.oasis.opendocument.spreadsheet-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "application/vnd.oasis.opendocument.text" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "application/vnd.oasis.opendocument.text",
@@ -14569,6 +19885,48 @@
               "language" : "en",
               "codeString" : "application/vnd.oasis.opendocument.text",
               "description" : "application/vnd.oasis.opendocument.text",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.text-master" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.text-master",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.text-master",
+              "description" : "application/vnd.oasis.opendocument.text-master",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.text-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.text-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.text-template",
+              "description" : "application/vnd.oasis.opendocument.text-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.text-web" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.text-web",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.text-web",
+              "description" : "application/vnd.oasis.opendocument.text-web",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -14741,6 +20099,76 @@
               "groupIds" : [ null ]
             }
           }
+        },
+        "application/vnd.ms-excel" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.ms-excel",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.ms-excel",
+              "description" : "application/vnd.ms-excel",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.ms-outlook" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.ms-outlook",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.ms-outlook",
+              "description" : "application/vnd.ms-outlook",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.ms-powerpoint" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.ms-powerpoint",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.ms-powerpoint",
+              "description" : "application/vnd.ms-powerpoint",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.rar" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.rar",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.rar",
+              "description" : "application/vnd.rar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/zip" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/zip",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/zip",
+              "description" : "application/zip",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
         }
       }
     }
@@ -14758,6 +20186,14 @@
             "en" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "en",
+              "codeString" : "compress",
+              "description" : "compress",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
               "codeString" : "compress",
               "description" : "compress",
               "groupName" : null,
@@ -14785,6 +20221,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
+              "codeString" : "deflate",
+              "description" : "deflate",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "pt" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "pt",
@@ -14802,6 +20246,14 @@
             "en" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "en",
+              "codeString" : "gzip",
+              "description" : "gzip",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
               "codeString" : "gzip",
               "description" : "gzip",
               "groupName" : null,
@@ -14837,6 +20289,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
+              "codeString" : "zlib",
+              "description" : "zlib",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "ja",
@@ -14862,6 +20322,14 @@
             "en" : {
               "terminologyId" : "openehr_compression_algorithms",
               "language" : "en",
+              "codeString" : "other",
+              "description" : "other",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_compression_algorithms",
+              "language" : "es",
               "codeString" : "other",
               "description" : "other",
               "groupName" : null,
@@ -14938,6 +20406,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-1",
+              "description" : "SHA-1",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_integrity_check_algorithms",
               "language" : "ja",
@@ -14956,6 +20432,44 @@
             }
           }
         },
+        "SHA-224" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-224",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-224",
+              "description" : "SHA-224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "SHA-256" : {
           "terminologyId" : "openehr_integrity_check_algorithms",
           "termId" : "SHA-256",
@@ -14963,6 +20477,14 @@
             "en" : {
               "terminologyId" : "openehr_integrity_check_algorithms",
               "language" : "en",
+              "codeString" : "SHA-256",
+              "description" : "SHA-256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
               "codeString" : "SHA-256",
               "description" : "SHA-256",
               "groupName" : null,
@@ -14981,6 +20503,158 @@
               "language" : "pt",
               "codeString" : "SHA-256",
               "description" : "SHA-256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-384" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-384",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-384",
+              "description" : "SHA-384",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-512" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-512",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-512",
+              "description" : "SHA-512",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-512/224" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-512/224",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-512/224",
+              "description" : "SHA-512/224",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SHA-512/256" : {
+          "terminologyId" : "openehr_integrity_check_algorithms",
+          "termId" : "SHA-512/256",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "en",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "es",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "ja",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr_integrity_check_algorithms",
+              "language" : "pt",
+              "codeString" : "SHA-512/256",
+              "description" : "SHA-512/256",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -15000,6 +20674,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "HHH",
+              "description" : "HHH",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "HHH",
               "description" : "HHH",
               "groupName" : null,
@@ -15035,6 +20717,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
+              "codeString" : "HH",
+              "description" : "HH",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "ja",
@@ -15060,6 +20750,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "H",
+              "description" : "H",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "H",
               "description" : "H",
               "groupName" : null,
@@ -15095,6 +20793,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
+              "codeString" : "N",
+              "description" : "N",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "ja",
@@ -15120,6 +20826,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "L",
+              "description" : "L",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "L",
               "description" : "L",
               "groupName" : null,
@@ -15155,6 +20869,14 @@
               "groupName" : null,
               "groupIds" : [ null ]
             },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
+              "codeString" : "LL",
+              "description" : "LL",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
             "ja" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "ja",
@@ -15180,6 +20902,14 @@
             "en" : {
               "terminologyId" : "openehr_normal_statuses",
               "language" : "en",
+              "codeString" : "LLL",
+              "description" : "LLL",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            },
+            "es" : {
+              "terminologyId" : "openehr_normal_statuses",
+              "language" : "es",
               "codeString" : "LLL",
               "description" : "LLL",
               "groupName" : null,
@@ -15222,6 +20952,14 @@
               "groupName" : "attestation reason",
               "groupIds" : [ "attestation reason" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "240",
+              "description" : "firmado",
+              "groupName" : "attestation reason",
+              "groupIds" : [ "attestation reason" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15249,6 +20987,14 @@
               "language" : "en",
               "codeString" : "648",
               "description" : "witnessed",
+              "groupName" : "attestation reason",
+              "groupIds" : [ "attestation reason" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "648",
+              "description" : "testigo",
               "groupName" : "attestation reason",
               "groupIds" : [ "attestation reason" ]
             },
@@ -15282,6 +21028,14 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "249",
+              "description" : "creación",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15309,6 +21063,14 @@
               "language" : "en",
               "codeString" : "250",
               "description" : "amendment",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "250",
+              "description" : "enmienda",
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
@@ -15342,6 +21104,14 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "251",
+              "description" : "modificación",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15369,6 +21139,14 @@
               "language" : "en",
               "codeString" : "252",
               "description" : "synthesis",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "252",
+              "description" : "síntesis",
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
@@ -15402,6 +21180,14 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type", "version lifecycle state" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "523",
+              "description" : "eliminado",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type", "version lifecycle state" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15429,6 +21215,14 @@
               "language" : "en",
               "codeString" : "666",
               "description" : "attestation",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "666",
+              "description" : "testimonio",
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type" ]
             },
@@ -15462,13 +21256,21 @@
               "groupName" : "audit change type",
               "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "253",
+              "description" : "desconocido",
+              "groupName" : "audit change type",
+              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "253",
               "description" : "不明",
               "groupName" : "監査変更種別",
-              "groupIds" : [ "audit change type", "participation function", "subject relationships", "null flavours" ]
+              "groupIds" : [ "audit change type", "participation function", "subject relationship", "null flavours" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -15492,6 +21294,14 @@
               "groupName" : "composition category",
               "groupIds" : [ "composition category" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "431",
+              "description" : "persistente",
+              "groupName" : "composition category",
+              "groupIds" : [ "composition category" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15510,22 +21320,30 @@
             }
           }
         },
-        "435" : {
+        "451" : {
           "terminologyId" : "openehr",
-          "termId" : "435",
+          "termId" : "451",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
-              "codeString" : "435",
+              "codeString" : "451",
               "description" : "episodic",
+              "groupName" : "composition category",
+              "groupIds" : [ "composition category" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "451",
+              "description" : "episódico",
               "groupName" : "composition category",
               "groupIds" : [ "composition category" ]
             },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
-              "codeString" : "435",
+              "codeString" : "451",
               "description" : "*episodic(en)",
               "groupName" : "コンポジションカテゴリ",
               "groupIds" : [ "composition category" ]
@@ -15533,7 +21351,7 @@
             "pt" : {
               "terminologyId" : "openehr",
               "language" : "pt",
-              "codeString" : "435",
+              "codeString" : "451",
               "description" : "*episodic(en)",
               "groupName" : "categoria de composição",
               "groupIds" : [ "composition category" ]
@@ -15549,6 +21367,14 @@
               "language" : "en",
               "codeString" : "433",
               "description" : "event",
+              "groupName" : "composition category",
+              "groupIds" : [ "composition category" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "433",
+              "description" : "evento",
               "groupName" : "composition category",
               "groupIds" : [ "composition category" ]
             },
@@ -15577,6 +21403,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "387",
+              "description" : "audio/DVI4",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "387",
               "description" : "audio/DVI4",
               "groupName" : "MultiMedia",
@@ -15612,6 +21446,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "388",
+              "description" : "audio/G722",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15637,6 +21479,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "389",
+              "description" : "audio/G723",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "389",
               "description" : "audio/G723",
               "groupName" : "MultiMedia",
@@ -15672,6 +21522,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "390",
+              "description" : "audio/G726-16",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15697,6 +21555,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "391",
+              "description" : "audio/G726-24",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "391",
               "description" : "audio/G726-24",
               "groupName" : "MultiMedia",
@@ -15732,6 +21598,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "392",
+              "description" : "audio/G726-32",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15757,6 +21631,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "393",
+              "description" : "audio/G726-40",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "393",
               "description" : "audio/G726-40",
               "groupName" : "MultiMedia",
@@ -15792,6 +21674,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "394",
+              "description" : "audio/G728",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15817,6 +21707,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "395",
+              "description" : "audio/L8",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "395",
               "description" : "audio/L8",
               "groupName" : "MultiMedia",
@@ -15852,6 +21750,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "396",
+              "description" : "audio/L16",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15877,6 +21783,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "397",
+              "description" : "audio/LPC",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "397",
               "description" : "audio/LPC",
               "groupName" : "MultiMedia",
@@ -15912,6 +21826,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "398",
+              "description" : "audio/G729",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15937,6 +21859,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "399",
+              "description" : "audio/G729D",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "399",
               "description" : "audio/G729D",
               "groupName" : "MultiMedia",
@@ -15972,6 +21902,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "400",
+              "description" : "audio/G729E",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -15997,6 +21935,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "401",
+              "description" : "video/BT656",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "401",
               "description" : "video/BT656",
               "groupName" : "MultiMedia",
@@ -16032,6 +21978,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "402",
+              "description" : "video/CelB",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16057,6 +22011,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "403",
+              "description" : "video/JPEG",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "403",
               "description" : "video/JPEG",
               "groupName" : "MultiMedia",
@@ -16092,6 +22054,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "404",
+              "description" : "video/H261",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16117,6 +22087,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "405",
+              "description" : "video/H263",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "405",
               "description" : "video/H263",
               "groupName" : "MultiMedia",
@@ -16152,6 +22130,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "406",
+              "description" : "video/H263-1998",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16177,6 +22163,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "407",
+              "description" : "video/H263-2000",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "407",
               "description" : "video/H263-2000",
               "groupName" : "MultiMedia",
@@ -16212,6 +22206,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "408",
+              "description" : "video/MPV",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16237,6 +22239,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "409",
+              "description" : "audio/mpeg",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "409",
               "description" : "audio/mpeg",
               "groupName" : "MultiMedia",
@@ -16272,6 +22282,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "410",
+              "description" : "audio/mpeg4-generic",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16297,6 +22315,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "411",
+              "description" : "audio/L20",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "411",
               "description" : "audio/L20",
               "groupName" : "MultiMedia",
@@ -16332,6 +22358,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "412",
+              "description" : "audio/L24",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16362,6 +22396,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "413",
+              "description" : "audio/telephone-evento",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16387,6 +22429,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "414",
+              "description" : "video/quicktime",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "414",
               "description" : "video/quicktime",
               "groupName" : "MultiMedia",
@@ -16422,6 +22472,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "415",
+              "description" : "text/calendar",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16447,6 +22505,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "416",
+              "description" : "text/directory",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "416",
               "description" : "text/directory",
               "groupName" : "MultiMedia",
@@ -16482,6 +22548,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "417",
+              "description" : "text/html",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16507,6 +22581,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "418",
+              "description" : "text/plain",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "418",
               "description" : "text/plain",
               "groupName" : "MultiMedia",
@@ -16542,6 +22624,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "419",
+              "description" : "text/rtf",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16567,6 +22657,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "420",
+              "description" : "text/sgml",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "420",
               "description" : "text/sgml",
               "groupName" : "MultiMedia",
@@ -16602,6 +22700,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "421",
+              "description" : "text/tab-separated-values",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16627,6 +22733,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "422",
+              "description" : "text/uri-list",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "422",
               "description" : "text/uri-list",
               "groupName" : "MultiMedia",
@@ -16662,6 +22776,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "423",
+              "description" : "text/xml",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16687,6 +22809,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "424",
+              "description" : "text/xml-external-parsed-entity",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "424",
               "description" : "text/xml-external-parsed-entity",
               "groupName" : "MultiMedia",
@@ -16722,6 +22852,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "425",
+              "description" : "image/cgm",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16747,6 +22885,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "426",
+              "description" : "image/gif",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "426",
               "description" : "image/gif",
               "groupName" : "MultiMedia",
@@ -16782,6 +22928,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "427",
+              "description" : "image/png",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16807,6 +22961,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "428",
+              "description" : "image/tiff",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "428",
               "description" : "image/tiff",
               "groupName" : "MultiMedia",
@@ -16842,6 +23004,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "429",
+              "description" : "image/jpeg",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16867,6 +23037,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "517",
+              "description" : "application/msword",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "517",
               "description" : "application/msword",
               "groupName" : "MultiMedia",
@@ -16902,6 +23080,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "518",
+              "description" : "application/pdf",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16927,6 +23113,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "519",
+              "description" : "application/rtf",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "519",
               "description" : "application/rtf",
               "groupName" : "MultiMedia",
@@ -16962,6 +23156,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "637",
+              "description" : "application/dicom",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -16987,6 +23189,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "682",
+              "description" : "application/vnd.oasis.opendocument.text",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "682",
               "description" : "application/vnd.oasis.opendocument.text",
               "groupName" : "MultiMedia",
@@ -17022,6 +23232,14 @@
               "groupName" : "MultiMedia",
               "groupIds" : [ "MultiMedia" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "683",
+              "description" : "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              "groupName" : "MultiMedia",
+              "groupIds" : [ "MultiMedia" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17049,6 +23267,14 @@
               "language" : "en",
               "codeString" : "339",
               "description" : "Acceleration",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "339",
+              "description" : "Aceleración",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17082,6 +23308,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "342",
+              "description" : "Aceleración, angular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17109,6 +23343,14 @@
               "language" : "en",
               "codeString" : "381",
               "description" : "Amount (Eq)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "381",
+              "description" : "Cantidad (equivalente)",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17142,6 +23384,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "384",
+              "description" : "Cantidad (mol)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17169,6 +23419,14 @@
               "language" : "en",
               "codeString" : "497",
               "description" : "Angle, plane",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "497",
+              "description" : "Ángulo, plano",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17202,6 +23460,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "500",
+              "description" : "Ángulo, sólido",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17229,6 +23495,14 @@
               "language" : "en",
               "codeString" : "335",
               "description" : "Area",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "335",
+              "description" : "Área",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17262,6 +23536,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "119",
+              "description" : "Concentración",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17289,6 +23571,14 @@
               "language" : "en",
               "codeString" : "350",
               "description" : "Density",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "350",
+              "description" : "Densidad",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17322,6 +23612,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "362",
+              "description" : "Coeficiente de difusión",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17348,7 +23646,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "501",
-              "description" : "Electrical capacitance",
+              "description" : "Electric capacitance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "501",
+              "description" : "Capacidad eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17378,7 +23684,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "498",
-              "description" : "Electrical charge",
+              "description" : "Electric charge",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "498",
+              "description" : "Carga eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17408,7 +23722,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "502",
-              "description" : "Electrical conductance",
+              "description" : "Electric conductance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "502",
+              "description" : "Conductancia eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17438,7 +23760,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "334",
-              "description" : "Electrical current",
+              "description" : "Electric current",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "334",
+              "description" : "Corriente eléctrica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17468,7 +23798,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "377",
-              "description" : "Electrical field strength",
+              "description" : "Electric field strength",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "377",
+              "description" : "Intensidad del campo eléctrico",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17498,7 +23836,15 @@
               "terminologyId" : "openehr",
               "language" : "en",
               "codeString" : "655",
-              "description" : "Electrical potential time",
+              "description" : "Electric potential",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "655",
+              "description" : "Potencial eléctrico",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17532,6 +23878,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "121",
+              "description" : "Energía",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17559,6 +23913,14 @@
               "language" : "en",
               "codeString" : "366",
               "description" : "Energy density",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "366",
+              "description" : "Densidad de energía",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17592,6 +23954,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "508",
+              "description" : "Dosis de energía",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17619,6 +23989,14 @@
               "language" : "en",
               "codeString" : "365",
               "description" : "Energy per area",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "365",
+              "description" : "Energía por área",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17652,6 +24030,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "364",
+              "description" : "Energía, lineal",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17679,6 +24065,14 @@
               "language" : "en",
               "codeString" : "347",
               "description" : "Flow rate, mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "347",
+              "description" : "Caudal, masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17712,6 +24106,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "352",
+              "description" : "Caudal, masa/fuerza",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17739,6 +24141,14 @@
               "language" : "en",
               "codeString" : "351",
               "description" : "Flow rate, mass/volume",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "351",
+              "description" : "Caudal, amsa/volumen",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17772,6 +24182,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "126",
+              "description" : "Caudal, volumen",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17799,6 +24217,14 @@
               "language" : "en",
               "codeString" : "348",
               "description" : "Flux, mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "348",
+              "description" : "Flujo, masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17832,6 +24258,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "355",
+              "description" : "Fuerza",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17859,6 +24293,14 @@
               "language" : "en",
               "codeString" : "358",
               "description" : "Force per mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "358",
+              "description" : "Fuerza por masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17892,6 +24334,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "357",
+              "description" : "Fuerza, cuerpo",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17919,6 +24369,14 @@
               "language" : "en",
               "codeString" : "382",
               "description" : "Frequency",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "382",
+              "description" : "Frecuencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -17952,6 +24410,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "586",
+              "description" : "Tasa de filtración glomerular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -17979,6 +24445,14 @@
               "language" : "en",
               "codeString" : "373",
               "description" : "Heat transfer coefficient",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "373",
+              "description" : "Coeficiente de transferencia de calor",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18012,6 +24486,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "505",
+              "description" : "Iluminancia",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18039,6 +24521,14 @@
               "language" : "en",
               "codeString" : "379",
               "description" : "Inductance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "379",
+              "description" : "Inductancia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18072,6 +24562,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "122",
+              "description" : "Longitud",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18099,6 +24597,14 @@
               "language" : "en",
               "codeString" : "499",
               "description" : "Light intensity",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "499",
+              "description" : "Intensidad de luz",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18132,6 +24638,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "123",
+              "description" : "Volumen sonoro",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18159,6 +24673,14 @@
               "language" : "en",
               "codeString" : "504",
               "description" : "Luminous flux",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "504",
+              "description" : "Flujo luminoso",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18192,6 +24714,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "378",
+              "description" : "Flujo magnético",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18219,6 +24749,14 @@
               "language" : "en",
               "codeString" : "503",
               "description" : "Magnetic flux density",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "503",
+              "description" : "Densidad de flujo magnético",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18252,6 +24790,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "124",
+              "description" : "Masa",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18279,6 +24825,14 @@
               "language" : "en",
               "codeString" : "385",
               "description" : "Mass (IU)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "385",
+              "description" : "Masa (IU)",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18312,6 +24866,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "445",
+              "description" : "Masa (Unidades)",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18339,6 +24901,14 @@
               "language" : "en",
               "codeString" : "349",
               "description" : "Mass per area",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "349",
+              "description" : "Masa por área",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18372,6 +24942,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "344",
+              "description" : "Momento de inercia, área",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18399,6 +24977,14 @@
               "language" : "en",
               "codeString" : "345",
               "description" : "Moment inertia, mass",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "345",
+              "description" : "Momento de inercia, masa",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18432,6 +25018,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "340",
+              "description" : "Impulso",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18459,6 +25053,14 @@
               "language" : "en",
               "codeString" : "346",
               "description" : "Momentum, flow rate",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "346",
+              "description" : "Impulso, caudal",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18492,6 +25094,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "343",
+              "description" : "Impulso, angular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18519,6 +25129,14 @@
               "language" : "en",
               "codeString" : "363",
               "description" : "Power",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "363",
+              "description" : "Potencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18552,6 +25170,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "369",
+              "description" : "Densidad de potencia",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18579,6 +25205,14 @@
               "language" : "en",
               "codeString" : "368",
               "description" : "Power flux",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "368",
+              "description" : "Flujo de potencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18612,6 +25246,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "367",
+              "description" : "Potencia, lineal",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18639,6 +25281,14 @@
               "language" : "en",
               "codeString" : "125",
               "description" : "Pressure",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "125",
+              "description" : "Presión",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18672,6 +25322,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "507",
+              "description" : "Proporción",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18699,6 +25357,14 @@
               "language" : "en",
               "codeString" : "380",
               "description" : "Qualified real",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "380",
+              "description" : "Real calificado",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18732,6 +25398,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "506",
+              "description" : "Radioactividad",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18759,6 +25433,14 @@
               "language" : "en",
               "codeString" : "375",
               "description" : "Resistance",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "375",
+              "description" : "Resistencia",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18792,6 +25474,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "370",
+              "description" : "Energía específica",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18819,6 +25509,14 @@
               "language" : "en",
               "codeString" : "371",
               "description" : "Specific heat, gas constant",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "371",
+              "description" : "Calor específico, constante de gas",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18852,6 +25550,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "337",
+              "description" : "Superficie específica",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18879,6 +25585,14 @@
               "language" : "en",
               "codeString" : "336",
               "description" : "Specific volume",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "336",
+              "description" : "Volumen específico",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18912,6 +25626,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "354",
+              "description" : "Peso específico",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18939,6 +25661,14 @@
               "language" : "en",
               "codeString" : "356",
               "description" : "Surface tension",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "356",
+              "description" : "Tensión superficial",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -18972,6 +25702,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "127",
+              "description" : "Temperatura",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -18999,6 +25737,14 @@
               "language" : "en",
               "codeString" : "372",
               "description" : "Thermal conductivity",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "372",
+              "description" : "Conductividad térmica",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -19032,6 +25778,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "128",
+              "description" : "Tiempo",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19057,6 +25811,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "359",
+              "description" : "Torque",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "359",
               "description" : "Torque",
               "groupName" : "property",
@@ -19092,6 +25854,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "338",
+              "description" : "Velocidad",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19119,6 +25889,14 @@
               "language" : "en",
               "codeString" : "341",
               "description" : "Velocity, angular",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "341",
+              "description" : "Velocidad, angular",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -19152,6 +25930,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "360",
+              "description" : "Velocidad, dinámica",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19179,6 +25965,14 @@
               "language" : "en",
               "codeString" : "361",
               "description" : "Velocity, kinematic",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "361",
+              "description" : "Velocidad, cinemática",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -19212,6 +26006,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "374",
+              "description" : "Voltaje, eléctrico",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19239,6 +26041,14 @@
               "language" : "en",
               "codeString" : "129",
               "description" : "Volume",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "129",
+              "description" : "Volumen",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -19272,6 +26082,14 @@
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "130",
+              "description" : "Trabajo",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19299,6 +26117,14 @@
               "language" : "en",
               "codeString" : "685",
               "description" : "Refractive power",
+              "groupName" : "property",
+              "groupIds" : [ "property" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "685",
+              "description" : "Poder refractivo",
               "groupName" : "property",
               "groupIds" : [ "property" ]
             },
@@ -19332,6 +26158,14 @@
               "groupName" : "version lifecycle state",
               "groupIds" : [ "instruction states", "version lifecycle state" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "532",
+              "description" : "completo",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "instruction states", "version lifecycle state" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19362,6 +26196,14 @@
               "groupName" : "version lifecycle state",
               "groupIds" : [ "version lifecycle state" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "553",
+              "description" : "incompleto",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19380,6 +26222,82 @@
             }
           }
         },
+        "800" : {
+          "terminologyId" : "openehr",
+          "termId" : "800",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "800",
+              "description" : "inactive",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "800",
+              "description" : "*inactive(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "800",
+              "description" : "*inactive(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "800",
+              "description" : "*inactive(en)",
+              "groupName" : "estado de ciclo de vida de versão",
+              "groupIds" : [ "version lifecycle state" ]
+            }
+          }
+        },
+        "801" : {
+          "terminologyId" : "openehr",
+          "termId" : "801",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "801",
+              "description" : "abandoned",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "801",
+              "description" : "*abandoned(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "801",
+              "description" : "*abandoned(en)",
+              "groupName" : "version lifecycle state",
+              "groupIds" : [ "version lifecycle state" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "801",
+              "description" : "*abandoned(en)",
+              "groupName" : "estado de ciclo de vida de versão",
+              "groupIds" : [ "version lifecycle state" ]
+            }
+          }
+        },
         "271" : {
           "terminologyId" : "openehr",
           "termId" : "271",
@@ -19389,6 +26307,14 @@
               "language" : "en",
               "codeString" : "271",
               "description" : "no information",
+              "groupName" : "null flavours",
+              "groupIds" : [ "null flavours" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "271",
+              "description" : "sin información",
               "groupName" : "null flavours",
               "groupIds" : [ "null flavours" ]
             },
@@ -19422,6 +26348,14 @@
               "groupName" : "null flavours",
               "groupIds" : [ "null flavours" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "272",
+              "description" : "oculto",
+              "groupName" : "null flavours",
+              "groupIds" : [ "null flavours" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19449,6 +26383,14 @@
               "language" : "en",
               "codeString" : "273",
               "description" : "not applicable",
+              "groupName" : "null flavours",
+              "groupIds" : [ "null flavours" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "273",
+              "description" : "no aplica",
               "groupName" : "null flavours",
               "groupIds" : [ "null flavours" ]
             },
@@ -19482,6 +26424,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "193",
+              "description" : "no especificado",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19509,6 +26459,14 @@
               "language" : "en",
               "codeString" : "216",
               "description" : "face-to-face communication",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "216",
+              "description" : "comunicación cara a cara",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19542,6 +26500,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "223",
+              "description" : "comunicación cara a cara interpretada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19569,6 +26535,14 @@
               "language" : "en",
               "codeString" : "217",
               "description" : "signing (face-to-face)",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "217",
+              "description" : "firma (cara a cara)",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19602,6 +26576,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "195",
+              "description" : "audiovisuales en vivo; video conferencia; video llamada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19629,6 +26611,14 @@
               "language" : "en",
               "codeString" : "198",
               "description" : "videoconferencing",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "198",
+              "description" : "video conferencia",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19662,6 +26652,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "197",
+              "description" : "video llamada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19689,6 +26687,14 @@
               "language" : "en",
               "codeString" : "218",
               "description" : "signing over video",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "218",
+              "description" : "firma sobre video",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19722,6 +26728,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "224",
+              "description" : "comunicación por video interpretada",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19749,6 +26763,14 @@
               "language" : "en",
               "codeString" : "194",
               "description" : "asynchronous audiovisual; recorded video",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "194",
+              "description" : "audiovisual asíncrona; video grabado",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19782,6 +26804,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "196",
+              "description" : "video grabado",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19809,6 +26839,14 @@
               "language" : "en",
               "codeString" : "202",
               "description" : "live audio-only; telephone; internet phone; teleconference",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "202",
+              "description" : "sólo audio en vivo; teléfono; teléfono de internet; tele-conferencia",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19842,6 +26880,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "204",
+              "description" : "teléfono",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19869,6 +26915,14 @@
               "language" : "en",
               "codeString" : "203",
               "description" : "teleconference",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "203",
+              "description" : "tele-conferencia",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19902,6 +26956,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "205",
+              "description" : "teléfono de internet",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19929,6 +26991,14 @@
               "language" : "en",
               "codeString" : "222",
               "description" : "interpreted audio-only",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "222",
+              "description" : "sólo audio interpretado",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -19962,6 +27032,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "199",
+              "description" : "sólo audio asíncrono; dictado; correo de voz",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -19989,6 +27067,14 @@
               "language" : "en",
               "codeString" : "200",
               "description" : "dictated",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "200",
+              "description" : "dictado",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20022,6 +27108,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "201",
+              "description" : "correo de voz",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20049,6 +27143,14 @@
               "language" : "en",
               "codeString" : "212",
               "description" : "live text-only; internet chat; SMS chat; interactive written note",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "212",
+              "description" : "sólo texto en vivo; charla de texto por internet; charla por SMS; nota escrita interactiva",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20082,6 +27184,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "213",
+              "description" : "charla (texto) por internet",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20109,6 +27219,14 @@
               "language" : "en",
               "codeString" : "214",
               "description" : "SMS chat",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "214",
+              "description" : "charla por SMS",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20142,6 +27260,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "215",
+              "description" : "nota escrita interactiva",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20169,6 +27295,14 @@
               "language" : "en",
               "codeString" : "206",
               "description" : "asynchronous text; email; fax; letter; handwritten note; SMS message",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "206",
+              "description" : "texto asíncrono; correo electrónico; fax; carta; nota manuscrita; mensaje SMS",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20202,6 +27336,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "211",
+              "description" : "nota manuscrita",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20229,6 +27371,14 @@
               "language" : "en",
               "codeString" : "210",
               "description" : "printed/typed letter",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "210",
+              "description" : "carta impresa/escrita",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20262,6 +27412,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "207",
+              "description" : "correo electrónico",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20289,6 +27447,14 @@
               "language" : "en",
               "codeString" : "208",
               "description" : "facsimile/telefax",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "208",
+              "description" : "facsímil/telefax",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20322,6 +27488,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "221",
+              "description" : "texto traducido",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20349,6 +27523,14 @@
               "language" : "en",
               "codeString" : "209",
               "description" : "SMS message",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "209",
+              "description" : "mensajería SMS",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20382,6 +27564,14 @@
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "219",
+              "description" : "físicamente presente",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20409,6 +27599,14 @@
               "language" : "en",
               "codeString" : "220",
               "description" : "physically remote",
+              "groupName" : "participation mode",
+              "groupIds" : [ "participation mode" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "220",
+              "description" : "físicamente remoto",
               "groupName" : "participation mode",
               "groupIds" : [ "participation mode" ]
             },
@@ -20442,6 +27640,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "524",
+              "description" : "inicial",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20469,6 +27675,14 @@
               "language" : "en",
               "codeString" : "526",
               "description" : "planned",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "526",
+              "description" : "planificado",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -20502,6 +27716,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "527",
+              "description" : "postpuesto",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20529,6 +27751,14 @@
               "language" : "en",
               "codeString" : "528",
               "description" : "cancelled",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "528",
+              "description" : "cancelado",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -20562,6 +27792,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "529",
+              "description" : "coordinado",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20589,6 +27827,14 @@
               "language" : "en",
               "codeString" : "245",
               "description" : "active",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "245",
+              "description" : "activo",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -20622,6 +27868,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "530",
+              "description" : "suspendido",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20649,6 +27903,14 @@
               "language" : "en",
               "codeString" : "531",
               "description" : "aborted",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "531",
+              "description" : "abortado",
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
@@ -20682,6 +27944,14 @@
               "groupName" : "instruction states",
               "groupIds" : [ "instruction states" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "533",
+              "description" : "expirado",
+              "groupName" : "instruction states",
+              "groupIds" : [ "instruction states" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -20712,13 +27982,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "535",
+              "description" : "iniciar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "535",
               "description" : "新しく始める",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20742,13 +28020,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "536",
+              "description" : "paso del plan",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "536",
               "description" : "ステップを計画する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20772,13 +28058,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "537",
+              "description" : "postponer",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "537",
               "description" : "延期する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20802,13 +28096,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "538",
+              "description" : "restaurar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "538",
               "description" : "元に戻す",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20832,13 +28134,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "166",
+              "description" : "cancelar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "166",
               "description" : "キャンセルする",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20862,13 +28172,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "542",
+              "description" : "paso postpuesto",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "542",
               "description" : "延期されたステップ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20892,13 +28210,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "539",
+              "description" : "coordinar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "539",
               "description" : "計画する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20922,13 +28248,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "534",
+              "description" : "paso coordinado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "534",
               "description" : "*scheduled step(en)",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20952,13 +28286,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "540",
+              "description" : "comienzar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "540",
               "description" : "開始する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -20982,13 +28324,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "541",
+              "description" : "realizar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "541",
               "description" : "実施する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21012,13 +28362,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "543",
+              "description" : "paso activo",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "543",
               "description" : "実行中のステップ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21042,13 +28400,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "544",
+              "description" : "suspender",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "544",
               "description" : "中断する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21072,13 +28438,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "545",
+              "description" : "paso suspendido",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "545",
               "description" : "中断されたステップ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21102,13 +28476,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "546",
+              "description" : "reanudar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "546",
               "description" : "再開する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21132,13 +28514,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "547",
+              "description" : "abortar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "547",
               "description" : "中断する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21162,13 +28552,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "548",
+              "description" : "terminar",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "548",
               "description" : "完了する",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21192,13 +28590,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "549",
+              "description" : "se acabó el tiempo",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "549",
               "description" : "時間切れ",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21222,13 +28628,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "550",
+              "description" : "notificar abortado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "550",
               "description" : "中断を知らせる",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21252,13 +28666,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "551",
+              "description" : "notificar completado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "551",
               "description" : "完了を知らせる",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21282,13 +28704,21 @@
               "groupName" : "instruction transitions",
               "groupIds" : [ "instruction transitions" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "552",
+              "description" : "notificar cancelado",
+              "groupName" : "instruction transitions",
+              "groupIds" : [ "instruction transitions" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "552",
               "description" : "キャンセルを知らせる",
               "groupName" : "instruction transitions",
-              "groupIds" : [ "instruction transitionss" ]
+              "groupIds" : [ "instruction transitions" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21312,13 +28742,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "0",
+              "description" : "sí mismo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "0",
               "description" : "自己",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21342,13 +28780,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "3",
+              "description" : "feto",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "3",
               "description" : "胎児",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21372,13 +28818,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "10",
+              "description" : "madre",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "10",
               "description" : "母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21402,13 +28856,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "9",
+              "description" : "padre",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "9",
               "description" : "父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21432,13 +28894,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "6",
+              "description" : "donante",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "6",
               "description" : "ドナー",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21462,13 +28932,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "261",
+              "description" : "hija adoptiva",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "261",
               "description" : "養女",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21492,13 +28970,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "260",
+              "description" : "hijo adoptivo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "260",
               "description" : "養子",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21522,13 +29008,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "259",
+              "description" : "padre adoptivo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "259",
               "description" : "養父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21552,13 +29046,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "258",
+              "description" : "madre adoptiva",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "258",
               "description" : "養母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21582,13 +29084,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "256",
+              "description" : "padre biológico",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "256",
               "description" : "生物学上の父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21612,13 +29122,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "255",
+              "description" : "madre biológica",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "255",
               "description" : "生物学上の母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21642,13 +29160,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "23",
+              "description" : "hermano",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "23",
               "description" : "兄弟",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21672,13 +29198,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "28",
+              "description" : "niño",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "28",
               "description" : "子",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21702,13 +29236,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "265",
+              "description" : "cohabitante",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "265",
               "description" : "同居者",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21732,13 +29274,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "257",
+              "description" : "primo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "257",
               "description" : "従兄弟",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21762,13 +29312,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "29",
+              "description" : "hija",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "29",
               "description" : "娘",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21792,13 +29350,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "264",
+              "description" : "guardián",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "264",
               "description" : "保護者",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21822,13 +29388,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "39",
+              "description" : "tía materna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "39",
               "description" : "母方の叔母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21852,13 +29426,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "8",
+              "description" : "abuelo materno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "8",
               "description" : "母方",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21882,13 +29464,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "7",
+              "description" : "abuela materna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "7",
               "description" : "母型の",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21912,13 +29502,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "38",
+              "description" : "tío materno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "38",
               "description" : "母型の叔父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21942,13 +29540,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "189",
+              "description" : "neonato",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "189",
               "description" : "新生児",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -21972,13 +29578,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "254",
+              "description" : "padre",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "254",
               "description" : "親",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22002,13 +29616,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "22",
+              "description" : "compañero/esposo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "22",
               "description" : "配偶者",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22032,13 +29654,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "41",
+              "description" : "tía paterna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "41",
               "description" : "父方の叔母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22062,13 +29692,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "36",
+              "description" : "abuelo paterno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "36",
               "description" : "父方の祖母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22092,13 +29730,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "37",
+              "description" : "abuela paterna",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "37",
               "description" : "父方の祖-",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22122,13 +29768,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "40",
+              "description" : "tío paterno",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "40",
               "description" : "父方の叔父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22152,13 +29806,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "27",
+              "description" : "hermano",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "27",
               "description" : "同胞",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22182,13 +29844,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "24",
+              "description" : "hermana",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "24",
               "description" : "姉妹",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22212,13 +29882,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "31",
+              "description" : "hijo",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "31",
               "description" : "息子",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22242,13 +29920,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "263",
+              "description" : "padrastro",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "263",
               "description" : "義父",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22272,13 +29958,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "262",
+              "description" : "madrastra",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "262",
               "description" : "義母",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22302,13 +29996,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "25",
+              "description" : "hermanastro o medio hermano",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "25",
               "description" : "義理あるいは異父母兄弟",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22332,13 +30034,21 @@
               "groupName" : "subject relationship",
               "groupIds" : [ "subject relationship" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "26",
+              "description" : "hermanastra o media hermana",
+              "groupName" : "subject relationship",
+              "groupIds" : [ "subject relationship" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
               "codeString" : "26",
               "description" : "義理あるいは異父母姉妹",
               "groupName" : "subject relationship",
-              "groupIds" : [ "subject relationships" ]
+              "groupIds" : [ "subject relationship" ]
             },
             "pt" : {
               "terminologyId" : "openehr",
@@ -22359,6 +30069,14 @@
               "language" : "en",
               "codeString" : "669",
               "description" : "public health",
+              "groupName" : "term mapping purpose",
+              "groupIds" : [ "term mapping purpose" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "669",
+              "description" : "salud pública",
               "groupName" : "term mapping purpose",
               "groupIds" : [ "term mapping purpose" ]
             },
@@ -22392,6 +30110,14 @@
               "groupName" : "term mapping purpose",
               "groupIds" : [ "term mapping purpose" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "670",
+              "description" : "reembolso",
+              "groupName" : "term mapping purpose",
+              "groupIds" : [ "term mapping purpose" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22419,6 +30145,14 @@
               "language" : "en",
               "codeString" : "671",
               "description" : "research study",
+              "groupName" : "term mapping purpose",
+              "groupIds" : [ "term mapping purpose" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "671",
+              "description" : "investigación",
               "groupName" : "term mapping purpose",
               "groupIds" : [ "term mapping purpose" ]
             },
@@ -22452,6 +30186,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "145",
+              "description" : "mínimo",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22479,6 +30221,14 @@
               "language" : "en",
               "codeString" : "144",
               "description" : "maximum",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "144",
+              "description" : "máximo",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -22512,6 +30262,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "267",
+              "description" : "modo",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22539,6 +30297,14 @@
               "language" : "en",
               "codeString" : "268",
               "description" : "median",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "268",
+              "description" : "mediana",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -22572,6 +30338,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "146",
+              "description" : "media",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22602,6 +30376,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "147",
+              "description" : "cambio",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22627,6 +30409,14 @@
             "en" : {
               "terminologyId" : "openehr",
               "language" : "en",
+              "codeString" : "148",
+              "description" : "total",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
               "codeString" : "148",
               "description" : "total",
               "groupName" : "event math function",
@@ -22662,6 +30452,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "149",
+              "description" : "variación",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22689,6 +30487,14 @@
               "language" : "en",
               "codeString" : "521",
               "description" : "decrease",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "521",
+              "description" : "disminución",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -22722,6 +30528,14 @@
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "522",
+              "description" : "incremento",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22749,6 +30563,14 @@
               "language" : "en",
               "codeString" : "640",
               "description" : "actual",
+              "groupName" : "event math function",
+              "groupIds" : [ "event math function" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "640",
+              "description" : "real",
               "groupName" : "event math function",
               "groupIds" : [ "event math function" ]
             },
@@ -22782,6 +30604,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "225",
+              "description" : "hogar",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22809,6 +30639,14 @@
               "language" : "en",
               "codeString" : "227",
               "description" : "emergency care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "227",
+              "description" : "atención de emergencia",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -22842,6 +30680,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "228",
+              "description" : "atención médica primaria",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22869,6 +30715,14 @@
               "language" : "en",
               "codeString" : "229",
               "description" : "primary nursing care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "229",
+              "description" : "atención primaria de enfermería",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -22902,6 +30756,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "230",
+              "description" : "atención primaria de trabajadores de la salud",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22929,6 +30791,14 @@
               "language" : "en",
               "codeString" : "231",
               "description" : "midwifery care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "231",
+              "description" : "atención de partera",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -22962,6 +30832,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "232",
+              "description" : "atención médica secundaria",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -22989,6 +30867,14 @@
               "language" : "en",
               "codeString" : "233",
               "description" : "secondary nursing care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "233",
+              "description" : "atención secundaria de enfermería",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -23022,6 +30908,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "234",
+              "description" : "atención secundaria de trabajadores de la salud",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -23049,6 +30943,14 @@
               "language" : "en",
               "codeString" : "235",
               "description" : "complementary health care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "235",
+              "description" : "atención complementaria",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -23082,6 +30984,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "236",
+              "description" : "atención dental",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -23112,6 +31022,14 @@
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "237",
+              "description" : "atención en casa de salud",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
             "ja" : {
               "terminologyId" : "openehr",
               "language" : "ja",
@@ -23130,6 +31048,44 @@
             }
           }
         },
+        "802" : {
+          "terminologyId" : "openehr",
+          "termId" : "802",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "802",
+              "description" : "mental healthcare",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "802",
+              "description" : "*mental healthcare(en)",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "802",
+              "description" : "*mental healthcare(en)",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "802",
+              "description" : "*mental healthcare(en)",
+              "groupName" : "configuração",
+              "groupIds" : [ "setting" ]
+            }
+          }
+        },
         "238" : {
           "terminologyId" : "openehr",
           "termId" : "238",
@@ -23139,6 +31095,14 @@
               "language" : "en",
               "codeString" : "238",
               "description" : "other care",
+              "groupName" : "setting",
+              "groupIds" : [ "setting" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "238",
+              "description" : "otros cuidados",
               "groupName" : "setting",
               "groupIds" : [ "setting" ]
             },
@@ -23157,6 +31121,462 @@
               "description" : "outro cuidado",
               "groupName" : "configuração",
               "groupIds" : [ "setting" ]
+            }
+          }
+        },
+        "803" : {
+          "terminologyId" : "openehr",
+          "termId" : "803",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "803",
+              "description" : "openEHR EHR",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "803",
+              "description" : "*openEHR EHR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "803",
+              "description" : "*openEHR EHR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "803",
+              "description" : "*openEHR EHR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "804" : {
+          "terminologyId" : "openehr",
+          "termId" : "804",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "804",
+              "description" : "openEHR Demographic",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "804",
+              "description" : "*openEHR Demographic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "804",
+              "description" : "*openEHR Demographic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "804",
+              "description" : "*openEHR Demographic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "805" : {
+          "terminologyId" : "openehr",
+          "termId" : "805",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "805",
+              "description" : "openEHR synchronisation",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "805",
+              "description" : "*openEHR synchronisation(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "805",
+              "description" : "*openEHR synchronisation(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "805",
+              "description" : "*openEHR synchronisation(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "806" : {
+          "terminologyId" : "openehr",
+          "termId" : "806",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "806",
+              "description" : "openEHR generic",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "806",
+              "description" : "*openEHR generic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "806",
+              "description" : "*openEHR generic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "806",
+              "description" : "*openEHR generic(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "807" : {
+          "terminologyId" : "openehr",
+          "termId" : "807",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "807",
+              "description" : "generic EMR",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "807",
+              "description" : "*generic EMR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "807",
+              "description" : "*generic EMR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "807",
+              "description" : "*generic EMR(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "808" : {
+          "terminologyId" : "openehr",
+          "termId" : "808",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "808",
+              "description" : "other",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "808",
+              "description" : "*other(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "808",
+              "description" : "*other(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "808",
+              "description" : "*other(en)",
+              "groupName" : "extract content type",
+              "groupIds" : [ "extract content type" ]
+            }
+          }
+        },
+        "809" : {
+          "terminologyId" : "openehr",
+          "termId" : "809",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "809",
+              "description" : "cancel",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "809",
+              "description" : "*cancel(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "809",
+              "description" : "*cancel(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "809",
+              "description" : "*cancel(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            }
+          }
+        },
+        "810" : {
+          "terminologyId" : "openehr",
+          "termId" : "810",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "810",
+              "description" : "resend",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "810",
+              "description" : "*resend(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "810",
+              "description" : "*resend(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "810",
+              "description" : "*resend(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            }
+          }
+        },
+        "811" : {
+          "terminologyId" : "openehr",
+          "termId" : "811",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "811",
+              "description" : "send new",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "811",
+              "description" : "*send new(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "811",
+              "description" : "*send new(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "811",
+              "description" : "*send new(en)",
+              "groupName" : "extract action type",
+              "groupIds" : [ "extract action type" ]
+            }
+          }
+        },
+        "812" : {
+          "terminologyId" : "openehr",
+          "termId" : "812",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "812",
+              "description" : "any change",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "812",
+              "description" : "*any change(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "812",
+              "description" : "*any change(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "812",
+              "description" : "*any change(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            }
+          }
+        },
+        "813" : {
+          "terminologyId" : "openehr",
+          "termId" : "813",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "813",
+              "description" : "correction",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "813",
+              "description" : "*correction(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "813",
+              "description" : "*correction(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "813",
+              "description" : "*correction(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            }
+          }
+        },
+        "814" : {
+          "terminologyId" : "openehr",
+          "termId" : "814",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "openehr",
+              "language" : "en",
+              "codeString" : "814",
+              "description" : "update",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "es" : {
+              "terminologyId" : "openehr",
+              "language" : "es",
+              "codeString" : "814",
+              "description" : "*update(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "ja" : {
+              "terminologyId" : "openehr",
+              "language" : "ja",
+              "codeString" : "814",
+              "description" : "*update(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
+            },
+            "pt" : {
+              "terminologyId" : "openehr",
+              "language" : "pt",
+              "codeString" : "814",
+              "description" : "*update(en)",
+              "groupName" : "extract update trigger event type",
+              "groupIds" : [ "extract update trigger event type" ]
             }
           }
         }
@@ -23545,6 +31965,20 @@
             }
           }
         },
+        "BQ" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "BQ",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "BQ",
+              "description" : "BONAIRE, SINT EUSTATIUS AND SABA",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "BA" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "BA",
@@ -23951,6 +32385,20 @@
             }
           }
         },
+        "CW" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "CW",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "CW",
+              "description" : "CURAÇAO",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "CY" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "CY",
@@ -24114,6 +32562,20 @@
               "language" : "en",
               "codeString" : "EE",
               "description" : "ESTONIA",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "SZ" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "SZ",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "SZ",
+              "description" : "ESWATINI",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -24911,7 +33373,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "LY",
-              "description" : "LIBYAN ARAB JAMAHIRIYA",
+              "description" : "LIBYA",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -24968,20 +33430,6 @@
               "language" : "en",
               "codeString" : "MO",
               "description" : "MACAO",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
-        "MK" : {
-          "terminologyId" : "ISO_3166-1",
-          "termId" : "MK",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "ISO_3166-1",
-              "language" : "en",
-              "codeString" : "MK",
-              "description" : "MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -25345,7 +33793,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "AN",
-              "description" : "NETHERLANDS ANTILLES",
+              "description" : "NETHERLANDS ANTILLES - DEPRECATED",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -25449,6 +33897,20 @@
             }
           }
         },
+        "MK" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "MK",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "MK",
+              "description" : "NORTH MACEDONIA",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "MP" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "MP",
@@ -25527,7 +33989,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "PS",
-              "description" : "PALESTINIAN TERRITORY, OCCUPIED",
+              "description" : "PALESTINIAN, STATE OF",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -25681,7 +34143,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "RE",
-              "description" : "REUNION",
+              "description" : "RÉUNION",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -25751,7 +34213,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "SH",
-              "description" : "SAINT HELENA",
+              "description" : "SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -25793,7 +34255,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "MF",
-              "description" : "SAINT MARTIN",
+              "description" : "SAINT MARTIN (FRENCH PART)",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -25953,6 +34415,20 @@
             }
           }
         },
+        "SX" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "SX",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "SX",
+              "description" : "SINT MAARTEN (DUTCH PART)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "SK" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "SK",
@@ -26037,6 +34513,20 @@
             }
           }
         },
+        "SS" : {
+          "terminologyId" : "ISO_3166-1",
+          "termId" : "SS",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_3166-1",
+              "language" : "en",
+              "codeString" : "SS",
+              "description" : "SOUTH SUDAN",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ES" : {
           "terminologyId" : "ISO_3166-1",
           "termId" : "ES",
@@ -26102,20 +34592,6 @@
               "language" : "en",
               "codeString" : "SJ",
               "description" : "SVALBARD AND JAN MAYEN",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
-        "SZ" : {
-          "terminologyId" : "ISO_3166-1",
-          "termId" : "SZ",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "ISO_3166-1",
-              "language" : "en",
-              "codeString" : "SZ",
-              "description" : "SWAZILAND",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26311,7 +34787,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "TR",
-              "description" : "TURKEY",
+              "description" : "TÜRKIYE",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26409,7 +34885,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "GB",
-              "description" : "UNITED KINGDOM",
+              "description" : "UNITED KINGDOM OF GREAT BRITAIN AND NORTHERN IRELAND",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26423,7 +34899,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "US",
-              "description" : "UNITED STATES",
+              "description" : "UNITED STATES OF AMERICA",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26493,7 +34969,7 @@
               "terminologyId" : "ISO_3166-1",
               "language" : "en",
               "codeString" : "VE",
-              "description" : "VENEZUELA",
+              "description" : "VENEZUELA, BOLIVARIAN REPUBLIC OF",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26632,6 +35108,34 @@
             }
           }
         },
+        "ISO_8859-1:1987" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "ISO_8859-1:1987",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "ISO_8859-1:1987",
+              "description" : "ISO_8859-1:1987",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ISO-8859-2" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "ISO-8859-2",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "ISO-8859-2",
+              "description" : "ISO-8859-2",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ISO_8859-3:1988" : {
           "terminologyId" : "IANA_character-sets",
           "termId" : "ISO_8859-3:1988",
@@ -26641,6 +35145,48 @@
               "language" : "en",
               "codeString" : "ISO_8859-3:1988",
               "description" : "ISO_8859-3:1988",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ISO-8859-15" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "ISO-8859-15",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "ISO-8859-15",
+              "description" : "ISO-8859-15",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "US-ASCII" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "US-ASCII",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "US-ASCII",
+              "description" : "US-ASCII",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "UTF-7" : {
+          "terminologyId" : "IANA_character-sets",
+          "termId" : "UTF-7",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_character-sets",
+              "language" : "en",
+              "codeString" : "UTF-7",
+              "description" : "UTF-7",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26660,15 +35206,15 @@
             }
           }
         },
-        "UTF-7" : {
+        "UTF-16" : {
           "terminologyId" : "IANA_character-sets",
-          "termId" : "UTF-7",
+          "termId" : "UTF-16",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "IANA_character-sets",
               "language" : "en",
-              "codeString" : "UTF-7",
-              "description" : "UTF-7",
+              "codeString" : "UTF-16",
+              "description" : "UTF-16",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26697,20 +35243,6 @@
               "language" : "en",
               "codeString" : "UTF-16LE",
               "description" : "UTF-16LE",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
-        "UTF-16" : {
-          "terminologyId" : "IANA_character-sets",
-          "termId" : "UTF-16",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "IANA_character-sets",
-              "language" : "en",
-              "codeString" : "UTF-16",
-              "description" : "UTF-16",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -26757,20 +35289,6 @@
               "groupIds" : [ null ]
             }
           }
-        },
-        "ISO_8859-1:1987" : {
-          "terminologyId" : "IANA_character-sets",
-          "termId" : "ISO_8859-1:1987",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "IANA_character-sets",
-              "language" : "en",
-              "codeString" : "ISO_8859-1:1987",
-              "description" : "ISO_8859-1:1987",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
         }
       }
     },
@@ -26807,6 +35325,20 @@
             }
           }
         },
+        "ak" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ak",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ak",
+              "description" : "Akan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "sq" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "sq",
@@ -26816,6 +35348,34 @@
               "language" : "en",
               "codeString" : "sq",
               "description" : "Albanian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "am" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "am",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "am",
+              "description" : "Amharic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ar" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ar",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ar",
+              "description" : "Arabic",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27045,6 +35605,76 @@
             }
           }
         },
+        "an" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "an",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "an",
+              "description" : "Aragonese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "hy" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "hy",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "hy",
+              "description" : "Armenian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "as" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "as",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "as",
+              "description" : "Assamese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "av" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "av",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "av",
+              "description" : "Avaric, Avar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ay" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ay",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ay",
+              "description" : "Aymara",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "az" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "az",
@@ -27053,7 +35683,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "az",
-              "description" : "Azerbaijani",
+              "description" : "Azerbaijani, Azeri",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bm" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bm",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bm",
+              "description" : "Bambara",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ba" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ba",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ba",
+              "description" : "Bashkir",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27073,20 +35731,6 @@
             }
           }
         },
-        "bg" : {
-          "terminologyId" : "ISO_639-1",
-          "termId" : "bg",
-          "termCodesByLanguage" : {
-            "en" : {
-              "terminologyId" : "ISO_639-1",
-              "language" : "en",
-              "codeString" : "bg",
-              "description" : "Bulgarian",
-              "groupName" : null,
-              "groupIds" : [ null ]
-            }
-          }
-        },
         "be" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "be",
@@ -27101,6 +35745,90 @@
             }
           }
         },
+        "bn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bn",
+              "description" : "Bengali, Bangla",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bi" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bi",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bi",
+              "description" : "Bislama",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bs" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bs",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bs",
+              "description" : "Bosnian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "br" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "br",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "br",
+              "description" : "Breton",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bg",
+              "description" : "Bulgarian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "my" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "my",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "my",
+              "description" : "Burmese, Myanmar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ca" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ca",
@@ -27109,7 +35837,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "ca",
-              "description" : "Catalan",
+              "description" : "Catalan, Valencian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ch" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ch",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ch",
+              "description" : "Chamorro",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ce" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ce",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ce",
+              "description" : "Chechen",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ny" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ny",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ny",
+              "description" : "Chichewa, Chewa, Nyanja",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27185,6 +35955,76 @@
             }
           }
         },
+        "zh-mo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "zh-mo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "zh-mo",
+              "description" : "Chinese (Macau)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "cv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "cv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "cv",
+              "description" : "Chuvash",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kw",
+              "description" : "Cornish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "co" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "co",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "co",
+              "description" : "Corsican",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "cr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "cr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "cr",
+              "description" : "Cree",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "hr" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "hr",
@@ -27194,6 +36034,20 @@
               "language" : "en",
               "codeString" : "hr",
               "description" : "Croatian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "hr-ba" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "hr-ba",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "hr-ba",
+              "description" : "Croatian (Bosnia and Herzegovina)",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27227,6 +36081,20 @@
             }
           }
         },
+        "dv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "dv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "dv",
+              "description" : "Divehi, Dhivehi, Maldivian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "nl" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "nl",
@@ -27235,7 +36103,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "nl",
-              "description" : "Dutch (Standard)",
+              "description" : "Dutch",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27250,6 +36118,20 @@
               "language" : "en",
               "codeString" : "nl-be",
               "description" : "Dutch (Belgium)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "dz" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "dz",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "dz",
+              "description" : "Dzongkha",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27381,6 +36263,20 @@
             }
           }
         },
+        "en-cb" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "en-cb",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "en-cb",
+              "description" : "English (Caribbean)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "en-bz" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "en-bz",
@@ -27403,7 +36299,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "en-tt",
-              "description" : "English (Trinidad)",
+              "description" : "English (Trinidad and Tobago)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "en-ph" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "en-ph",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "en-ph",
+              "description" : "English (Republic of the Philippines)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "en-zw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "en-zw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "en-zw",
+              "description" : "English (Zimbabwe)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "eo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "eo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "eo",
+              "description" : "Esperanto",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27423,6 +36361,20 @@
             }
           }
         },
+        "ee" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ee",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ee",
+              "description" : "Ewe",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "fo" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "fo",
@@ -27431,21 +36383,21 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "fo",
-              "description" : "Faeroese",
+              "description" : "Faroese",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "fa" : {
+        "fj" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "fa",
+          "termId" : "fj",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "fa",
-              "description" : "Farsi",
+              "codeString" : "fj",
+              "description" : "Fijian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27473,7 +36425,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "fr",
-              "description" : "French (Standard)",
+              "description" : "French",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27535,6 +36487,48 @@
             }
           }
         },
+        "fr-mc" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "fr-mc",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "fr-mc",
+              "description" : "French (Principality of Monaco)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "fy" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "fy",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "fy",
+              "description" : "Frisian, Western Frisian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ff" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ff",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ff",
+              "description" : "Fulah, Fulani",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "gd" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "gd",
@@ -27543,7 +36537,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "gd",
-              "description" : "Gaelic (Scotland)",
+              "description" : "Gaelic, Scottish Gaelic",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27563,6 +36557,48 @@
             }
           }
         },
+        "gl" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gl",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gl",
+              "description" : "Galician",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "lg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lg",
+              "description" : "Ganda",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ka" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ka",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ka",
+              "description" : "Georgian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "de" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "de",
@@ -27571,7 +36607,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "de",
-              "description" : "German (Standard)",
+              "description" : "German",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27647,6 +36683,76 @@
             }
           }
         },
+        "kl" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kl",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kl",
+              "description" : "Kalaallisut, Greenlandic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "gn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gn",
+              "description" : "Guarani",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "gu" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gu",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gu",
+              "description" : "Gujarati",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ht" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ht",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ht",
+              "description" : "Haitian, Haitian Creole",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ha" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ha",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ha",
+              "description" : "Hausa",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "he" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "he",
@@ -27661,6 +36767,20 @@
             }
           }
         },
+        "hz" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "hz",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "hz",
+              "description" : "Herero",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "hi" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "hi",
@@ -27670,6 +36790,20 @@
               "language" : "en",
               "codeString" : "hi",
               "description" : "Hindi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ho" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ho",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ho",
+              "description" : "Hiri Motu, Pidgin Motu",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27703,6 +36837,20 @@
             }
           }
         },
+        "ig" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ig",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ig",
+              "description" : "Igbo",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "id" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "id",
@@ -27717,6 +36865,48 @@
             }
           }
         },
+        "iu" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "iu",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "iu",
+              "description" : "Inuktitut",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ik" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ik",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ik",
+              "description" : "Inupiaq",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ga" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ga",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ga",
+              "description" : "Irish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "it" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "it",
@@ -27725,7 +36915,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "it",
-              "description" : "Italian (Standard)",
+              "description" : "Italian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27759,6 +36949,62 @@
             }
           }
         },
+        "jv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "jv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "jv",
+              "description" : "Javanese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kn",
+              "description" : "Kannada",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kr",
+              "description" : "Kanuri",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ks" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ks",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ks",
+              "description" : "Kashmiri",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "kk" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "kk",
@@ -27767,7 +37013,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "kk",
-              "description" : "Kasakh",
+              "description" : "Kazakh",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27781,7 +37027,77 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "km",
-              "description" : "Central Khmer",
+              "description" : "Central Khmer, Cambodian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ki" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ki",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ki",
+              "description" : "Kikuyu, Gikuyu",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "rw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "rw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "rw",
+              "description" : "Kinyarwanda",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ky" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ky",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ky",
+              "description" : "Kirghiz, Kyrgyz",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kv",
+              "description" : "Komi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "kg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kg",
+              "description" : "Kongo",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27801,6 +37117,62 @@
             }
           }
         },
+        "kj" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "kj",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "kj",
+              "description" : "Kuanyama, Kwanyama",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ku" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ku",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ku",
+              "description" : "Kurdish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "lo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lo",
+              "description" : "Lao",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "la" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "la",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "la",
+              "description" : "Latin",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "lv" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "lv",
@@ -27810,6 +37182,34 @@
               "language" : "en",
               "codeString" : "lv",
               "description" : "Latvian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "li" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "li",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "li",
+              "description" : "Limburgan, Limburger, Limburgish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ln" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ln",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ln",
+              "description" : "Lingala",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27829,6 +37229,34 @@
             }
           }
         },
+        "lu" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lu",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lu",
+              "description" : "Luba-Katanga, Luba-Shaba",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "lb" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "lb",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "lb",
+              "description" : "Luxembourgish, Letzeburgesch",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "mk" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "mk",
@@ -27837,7 +37265,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "mk",
-              "description" : "FYRO Macedonian ms Malaysian",
+              "description" : "Macedonian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mg",
+              "description" : "Malagasy",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ms" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ms",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ms",
+              "description" : "Malay",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ml" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ml",
+              "description" : "Malayalam",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27852,6 +37322,160 @@
               "language" : "en",
               "codeString" : "mt",
               "description" : "Maltese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "gv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "gv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "gv",
+              "description" : "Manx",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mi" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mi",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mi",
+              "description" : "Maori",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mr",
+              "description" : "Marathi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mh" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mh",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mh",
+              "description" : "Marshallese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "mn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "mn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "mn",
+              "description" : "Mongolian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "na" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "na",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "na",
+              "description" : "Nauru, Nauruan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "nv" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "nv",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "nv",
+              "description" : "Navajo, Navaho",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "nd" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "nd",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "nd",
+              "description" : "North Ndebele",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "nr" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "nr",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "nr",
+              "description" : "South Ndebele",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ng" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ng",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ng",
+              "description" : "Ndonga",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ne" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ne",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ne",
+              "description" : "Nepali",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27885,6 +37509,118 @@
             }
           }
         },
+        "ii" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ii",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ii",
+              "description" : "Sichuan Yi, Nuosu, Northern Yi, Liangshan Yi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "oc" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "oc",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "oc",
+              "description" : "Occitan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "oj" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "oj",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "oj",
+              "description" : "Ojibwa, Ojibwe",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "or" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "or",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "or",
+              "description" : "Oriya, Odia",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "om" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "om",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "om",
+              "description" : "Oromo",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "os" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "os",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "os",
+              "description" : "Ossetian, Ossetic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ps" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ps",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ps",
+              "description" : "Pashto, Pushto",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "fa" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "fa",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "fa",
+              "description" : "Persian, Farsi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "pl" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "pl",
@@ -27894,6 +37630,20 @@
               "language" : "en",
               "codeString" : "pl",
               "description" : "Polish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "pt" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "pt",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "pt",
+              "description" : "Portuguese",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27921,35 +37671,77 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "pt-pt",
-              "description" : "Portuguese (Portugal)",
+              "description" : "Portuguese (Portugal) - DEPRECATED",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "pt" : {
+        "pa" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "pt",
+          "termId" : "pa",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "pt",
-              "description" : "Portuguese",
+              "codeString" : "pa",
+              "description" : "Punjabi, Panjabi",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "rm" : {
+        "qu" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "rm",
+          "termId" : "qu",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "rm",
-              "description" : "Rhaeto-Romanic",
+              "codeString" : "qu",
+              "description" : "Quechua",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "qu-bo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "qu-bo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "qu-bo",
+              "description" : "Quechua (Bolivia)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "qu-ec" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "qu-ec",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "qu-ec",
+              "description" : "Quechua (Ecuador)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "qu-pe" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "qu-pe",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "qu-pe",
+              "description" : "Quechua (Peru)",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -27983,6 +37775,34 @@
             }
           }
         },
+        "rm" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "rm",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "rm",
+              "description" : "Romansh, Rhaeto-Romanic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "rn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "rn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "rn",
+              "description" : "Rundi, Kirundi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ru" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ru",
@@ -28011,6 +37831,20 @@
             }
           }
         },
+        "se" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "se",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "se",
+              "description" : "Northern Sami",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "sz" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "sz",
@@ -28019,7 +37853,49 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sz",
-              "description" : "Sami (Lappish)",
+              "description" : "Sami (Lappish) - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sm" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sm",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sm",
+              "description" : "Samoan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sg",
+              "description" : "Sango",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sc" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sc",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sc",
+              "description" : "Sardinian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28033,7 +37909,77 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sr",
-              "description" : "Serbian (Cyrillic)",
+              "description" : "Serbian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sr-ba" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sr-ba",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sr-ba",
+              "description" : "Serbian (Bosnia and Herzegovina)",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sb" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sb",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sb",
+              "description" : "Serbian - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sn" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sn",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sn",
+              "description" : "Shona",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sd" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sd",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sd",
+              "description" : "Sindhi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "si" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "si",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "si",
+              "description" : "Sinhala, Sinhalese",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28061,35 +38007,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sl",
-              "description" : "Slovenian",
+              "description" : "Slovenian, Slovene",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "si" : {
+        "so" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "si",
+          "termId" : "so",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "si",
-              "description" : "Sinhala",
+              "codeString" : "so",
+              "description" : "Somali",
               "groupName" : null,
               "groupIds" : [ null ]
             }
           }
         },
-        "sb" : {
+        "st" : {
           "terminologyId" : "ISO_639-1",
-          "termId" : "sb",
+          "termId" : "st",
           "termCodesByLanguage" : {
             "en" : {
               "terminologyId" : "ISO_639-1",
               "language" : "en",
-              "codeString" : "sb",
-              "description" : "Serbian",
+              "codeString" : "st",
+              "description" : "Southern Sotho, Sesotho, Sutu",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28103,7 +38049,7 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "es",
-              "description" : "Spanish (Spain ? Traditional)",
+              "description" : "Spanish, Castilian",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28361,6 +38307,20 @@
             }
           }
         },
+        "su" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "su",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "su",
+              "description" : "Sundanese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "sx" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "sx",
@@ -28369,7 +38329,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "sx",
-              "description" : "Sutu",
+              "description" : "Sutu - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "sw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "sw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "sw",
+              "description" : "Swahili",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ss" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ss",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ss",
+              "description" : "Swati, Swazi",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28403,6 +38391,90 @@
             }
           }
         },
+        "tl" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tl",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tl",
+              "description" : "Tagalog",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ty" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ty",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ty",
+              "description" : "Tahitian",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "tg" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tg",
+              "description" : "Tajik",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ta" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ta",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ta",
+              "description" : "Tamil",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "tt" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tt",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tt",
+              "description" : "Tatar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "te" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "te",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "te",
+              "description" : "Telugu",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "th" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "th",
@@ -28412,6 +38484,48 @@
               "language" : "en",
               "codeString" : "th",
               "description" : "Thai",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "bo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "bo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "bo",
+              "description" : "Tibetan",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ti" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ti",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ti",
+              "description" : "Tigrinya",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "to" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "to",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "to",
+              "description" : "Tonga, Tongan",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28459,6 +38573,48 @@
             }
           }
         },
+        "tk" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tk",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tk",
+              "description" : "Turkmen",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "tw" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "tw",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "tw",
+              "description" : "Twi",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "ug" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "ug",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "ug",
+              "description" : "Uighur, Uyghur",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "uk" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "uk",
@@ -28487,6 +38643,20 @@
             }
           }
         },
+        "uz" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "uz",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "uz",
+              "description" : "Uzbek",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ve" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ve",
@@ -28510,6 +38680,20 @@
               "language" : "en",
               "codeString" : "vi",
               "description" : "Vietnamese",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "wa" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "wa",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "wa",
+              "description" : "Walloon",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28557,6 +38741,20 @@
             }
           }
         },
+        "wo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "wo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "wo",
+              "description" : "Wolof",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "xh" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "xh",
@@ -28571,6 +38769,20 @@
             }
           }
         },
+        "yi" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "yi",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "yi",
+              "description" : "Yiddish",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "ji" : {
           "terminologyId" : "ISO_639-1",
           "termId" : "ji",
@@ -28579,7 +38791,35 @@
               "terminologyId" : "ISO_639-1",
               "language" : "en",
               "codeString" : "ji",
-              "description" : "Yiddish",
+              "description" : "Yiddish - DEPRECATED",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "yo" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "yo",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "yo",
+              "description" : "Yoruba",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "za" : {
+          "terminologyId" : "ISO_639-1",
+          "termId" : "za",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "ISO_639-1",
+              "language" : "en",
+              "codeString" : "za",
+              "description" : "Zhuang, Chuang",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28900,6 +39140,20 @@
             }
           }
         },
+        "video/H264" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/H264",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/H264",
+              "description" : "video/H264",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "video/MPV" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "video/MPV",
@@ -28909,6 +39163,48 @@
               "language" : "en",
               "codeString" : "video/MPV",
               "description" : "video/MPV",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "video/mp4" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/mp4",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/mp4",
+              "description" : "video/mp4",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "video/ogg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/ogg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/ogg",
+              "description" : "video/ogg",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "video/mpeg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "video/mpeg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "video/mpeg",
+              "description" : "video/mpeg",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28942,6 +39238,20 @@
             }
           }
         },
+        "audio/mpeg3" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/mpeg3",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/mpeg3",
+              "description" : "audio/mpeg3",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "audio/mpeg4-generic" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "audio/mpeg4-generic",
@@ -28951,6 +39261,20 @@
               "language" : "en",
               "codeString" : "audio/mpeg4-generic",
               "description" : "audio/mpeg4-generic",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "audio/mp4" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/mp4",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/mp4",
+              "description" : "audio/mp4",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -28993,6 +39317,34 @@
               "language" : "en",
               "codeString" : "audio/telephone-event",
               "description" : "audio/telephone-event",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "audio/ogg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/ogg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/ogg",
+              "description" : "audio/ogg",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "audio/vorbis" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "audio/vorbis",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "audio/vorbis",
+              "description" : "audio/vorbis",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -29180,6 +39532,34 @@
             }
           }
         },
+        "image/avif" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/avif",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/avif",
+              "description" : "image/avif",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "image/bmp" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/bmp",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/bmp",
+              "description" : "image/bmp",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "image/cgm" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "image/cgm",
@@ -29250,6 +39630,132 @@
             }
           }
         },
+        "image/jp2" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/jp2",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/jp2",
+              "description" : "image/jp2",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "image/svg+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "image/svg+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "image/svg+xml",
+              "description" : "image/svg+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/cda+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/cda+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/cda+xml",
+              "description" : "application/cda+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/EDIFACT" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/EDIFACT",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/EDIFACT",
+              "description" : "application/EDIFACT",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/fhir+json" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/fhir+json",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/fhir+json",
+              "description" : "application/fhir+json",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/fhir+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/fhir+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/fhir+xml",
+              "description" : "application/fhir+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/hl7v2+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/hl7v2+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/hl7v2+xml",
+              "description" : "application/hl7v2+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/gzip" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/gzip",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/gzip",
+              "description" : "application/gzip",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/json" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/json",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/json",
+              "description" : "application/json",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "application/msword" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "application/msword",
@@ -29306,6 +39812,244 @@
             }
           }
         },
+        "application/dicom+json" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/dicom+json",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/dicom+json",
+              "description" : "application/dicom+json",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/dicom+xml" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/dicom+xml",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/dicom+xml",
+              "description" : "application/dicom+xml",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/octet-stream" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/octet-stream",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/octet-stream",
+              "description" : "application/octet-stream",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/ogg" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/ogg",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/ogg",
+              "description" : "application/ogg",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.base" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.base",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.base",
+              "description" : "application/vnd.oasis.opendocument.base",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.chart" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.chart",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.chart",
+              "description" : "application/vnd.oasis.opendocument.chart",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.chart-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.chart-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.chart-template",
+              "description" : "application/vnd.oasis.opendocument.chart-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.formula" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.formula",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.formula",
+              "description" : "application/vnd.oasis.opendocument.formula",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.formula-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.formula-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.formula-template",
+              "description" : "application/vnd.oasis.opendocument.formula-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.graphics" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.graphics",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.graphics",
+              "description" : "application/vnd.oasis.opendocument.graphics",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.graphics-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.graphics-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.graphics-template",
+              "description" : "application/vnd.oasis.opendocument.graphics-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.image" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.image",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.image",
+              "description" : "application/vnd.oasis.opendocument.image",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.image-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.image-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.image-template",
+              "description" : "application/vnd.oasis.opendocument.image-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.presentation" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.presentation",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.presentation",
+              "description" : "application/vnd.oasis.opendocument.presentation",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.presentation-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.presentation-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.presentation-template",
+              "description" : "application/vnd.oasis.opendocument.presentation-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.spreadsheet" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.spreadsheet",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.spreadsheet",
+              "description" : "application/vnd.oasis.opendocument.spreadsheet",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.spreadsheet-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.spreadsheet-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.spreadsheet-template",
+              "description" : "application/vnd.oasis.opendocument.spreadsheet-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
         "application/vnd.oasis.opendocument.text" : {
           "terminologyId" : "IANA_media-types",
           "termId" : "application/vnd.oasis.opendocument.text",
@@ -29315,6 +40059,48 @@
               "language" : "en",
               "codeString" : "application/vnd.oasis.opendocument.text",
               "description" : "application/vnd.oasis.opendocument.text",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.text-master" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.text-master",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.text-master",
+              "description" : "application/vnd.oasis.opendocument.text-master",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.text-template" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.text-template",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.text-template",
+              "description" : "application/vnd.oasis.opendocument.text-template",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.oasis.opendocument.text-web" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.oasis.opendocument.text-web",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.oasis.opendocument.text-web",
+              "description" : "application/vnd.oasis.opendocument.text-web",
               "groupName" : null,
               "groupIds" : [ null ]
             }
@@ -29483,6 +40269,76 @@
               "language" : "en",
               "codeString" : "application/vnd.ms-xpsdocument",
               "description" : "application/vnd.ms-xpsdocument",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.ms-excel" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.ms-excel",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.ms-excel",
+              "description" : "application/vnd.ms-excel",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.ms-outlook" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.ms-outlook",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.ms-outlook",
+              "description" : "application/vnd.ms-outlook",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.ms-powerpoint" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.ms-powerpoint",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.ms-powerpoint",
+              "description" : "application/vnd.ms-powerpoint",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/vnd.rar" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/vnd.rar",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/vnd.rar",
+              "description" : "application/vnd.rar",
+              "groupName" : null,
+              "groupIds" : [ null ]
+            }
+          }
+        },
+        "application/zip" : {
+          "terminologyId" : "IANA_media-types",
+          "termId" : "application/zip",
+          "termCodesByLanguage" : {
+            "en" : {
+              "terminologyId" : "IANA_media-types",
+              "language" : "en",
+              "codeString" : "application/zip",
+              "description" : "application/zip",
               "groupName" : null,
               "groupIds" : [ null ]
             }

--- a/openehr-terminology/src/main/resources/openEHR_RM/ja/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/ja/openehr_terminology.xml
@@ -24,11 +24,11 @@
 		<code value="LL"/> 
 		<code value="LLL"/>
 	</codeset>
-	<group name="認証理由">
+	<group name="認証理由" id="attestation reason">
 		<concept id="240" rubric="署名"/>
 		<concept id="648" rubric="証言"/>
 	</group>
-	<group name="監査変更種別">
+	<group name="監査変更種別" id="audit change type">
 		<concept id="249" rubric="作成"/>
 		<concept id="250" rubric="訂正"/>
 		<concept id="251" rubric="変更"/>
@@ -37,13 +37,12 @@
 		<concept id="666" rubric="認証"/>
 		<concept id="253" rubric="不明"/>
 	</group>
-	<group name="コンポジションカテゴリ">
+	<group name="コンポジションカテゴリ" id="composition category">
 		<concept id="431" rubric="永続"/>
 		<concept id="433" rubric="イベント"/>
 		<concept id="451" rubric="*episodic(en)"/>
 	</group>
-	<!--
-	<group name="MultiMedia">
+	<group name="MultiMedia" id="MultiMedia">
 		<concept id="387" rubric="audio/DVI4" />
 		<concept id="388" rubric="audio/G722" />
 		<concept id="389" rubric="audio/G723" />
@@ -94,8 +93,7 @@
 		<concept id="682" rubric="application/vnd.oasis.opendocument.text" />
 		<concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 	</group>
-	-->
-	<group name="プロパティ">
+	<group name="プロパティ" id="property">
 		<concept id="339" rubric="加速度"/>
 		<concept id="342" rubric="角加速度"/>
 		<concept id="381" rubric="量 (Eq)"/>
@@ -173,23 +171,23 @@
 		<concept id="130" rubric="仕事量"/>
 		<concept id="685" rubric="屈折力"/>
 	</group>
-	<group name="version lifecycle state">
+	<group name="version lifecycle state" id="version lifecycle state">
 		<concept id="532" rubric="完了"/>
 		<concept id="553" rubric="未完"/>
 		<concept id="523" rubric="削除済み"/>
 		<concept id="800" rubric="*inactive(en)"/>
 		<concept id="801" rubric="*abandoned(en)"/>
 	</group>
-	<group name="participation function">
+	<group name="participation function" id="participation function">
 		<concept id="253" rubric="未知"/>
 	</group>
-	<group name="null flavours">
+	<group name="null flavours" id="null flavours">
 		<concept id="271" rubric="不明"/>
 		<concept id="253" rubric="未知"/>
 		<concept id="272" rubric="隠蔽された"/>
 		<concept id="273" rubric="該当なし"/>
 	</group>
-	<group name="participation mode">
+	<group name="participation mode" id="participation mode">
 		<concept id="193" rubric="指定なし"/>
 		<concept id="216" rubric="対面コミュニケーション"/>
 		<concept id="223" rubric="通訳された対面コミュニケーション"/>
@@ -223,7 +221,7 @@
 		<concept id="219" rubric="出席"/>
 		<concept id="220" rubric="遠隔での参加"/>
 	</group>
-	<group name="instruction states">
+	<group name="instruction states" id="instruction states">
 		<concept id="524" rubric="最初"/>
 		<concept id="526" rubric="予定されている"/>
 		<concept id="527" rubric="延期された"/>
@@ -235,7 +233,7 @@
 		<concept id="532" rubric="完了"/>
 		<concept id="533" rubric="期限切れ"/>
 	</group>
-	<group name="instruction transitions">
+	<group name="instruction transitions" id="instruction transitionss">
 		<concept id="535" rubric="新しく始める"/>
 		<concept id="536" rubric="ステップを計画する"/>
 		<concept id="537" rubric="延期する"/>
@@ -257,7 +255,7 @@
 		<concept id="551" rubric="完了を知らせる"/>
 		<concept id="552" rubric="キャンセルを知らせる"/>
 	</group>
-	<group name="subject relationship">
+	<group name="subject relationship" id="subject relationships">
 		<concept id="0" rubric="自己"/>
 		<concept id="3" rubric="胎児"/>
 		<concept id="10" rubric="母"/>
@@ -295,12 +293,12 @@
 		<concept id="25" rubric="義理あるいは異父母兄弟"/>
 		<concept id="26" rubric="義理あるいは異父母姉妹"/>
 	</group>
-	<group name="term mapping purpose">
+	<group name="term mapping purpose" id="term mapping purpose">
 		<concept id="669" rubric="公衆衛生"/>
 		<concept id="670" rubric="償還"/>
 		<concept id="671" rubric="研究"/>
 	</group>
-	<group name="event math function">
+	<group name="event math function" id="event math function">
 		<concept id="145" rubric="最小"/>
 		<concept id="144" rubric="最大"/>
 		<concept id="267" rubric="最頻値"/>
@@ -313,7 +311,7 @@
 		<concept id="522" rubric="増加"/>
 		<concept id="640" rubric="実際の"/>
 	</group>
-	<group name="setting">
+	<group name="setting" id="setting">
 		<concept id="225" rubric="居宅"/>
 		<concept id="227" rubric="救急治療"/>
 		<concept id="228" rubric="プライマリー医療"/>
@@ -329,7 +327,7 @@
 		<concept id="802" rubric="*mental healthcare(en)"/>
 		<concept id="238" rubric="その他のケア"/>
 	</group>
-	<group name="extract content type">
+	<group name="extract content type" id="extract content type">
 		<concept id="803" rubric="*openEHR EHR(en)"/>
 		<concept id="804" rubric="*openEHR Demographic(en)"/>
 		<concept id="805" rubric="*openEHR synchronisation(en)"/>
@@ -337,12 +335,12 @@
 		<concept id="807" rubric="*generic EMR(en)"/>
 		<concept id="808" rubric="*other(en)"/>
 	</group>
-	<group name="extract action type">
+	<group name="extract action type" id="extract action type">
 		<concept id="809" rubric="*cancel(en)"/>
 		<concept id="810" rubric="*resend(en)"/>
 		<concept id="811" rubric="*send new(en)"/>
 	</group>
-	<group name="extract update trigger event type">
+	<group name="extract update trigger event type" id="extract update trigger event type">
 		<concept id="812" rubric="*any change(en)"/>
 		<concept id="813" rubric="*correction(en)"/>
 		<concept id="814" rubric="*update(en)"/>

--- a/openehr-terminology/src/main/resources/openEHR_RM/ja/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/ja/openehr_terminology.xml
@@ -233,7 +233,7 @@
 		<concept id="532" rubric="完了"/>
 		<concept id="533" rubric="期限切れ"/>
 	</group>
-	<group name="instruction transitions" id="instruction transitionss">
+	<group name="instruction transitions" id="instruction transitions">
 		<concept id="535" rubric="新しく始める"/>
 		<concept id="536" rubric="ステップを計画する"/>
 		<concept id="537" rubric="延期する"/>
@@ -255,7 +255,7 @@
 		<concept id="551" rubric="完了を知らせる"/>
 		<concept id="552" rubric="キャンセルを知らせる"/>
 	</group>
-	<group name="subject relationship" id="subject relationships">
+	<group name="subject relationship" id="subject relationship">
 		<concept id="0" rubric="自己"/>
 		<concept id="3" rubric="胎児"/>
 		<concept id="10" rubric="母"/>

--- a/openehr-terminology/src/main/resources/openEHR_RM/ja/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/ja/openehr_terminology.xml
@@ -1,4 +1,4 @@
-<terminology name="openehr" language="ja">
+<terminology name="openehr" language="ja">	
 	<codeset issuer="openehr" openehr_id="compression algorithms" external_id="openehr_compression_algorithms">
 		<code value="圧縮"/>
 		<code value="展開"/>
@@ -8,8 +8,13 @@
 	</codeset>
 	<codeset issuer="openehr" openehr_id="integrity check algorithms" external_id="openehr_integrity_check_algorithms">
 		<code value="SHA-1"/>
+		<code value="SHA-224"/>
 		<code value="SHA-256"/>
-	</codeset>	
+		<code value="SHA-384"/>
+		<code value="SHA-512"/>
+		<code value="SHA-512/224"/>
+		<code value="SHA-512/256"/>
+	</codeset>
 	<codeset issuer="openehr" openehr_id="normal statuses" external_id="openehr_normal_statuses">
 		<code value="HHH"/>
 		<code value="HH"/>
@@ -19,11 +24,11 @@
 		<code value="LL"/> 
 		<code value="LLL"/>
 	</codeset>
-	<group name="認証理由" id="attestation reason">
+	<group name="認証理由">
 		<concept id="240" rubric="署名"/>
 		<concept id="648" rubric="証言"/>
 	</group>
-	<group name="監査変更種別" id="audit change type">
+	<group name="監査変更種別">
 		<concept id="249" rubric="作成"/>
 		<concept id="250" rubric="訂正"/>
 		<concept id="251" rubric="変更"/>
@@ -32,12 +37,13 @@
 		<concept id="666" rubric="認証"/>
 		<concept id="253" rubric="不明"/>
 	</group>
-	<group name="コンポジションカテゴリ" id="composition category">
+	<group name="コンポジションカテゴリ">
 		<concept id="431" rubric="永続"/>
 		<concept id="433" rubric="イベント"/>
-		<concept id="435" rubric="*episodic(en)"/>
+		<concept id="451" rubric="*episodic(en)"/>
 	</group>
-	<group name="MultiMedia" id="MultiMedia">
+	<!--
+	<group name="MultiMedia">
 		<concept id="387" rubric="audio/DVI4" />
 		<concept id="388" rubric="audio/G722" />
 		<concept id="389" rubric="audio/G723" />
@@ -88,7 +94,8 @@
 		<concept id="682" rubric="application/vnd.oasis.opendocument.text" />
 		<concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 	</group>
-	<group name="プロパティ" id="property">
+	-->
+	<group name="プロパティ">
 		<concept id="339" rubric="加速度"/>
 		<concept id="342" rubric="角加速度"/>
 		<concept id="381" rubric="量 (Eq)"/>
@@ -166,21 +173,23 @@
 		<concept id="130" rubric="仕事量"/>
 		<concept id="685" rubric="屈折力"/>
 	</group>
-	<group name="version lifecycle state" id="version lifecycle state">
+	<group name="version lifecycle state">
 		<concept id="532" rubric="完了"/>
 		<concept id="553" rubric="未完"/>
 		<concept id="523" rubric="削除済み"/>
+		<concept id="800" rubric="*inactive(en)"/>
+		<concept id="801" rubric="*abandoned(en)"/>
 	</group>
-	<group name="participation function" id="participation function">
+	<group name="participation function">
 		<concept id="253" rubric="未知"/>
 	</group>
-	<group name="null flavours" id="null flavours">
+	<group name="null flavours">
 		<concept id="271" rubric="不明"/>
 		<concept id="253" rubric="未知"/>
 		<concept id="272" rubric="隠蔽された"/>
 		<concept id="273" rubric="該当なし"/>
 	</group>
-	<group name="participation mode" id="participation mode">
+	<group name="participation mode">
 		<concept id="193" rubric="指定なし"/>
 		<concept id="216" rubric="対面コミュニケーション"/>
 		<concept id="223" rubric="通訳された対面コミュニケーション"/>
@@ -214,7 +223,7 @@
 		<concept id="219" rubric="出席"/>
 		<concept id="220" rubric="遠隔での参加"/>
 	</group>
-	<group name="instruction states" id="instruction states">
+	<group name="instruction states">
 		<concept id="524" rubric="最初"/>
 		<concept id="526" rubric="予定されている"/>
 		<concept id="527" rubric="延期された"/>
@@ -226,7 +235,7 @@
 		<concept id="532" rubric="完了"/>
 		<concept id="533" rubric="期限切れ"/>
 	</group>
-	<group name="instruction transitions" id="instruction transitionss">
+	<group name="instruction transitions">
 		<concept id="535" rubric="新しく始める"/>
 		<concept id="536" rubric="ステップを計画する"/>
 		<concept id="537" rubric="延期する"/>
@@ -248,7 +257,7 @@
 		<concept id="551" rubric="完了を知らせる"/>
 		<concept id="552" rubric="キャンセルを知らせる"/>
 	</group>
-	<group name="subject relationship" id="subject relationships">
+	<group name="subject relationship">
 		<concept id="0" rubric="自己"/>
 		<concept id="3" rubric="胎児"/>
 		<concept id="10" rubric="母"/>
@@ -286,12 +295,12 @@
 		<concept id="25" rubric="義理あるいは異父母兄弟"/>
 		<concept id="26" rubric="義理あるいは異父母姉妹"/>
 	</group>
-	<group name="term mapping purpose" id="term mapping purpose">
+	<group name="term mapping purpose">
 		<concept id="669" rubric="公衆衛生"/>
 		<concept id="670" rubric="償還"/>
 		<concept id="671" rubric="研究"/>
 	</group>
-	<group name="event math function" id="event math function">
+	<group name="event math function">
 		<concept id="145" rubric="最小"/>
 		<concept id="144" rubric="最大"/>
 		<concept id="267" rubric="最頻値"/>
@@ -304,7 +313,7 @@
 		<concept id="522" rubric="増加"/>
 		<concept id="640" rubric="実際の"/>
 	</group>
-	<group name="setting" id="setting">
+	<group name="setting">
 		<concept id="225" rubric="居宅"/>
 		<concept id="227" rubric="救急治療"/>
 		<concept id="228" rubric="プライマリー医療"/>
@@ -317,6 +326,25 @@
 		<concept id="235" rubric="代替医療 "/>
 		<concept id="236" rubric="歯科治療"/>
 		<concept id="237" rubric="在宅介護"/>
+		<concept id="802" rubric="*mental healthcare(en)"/>
 		<concept id="238" rubric="その他のケア"/>
+	</group>
+	<group name="extract content type">
+		<concept id="803" rubric="*openEHR EHR(en)"/>
+		<concept id="804" rubric="*openEHR Demographic(en)"/>
+		<concept id="805" rubric="*openEHR synchronisation(en)"/>
+		<concept id="806" rubric="*openEHR generic(en)"/>
+		<concept id="807" rubric="*generic EMR(en)"/>
+		<concept id="808" rubric="*other(en)"/>
+	</group>
+	<group name="extract action type">
+		<concept id="809" rubric="*cancel(en)"/>
+		<concept id="810" rubric="*resend(en)"/>
+		<concept id="811" rubric="*send new(en)"/>
+	</group>
+	<group name="extract update trigger event type">
+		<concept id="812" rubric="*any change(en)"/>
+		<concept id="813" rubric="*correction(en)"/>
+		<concept id="814" rubric="*update(en)"/>
 	</group>
 </terminology>

--- a/openehr-terminology/src/main/resources/openEHR_RM/openehr_external_terminologies.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/openehr_external_terminologies.xml
@@ -27,6 +27,7 @@
 		<code value="BM" description="BERMUDA"/>
 		<code value="BT" description="BHUTAN"/>
 		<code value="BO" description="BOLIVIA"/>
+		<code value="BQ" description="BONAIRE, SINT EUSTATIUS AND SABA"/>
 		<code value="BA" description="BOSNIA AND HERZEGOVINA"/>
 		<code value="BW" description="BOTSWANA"/>
 		<code value="BV" description="BOUVET ISLAND"/>
@@ -56,6 +57,7 @@
 		<code value="CI" description="CÔTE D'IVOIRE"/>
 		<code value="HR" description="CROATIA"/>
 		<code value="CU" description="CUBA"/>
+        <code value="CW" description="CURAÇAO"/>
 		<code value="CY" description="CYPRUS"/>
 		<code value="CZ" description="CZECH REPUBLIC"/>
 		<code value="DK" description="DENMARK"/>
@@ -68,6 +70,7 @@
 		<code value="GQ" description="EQUATORIAL GUINEA"/>
 		<code value="ER" description="ERITREA"/>
 		<code value="EE" description="ESTONIA"/>
+        <code value="SZ" description="ESWATINI"/>
 		<code value="ET" description="ETHIOPIA"/>
 		<code value="FK" description="FALKLAND ISLANDS (MALVINAS)"/>
 		<code value="FO" description="FAROE ISLANDS"/>
@@ -124,12 +127,11 @@
 		<code value="LB" description="LEBANON"/>
 		<code value="LS" description="LESOTHO"/>
 		<code value="LR" description="LIBERIA"/>
-		<code value="LY" description="LIBYAN ARAB JAMAHIRIYA"/>
+		<code value="LY" description="LIBYA"/>
 		<code value="LI" description="LIECHTENSTEIN"/>
 		<code value="LT" description="LITHUANIA"/>
 		<code value="LU" description="LUXEMBOURG"/>
 		<code value="MO" description="MACAO"/>
-		<code value="MK" description="MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF"/>
 		<code value="MG" description="MADAGASCAR"/>
 		<code value="MW" description="MALAWI"/>
 		<code value="MY" description="MALAYSIA"/>
@@ -155,7 +157,7 @@
 		<code value="NR" description="NAURU"/>
 		<code value="NP" description="NEPAL"/>
 		<code value="NL" description="NETHERLANDS"/>
-		<code value="AN" description="NETHERLANDS ANTILLES"/>
+		<code value="AN" description="NETHERLANDS ANTILLES - DEPRECATED"/>
 		<code value="NC" description="NEW CALEDONIA"/>
 		<code value="NZ" description="NEW ZEALAND"/>
 		<code value="NI" description="NICARAGUA"/>
@@ -163,12 +165,13 @@
 		<code value="NG" description="NIGERIA"/>
 		<code value="NU" description="NIUE"/>
 		<code value="NF" description="NORFOLK ISLAND"/>
+		<code value="MK" description="NORTH MACEDONIA"/>
 		<code value="MP" description="NORTHERN MARIANA ISLANDS"/>
 		<code value="NO" description="NORWAY"/>
 		<code value="OM" description="OMAN"/>
 		<code value="PK" description="PAKISTAN"/>
 		<code value="PW" description="PALAU"/>
-		<code value="PS" description="PALESTINIAN TERRITORY, OCCUPIED"/>
+		<code value="PS" description="PALESTINIAN, STATE OF"/>
 		<code value="PA" description="PANAMA"/>
 		<code value="PG" description="PAPUA NEW GUINEA"/>
 		<code value="PY" description="PARAGUAY"/>
@@ -179,15 +182,15 @@
 		<code value="PT" description="PORTUGAL"/>
 		<code value="PR" description="PUERTO RICO"/>
 		<code value="QA" description="QATAR"/>
-		<code value="RE" description="REUNION"/>
+		<code value="RE" description="RÉUNION"/>
 		<code value="RO" description="ROMANIA"/>
 		<code value="RU" description="RUSSIAN FEDERATION"/>
 		<code value="RW" description="RWANDA"/>
 		<code value="BL" description="SAINT BARTHÉLEMY"/>
-		<code value="SH" description="SAINT HELENA"/>
+		<code value="SH" description="SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA"/>
 		<code value="KN" description="SAINT KITTS AND NEVIS"/>
 		<code value="LC" description="SAINT LUCIA"/>
-		<code value="MF" description="SAINT MARTIN"/>
+		<code value="MF" description="SAINT MARTIN (FRENCH PART)"/>
 		<code value="PM" description="SAINT PIERRE AND MIQUELON"/>
 		<code value="VC" description="SAINT VINCENT AND THE GRENADINES"/>
 		<code value="WS" description="SAMOA"/>
@@ -199,18 +202,19 @@
 		<code value="SC" description="SEYCHELLES"/>
 		<code value="SL" description="SIERRA LEONE"/>
 		<code value="SG" description="SINGAPORE"/>
+        <code value="SX" description="SINT MAARTEN (DUTCH PART)"/>
 		<code value="SK" description="SLOVAKIA"/>
 		<code value="SI" description="SLOVENIA"/>
 		<code value="SB" description="SOLOMON ISLANDS"/>
 		<code value="SO" description="SOMALIA"/>
 		<code value="ZA" description="SOUTH AFRICA"/>
 		<code value="GS" description="SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS"/>
+        <code value="SS" description="SOUTH SUDAN"/>
 		<code value="ES" description="SPAIN"/>
 		<code value="LK" description="SRI LANKA"/>
 		<code value="SD" description="SUDAN"/>
 		<code value="SR" description="SURINAME"/>
 		<code value="SJ" description="SVALBARD AND JAN MAYEN"/>
-		<code value="SZ" description="SWAZILAND"/>
 		<code value="SE" description="SWEDEN"/>
 		<code value="CH" description="SWITZERLAND"/>
 		<code value="SY" description="SYRIAN ARAB REPUBLIC"/>
@@ -224,20 +228,20 @@
 		<code value="TO" description="TONGA"/>
 		<code value="TT" description="TRINIDAD AND TOBAGO"/>
 		<code value="TN" description="TUNISIA"/>
-		<code value="TR" description="TURKEY"/>
+		<code value="TR" description="TÜRKIYE"/>
 		<code value="TM" description="TURKMENISTAN"/>
 		<code value="TC" description="TURKS AND CAICOS ISLANDS"/>
 		<code value="TV" description="TUVALU"/>
 		<code value="UG" description="UGANDA"/>
 		<code value="UA" description="UKRAINE"/>
 		<code value="AE" description="UNITED ARAB EMIRATES"/>
-		<code value="GB" description="UNITED KINGDOM"/>
-		<code value="US" description="UNITED STATES"/>
+		<code value="GB" description="UNITED KINGDOM OF GREAT BRITAIN AND NORTHERN IRELAND"/>
+		<code value="US" description="UNITED STATES OF AMERICA"/>
 		<code value="UM" description="UNITED STATES MINOR OUTLYING ISLANDS"/>
 		<code value="UY" description="URUGUAY"/>
 		<code value="UZ" description="UZBEKISTAN"/>
 		<code value="VU" description="VANUATU"/>
-		<code value="VE" description="VENEZUELA"/>
+		<code value="VE" description="VENEZUELA, BOLIVARIAN REPUBLIC OF"/>
 		<code value="VN" description="VIET NAM"/>
 		<code value="VG" description="VIRGIN ISLANDS, BRITISH"/>
 		<code value="VI" description="VIRGIN ISLANDS, U.S."/>
@@ -249,21 +253,27 @@
 	</codeset>
 	<codeset issuer="IANA" openehr_id="character sets" external_id="IANA_character-sets">
 		<code value="ISO-10646-UTF-1"/>
+		<code value="ISO_8859-1:1987"/>
+		<code value="ISO-8859-2"/>
 		<code value="ISO_8859-3:1988"/>
-		<code value="UTF-8"/>
+		<code value="ISO-8859-15"/>
+		<code value="US-ASCII"/>
 		<code value="UTF-7"/>
+		<code value="UTF-8"/>
+		<code value="UTF-16"/>
 		<code value="UTF-16BE"/>
 		<code value="UTF-16LE"/>
-		<code value="UTF-16"/>
 		<code value="UTF-32"/>
 		<code value="UTF-32BE"/>
 		<code value="UTF-32LE"/>
-		<code value="ISO_8859-1:1987"/>
 	</codeset>
 	<codeset issuer="ISO" openehr_id="languages" external_id="ISO_639-1">
 		<code value="aa" description="Afar"/>
 		<code value="af" description="Afrikaans"/>
+		<code value="ak" description="Akan"/>
 		<code value="sq" description="Albanian"/>
+		<code value="am" description="Amharic"/>
+		<code value="ar" description="Arabic"/>
 		<code value="ar-sa" description="Arabic (Saudi Arabia)"/>
 		<code value="ar-iq" description="Arabic (Iraq)"/>
 		<code value="ar-eg" description="Arabic (Egypt)"/>
@@ -280,21 +290,44 @@
 		<code value="ar-ae" description="Arabic (U.A.E.)"/>
 		<code value="ar-bh" description="Arabic (Bahrain)"/>
 		<code value="ar-qa" description="Arabic (Qatar)"/>
-		<code value="az" description="Azerbaijani"/>
+		<code value="an" description="Aragonese"/>
+		<code value="hy" description="Armenian"/>
+		<code value="as" description="Assamese"/>
+		<code value="av" description="Avaric, Avar"/>
+		<code value="ay" description="Aymara"/>
+		<code value="az" description="Azerbaijani, Azeri"/>
+		<code value="bm" description="Bambara"/>
+		<code value="ba" description="Bashkir"/>
 		<code value="eu" description="Basque"/>
-		<code value="bg" description="Bulgarian"/>
 		<code value="be" description="Belarusian"/>
-		<code value="ca" description="Catalan"/>
+		<code value="bn" description="Bengali, Bangla"/>
+		<code value="bi" description="Bislama"/>
+		<code value="bs" description="Bosnian"/>
+		<code value="br" description="Breton"/>
+		<code value="bg" description="Bulgarian"/>
+		<code value="my" description="Burmese, Myanmar"/>
+		<code value="ca" description="Catalan, Valencian"/>
+		<code value="ch" description="Chamorro"/>
+		<code value="ce" description="Chechen"/>
+		<code value="ny" description="Chichewa, Chewa, Nyanja"/>
 		<code value="zh" description="Chinese"/>
 		<code value="zh-tw" description="Chinese (Taiwan)"/>
 		<code value="zh-cn" description="Chinese (PRC)"/>
 		<code value="zh-hk" description="Chinese (Hong Kong SAR)"/>
 		<code value="zh-sg" description="Chinese (Singapore)"/>
+		<code value="zh-mo" description="Chinese (Macau)"/>
+		<code value="cv" description="Chuvash"/>
+		<code value="kw" description="Cornish"/>
+		<code value="co" description="Corsican"/>
+		<code value="cr" description="Cree"/>
 		<code value="hr" description="Croatian"/>
+		<code value="hr-ba" description="Croatian (Bosnia and Herzegovina)"/>
 		<code value="cs" description="Czech"/>
 		<code value="da" description="Danish"/>
-		<code value="nl" description="Dutch (Standard)"/>
+		<code value="dv" description="Divehi, Dhivehi, Maldivian"/>
+		<code value="nl" description="Dutch"/>
 		<code value="nl-be" description="Dutch (Belgium)"/>
+		<code value="dz" description="Dzongkha"/>
 		<code value="en" description="English"/>
 		<code value="en-us" description="English (United States)"/>
 		<code value="en-gb" description="English (United Kingdom)"/>
@@ -304,63 +337,135 @@
 		<code value="en-ie" description="English (Ireland)"/>
 		<code value="en-za" description="English (South Africa)"/>
 		<code value="en-jm" description="English (Jamaica)"/>
-		<code value="en" description="English (Caribbean)"/>
+		<code value="en-cb" description="English (Caribbean)"/>
 		<code value="en-bz" description="English (Belize)"/>
-		<code value="en-tt" description="English (Trinidad)"/>
+		<code value="en-tt" description="English (Trinidad and Tobago)"/>
+		<code value="en-ph" description="English (Republic of the Philippines)"/>
+		<code value="en-zw" description="English (Zimbabwe)"/>
+		<code value="eo" description="Esperanto"/>
 		<code value="et" description="Estonian"/>
-		<code value="fo" description="Faeroese"/>
-		<code value="fa" description="Farsi"/>
+		<code value="ee" description="Ewe"/>
+		<code value="fo" description="Faroese"/>
+		<code value="fj" description="Fijian"/>
 		<code value="fi" description="Finnish"/>
-		<code value="fr" description="French (Standard)"/>
+		<code value="fr" description="French"/>
 		<code value="fr-be" description="French (Belgium)"/>
 		<code value="fr-ca" description="French (Canada)"/>
 		<code value="fr-ch" description="French (Switzerland)"/>
 		<code value="fr-lu" description="French (Luxembourg)"/>
-		<code value="gd" description="Gaelic (Scotland)"/>
+		<code value="fr-mc" description="French (Principality of Monaco)"/>
+		<code value="fy" description="Frisian, Western Frisian"/>
+		<code value="ff" description="Fulah, Fulani"/>
+		<code value="gd" description="Gaelic, Scottish Gaelic"/>
 		<code value="gd-ie" description="Gaelic (Ireland)"/>
-		<code value="de" description="German (Standard)"/>
+		<code value="gl" description="Galician"/>
+		<code value="lg" description="Ganda"/>
+		<code value="ka" description="Georgian"/>
+		<code value="de" description="German"/>
 		<code value="de-ch" description="German (Switzerland)"/>
 		<code value="de-at" description="German (Austria)"/>
 		<code value="de-lu" description="German (Luxembourg)"/>
 		<code value="de-li" description="German (Liechtenstein)"/>
 		<code value="el" description="Greek"/>
+		<code value="kl" description="Kalaallisut, Greenlandic"/>
+		<code value="gn" description="Guarani"/>
+		<code value="gu" description="Gujarati"/>
+		<code value="ht" description="Haitian, Haitian Creole"/>
+		<code value="ha" description="Hausa"/>
 		<code value="he" description="Hebrew"/>
+		<code value="hz" description="Herero"/>
 		<code value="hi" description="Hindi"/>
+		<code value="ho" description="Hiri Motu, Pidgin Motu"/>
 		<code value="hu" description="Hungarian"/>
 		<code value="is" description="Icelandic"/>
+		<code value="ig" description="Igbo"/>
 		<code value="id" description="Indonesian"/>
-		<code value="it" description="Italian (Standard)"/>
+		<code value="iu" description="Inuktitut"/>
+		<code value="ik" description="Inupiaq"/>
+		<code value="ga" description="Irish"/>
+		<code value="it" description="Italian"/>
 		<code value="it-ch" description="Italian (Switzerland)"/>
 		<code value="ja" description="Japanese"/>
-		<code value="kk" description="Kasakh"/>
-		<code value="km" description="Central Khmer"/>
+		<code value="jv" description="Javanese"/>
+		<code value="kn" description="Kannada"/>
+		<code value="kr" description="Kanuri"/>
+		<code value="ks" description="Kashmiri"/>
+		<code value="kk" description="Kazakh"/>
+		<code value="km" description="Central Khmer, Cambodian"/>
+		<code value="ki" description="Kikuyu, Gikuyu"/>
+		<code value="rw" description="Kinyarwanda"/>
+		<code value="ky" description="Kirghiz, Kyrgyz"/>
+		<code value="kv" description="Komi"/>
+		<code value="kg" description="Kongo"/>
 		<code value="ko" description="Korean"/>
-		<code value="ko" description="Korean (Johab)"/>
+		<code value="kj" description="Kuanyama, Kwanyama"/>
+		<code value="ku" description="Kurdish"/>
+		<code value="lo" description="Lao"/>
+		<code value="la" description="Latin"/>
 		<code value="lv" description="Latvian"/>
+		<code value="li" description="Limburgan, Limburger, Limburgish"/>
+		<code value="ln" description="Lingala"/>
 		<code value="lt" description="Lithuanian"/>
-		<code value="mk" description="FYRO Macedonian ms Malaysian"/>
+		<code value="lu" description="Luba-Katanga, Luba-Shaba"/>
+		<code value="lb" description="Luxembourgish, Letzeburgesch"/>
+		<code value="mk" description="Macedonian"/>
+		<code value="mg" description="Malagasy"/>
+		<code value="ms" description="Malay"/>
+		<code value="ml" description="Malayalam"/>
 		<code value="mt" description="Maltese"/>
+		<code value="gv" description="Manx"/>
+		<code value="mi" description="Maori"/>
+		<code value="mr" description="Marathi"/>
+		<code value="mh" description="Marshallese"/>
+		<code value="mn" description="Mongolian"/>
+		<code value="na" description="Nauru, Nauruan"/>
+		<code value="nv" description="Navajo, Navaho"/>
+		<code value="nd" description="North Ndebele"/>
+		<code value="nr" description="South Ndebele"/>
+		<code value="ng" description="Ndonga"/>
+		<code value="ne" description="Nepali"/>
 		<code value="nb" description="Norwegian Bokmal"/>
 		<code value="nn" description="Norwegian Nynorsk"/>
+		<code value="ii" description="Sichuan Yi, Nuosu, Northern Yi, Liangshan Yi"/>
+		<code value="oc" description="Occitan"/>
+		<code value="oj" description="Ojibwa, Ojibwe"/>
+		<code value="or" description="Oriya, Odia"/>
+		<code value="om" description="Oromo"/>
+		<code value="os" description="Ossetian, Ossetic"/>
+		<code value="ps" description="Pashto, Pushto"/>
+		<code value="fa" description="Persian, Farsi"/>
 		<code value="pl" description="Polish"/>
-		<code value="pt-br" description="Portuguese (Brazil)"/>
-		<code value="pt-pt" description="Portuguese (Portugal)"/>
 		<code value="pt" description="Portuguese"/>
-		<code value="rm" description="Rhaeto-Romanic"/>
+		<code value="pt-br" description="Portuguese (Brazil)"/>
+		<code value="pt-pt" description="Portuguese (Portugal) - DEPRECATED"/>
+		<code value="pa" description="Punjabi, Panjabi"/>
+		<code value="qu" description="Quechua"/>
+		<code value="qu-bo" description="Quechua (Bolivia)"/>
+		<code value="qu-ec" description="Quechua (Ecuador)"/>
+		<code value="qu-pe" description="Quechua (Peru)"/>
 		<code value="ro" description="Romanian"/>
 		<code value="ro-mo" description="Romanian (Moldavia)"/>
+		<code value="rm" description="Romansh, Rhaeto-Romanic"/>
+		<code value="rn" description="Rundi, Kirundi"/>
 		<code value="ru" description="Russian"/>
 		<code value="ru-mo" description="Russian (Moldavia)"/>
-		<code value="sz" description="Sami (Lappish)"/>
-		<code value="sr" description="Serbian (Cyrillic)"/>
-		<code value="sr" description="Serbian (Latin)"/>
+		<code value="se" description="Northern Sami"/>
+		<code value="sz" description="Sami (Lappish) - DEPRECATED"/>
+		<code value="sm" description="Samoan"/>
+		<code value="sg" description="Sango"/>
+		<code value="sc" description="Sardinian"/>
+		<code value="sr" description="Serbian"/>
+		<code value="sr-ba" description="Serbian (Bosnia and Herzegovina)"/>
+		<code value="sb" description="Serbian - DEPRECATED"/>
+		<code value="sn" description="Shona"/>
+		<code value="sd" description="Sindhi"/>
+		<code value="si" description="Sinhala, Sinhalese"/>
 		<code value="sk" description="Slovak"/>
-		<code value="sl" description="Slovenian"/>
-		<code value="si" description="Sinhala"/>
-		<code value="sb" description="Serbian"/>
-		<code value="es" description="Spanish (Spain ? Traditional)"/>
+		<code value="sl" description="Slovenian, Slovene"/>
+		<code value="so" description="Somali"/>
+		<code value="st" description="Southern Sotho, Sesotho, Sutu"/>
+		<code value="es" description="Spanish, Castilian"/>
 		<code value="es-mx" description="Spanish (Mexico)"/>
-		<code value="es" description="Spanish (Spain ? Modern)"/>
 		<code value="es-gt" description="Spanish (Guatemala)"/>
 		<code value="es-cr" description="Spanish (Costa Rica)"/>
 		<code value="es-pa" description="Spanish (Panama)"/>
@@ -378,22 +483,43 @@
 		<code value="es-hn" description="Spanish (Honduras)"/>
 		<code value="es-ni" description="Spanish (Nicaragua)"/>
 		<code value="es-pr" description="Spanish (Puerto Rico)"/>
-		<code value="sx" description="Sutu"/>
+		<code value="su" description="Sundanese"/>
+		<code value="sx" description="Sutu - DEPRECATED"/>
+		<code value="sw" description="Swahili"/>
+		<code value="ss" description="Swati, Swazi"/>
 		<code value="sv" description="Swedish"/>
 		<code value="sv-fi" description="Swedish (Finland)"/>
+		<code value="tl" description="Tagalog"/>
+		<code value="ty" description="Tahitian"/>
+		<code value="tg" description="Tajik"/>
+		<code value="ta" description="Tamil"/>
+		<code value="tt" description="Tatar"/>
+		<code value="te" description="Telugu"/>
 		<code value="th" description="Thai"/>
+		<code value="bo" description="Tibetan"/>
+		<code value="ti" description="Tigrinya"/>
+		<code value="to" description="Tonga, Tongan"/>
 		<code value="ts" description="Tsonga"/>
 		<code value="tn" description="Tswana"/>
 		<code value="tr" description="Turkish"/>
+		<code value="tk" description="Turkmen"/>
+		<code value="tw" description="Twi"/>
+		<code value="ug" description="Uighur, Uyghur"/>
 		<code value="uk" description="Ukrainian"/>
 		<code value="ur" description="Urdu"/>
+		<code value="uz" description="Uzbek"/>
 		<code value="ve" description="Venda"/>
 		<code value="vi" description="Vietnamese"/>
+		<code value="wa" description="Walloon"/>
 		<code value="cy" description="Welsh"/>
 		<code value="cy-gb" description="Welsh (United Kingdom)"/>
 		<code value="cy-ar" description="Welsh (Argentina)"/>
+		<code value="wo" description="Wolof"/>
 		<code value="xh" description="Xhosa"/>
-		<code value="ji" description="Yiddish"/>
+		<code value="yi" description="Yiddish"/>
+		<code value="ji" description="Yiddish - DEPRECATED"/>
+		<code value="yo" description="Yoruba"/>
+		<code value="za" description="Zhuang, Chuang"/>
 		<code value="zu" description="Zulu"/>
 	</codeset>
 	<codeset issuer="IANA" openehr_id="media types" external_id="IANA_media-types">
@@ -418,13 +544,21 @@
 	    <code  value="video/H263" />
 	    <code  value="video/H263-1998" />
 	    <code  value="video/H263-2000" />
+	    <code  value="video/H264" />
 	    <code  value="video/MPV" />
+	    <code  value="video/mp4" />
+	    <code  value="video/ogg" />
+	    <code  value="video/mpeg" />
 	    <code  value="audio/basic"/>
 	    <code  value="audio/mpeg" />
+	    <code  value="audio/mpeg3" />
 	    <code  value="audio/mpeg4-generic" />
+	    <code  value="audio/mp4" />
 	    <code  value="audio/L20" />
 	    <code  value="audio/L24" />
 	    <code  value="audio/telephone-event" />
+	    <code  value="audio/ogg" />
+	    <code  value="audio/vorbis" />
 	    <code  value="video/quicktime" />
 	    <code  value="text/calendar" />
 	    <code  value="text/directory" />
@@ -438,16 +572,47 @@
 	    <code  value="text/uri-list" />
 	    <code  value="text/xml" />
 	    <code  value="text/xml-external-parsed-entity" />
+	    <code value="image/avif"/>
+	    <code value="image/bmp"/>
 	    <code  value="image/cgm" />
 	    <code  value="image/gif" />
 	    <code  value="image/png" />
 	    <code  value="image/tiff" />
 	    <code  value="image/jpeg" />
+	    <code  value="image/jp2" />
+	    <code value="image/svg+xml"/>
+	    <code value="application/cda+xml"/>
+	    <code value="application/EDIFACT"/>
+	    <code value="application/fhir+json"/>
+	    <code value="application/fhir+xml"/>
+	    <code value="application/hl7v2+xml"/>
+	    <code value="application/gzip"/>
+	    <code value="application/json"/>
 	    <code  value="application/msword" />
 	    <code  value="application/pdf" />
 	    <code  value="application/rtf" />
 	    <code  value="application/dicom" />
+	    <code value="application/dicom+json"/>
+	    <code value="application/dicom+xml"/>
+	    <code value="application/octet-stream"/>
+	    <code value="application/ogg"/>
+		<code value="application/vnd.oasis.opendocument.base"/>
+		<code value="application/vnd.oasis.opendocument.chart"/>
+		<code value="application/vnd.oasis.opendocument.chart-template"/>
+		<code value="application/vnd.oasis.opendocument.formula"/>
+		<code value="application/vnd.oasis.opendocument.formula-template"/>
+		<code value="application/vnd.oasis.opendocument.graphics"/>
+		<code value="application/vnd.oasis.opendocument.graphics-template"/>
+		<code value="application/vnd.oasis.opendocument.image"/>
+		<code value="application/vnd.oasis.opendocument.image-template"/>
+	    <code value="application/vnd.oasis.opendocument.presentation"/>
+	    <code value="application/vnd.oasis.opendocument.presentation-template"/>
+	    <code value="application/vnd.oasis.opendocument.spreadsheet"/>
+	    <code value="application/vnd.oasis.opendocument.spreadsheet-template"/>
 	    <code  value="application/vnd.oasis.opendocument.text" />
+	    <code value="application/vnd.oasis.opendocument.text-master"/>
+	    <code value="application/vnd.oasis.opendocument.text-template"/>
+	    <code value="application/vnd.oasis.opendocument.text-web"/>
 	    <code  value="application/vnd.ms-word.document.macroEnabled.12" />
 	    <code  value="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 	    <code  value="application/vnd.ms-word.template.macroEnabled.12" />
@@ -460,6 +625,10 @@
 	    <code  value="application/vnd.ms-excel.sheet.macroEnabled.12" />
 	    <code  value="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
 	    <code  value="application/vnd.ms-xpsdocument" />
-	    <code  value="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+	    <code value="application/vnd.ms-excel"/>
+	    <code value="application/vnd.ms-outlook"/>
+	    <code value="application/vnd.ms-powerpoint"/>
+	    <code value="application/vnd.rar"/>
+	    <code value="application/zip"/>
 	</codeset>
 </terminology>

--- a/openehr-terminology/src/main/resources/openEHR_RM/pt/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/pt/openehr_terminology.xml
@@ -8,8 +8,13 @@
 	</codeset>
 	<codeset issuer="openehr" openehr_id="integrity check algorithms" external_id="openehr_integrity_check_algorithms">
 		<code value="SHA-1"/>
+		<code value="SHA-224"/>
 		<code value="SHA-256"/>
-	</codeset>	
+		<code value="SHA-384"/>
+		<code value="SHA-512"/>
+		<code value="SHA-512/224"/>
+		<code value="SHA-512/256"/>
+	</codeset>
 	<codeset issuer="openehr" openehr_id="normal statuses" external_id="openehr_normal_statuses">
 		<code value="HHH"/>
 		<code value="HH"/>
@@ -19,11 +24,11 @@
 		<code value="LL"/> 
 		<code value="LLL"/>
 	</codeset>
-	<group name="razão de atestação" id="attestation reason">
+	<group name="razão de atestação">
 		<concept id="240" rubric="assinou"/>
 		<concept id="648" rubric="testemunhou"/>
 	</group>
-	<group name="tipo de auditoria de modificação" id="audit change type">
+	<group name="tipo de auditoria de modificação">
 		<concept id="249" rubric="criação"/>
 		<concept id="250" rubric="emenda"/>
 		<concept id="251" rubric="modificação"/>
@@ -32,13 +37,13 @@
 		<concept id="666" rubric="atestação"/>
 		<concept id="253" rubric="desconhecido"/>
 	</group>
-	<group name="categoria de composição" id="composition category">
+	<group name="categoria de composição">
 		<concept id="431" rubric="persistente"/>
 		<concept id="433" rubric="evento"/>
-		<concept id="435" rubric="*episodic(en)"/>
-
+		<concept id="451" rubric="*episodic(en)"/>
 	</group>
-	<group name="multimídia" id="MultiMedia">
+	<!--
+	<group name="multimídia">
 		<concept id="387" rubric="audio/DVI4" />
 		<concept id="388" rubric="audio/G722" />
 		<concept id="389" rubric="audio/G723" />
@@ -89,7 +94,8 @@
 		<concept id="682" rubric="application/vnd.oasis.opendocument.text" />
 		<concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 	</group>
-	<group name="propriedade" id="property">
+	-->
+	<group name="propriedade">
 		<concept id="339" rubric="aceleração"/>
 		<concept id="342" rubric="aceleração, angular"/>
 		<concept id="381" rubric="quantidade (Eq)"/>
@@ -105,7 +111,7 @@
 		<concept id="502" rubric="condutância elétrica"/>
 		<concept id="334" rubric="corrente elétrica"/>
 		<concept id="377" rubric="força de campo elétrico"/>
-		<concept id="655" rubric="tempo de potencial elétrico"/>
+		<concept id="655" rubric="potencial elétrico"/>
 		<concept id="121" rubric="energia"/>
 		<concept id="366" rubric="densidade de energia"/>
 		<concept id="508" rubric="dose de energia"/>
@@ -167,21 +173,23 @@
 		<concept id="130" rubric="trabalho"/>
 		<concept id="685" rubric="potência dióptrica"/>
 	</group>
-	<group name="estado de ciclo de vida de versão" id="version lifecycle state">
-		<concept id="532" rubric="completo"/>
+	<group name="estado de ciclo de vida de versão">
+		<concept id="532" rubric="completo"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->
 		<concept id="553" rubric="incompleto"/>
 		<concept id="523" rubric="removido"/>
+		<concept id="800" rubric="*inactive(en)"/>
+		<concept id="801" rubric="*abandoned(en)"/>
 	</group>
-	<group name="função de participação" id="participation function">
+	<group name="função de participação">
 		<concept id="253" rubric="desconhecido"/>
 	</group>
-	<group name="null flavours" id="null flavours">
+	<group name="null flavours">
 		<concept id="271" rubric="sem informação"/>
 		<concept id="253" rubric="desconhecido"/>
 		<concept id="272" rubric="mascarado"/>
 		<concept id="273" rubric="não aplicável"/>
 	</group>
-	<group name="modo de participação" id="participation mode">
+	<group name="modo de participação">
 		<concept id="193" rubric="não especificado"/>
 		<concept id="216" rubric="comunicação cara-a-cara"/>
 		<concept id="223" rubric="comuicação interpretada cara-a-cara"/>
@@ -215,7 +223,7 @@
 		<concept id="219" rubric="fisicamente presente"/>
 		<concept id="220" rubric="fisicamente remoto"/>
 	</group>
-	<group name="estados de instrução" id="instruction states">
+	<group name="estados de instrução">
 		<concept id="524" rubric="inicial"/>
 		<concept id="526" rubric="planejado"/>
 		<concept id="527" rubric="adiado"/>
@@ -224,10 +232,10 @@
 		<concept id="245" rubric="ativo"/>
 		<concept id="530" rubric="suspenso"/>
 		<concept id="531" rubric="abortado"/>
-		<concept id="532" rubric="concluído"/>
+		<concept id="532" rubric="concluído"/><!-- warning: the rubric for this concept is 'complete' in the 'version lifecycle state' group (known issue, see SPECPR-51) -->
 		<concept id="533" rubric="expirado"/>
 	</group>
-	<group name="transições de instrução" id="instruction transitions">
+	<group name="transições de instrução">
 		<concept id="535" rubric="iniciar"/>
 		<concept id="536" rubric="planejar etapa"/>
 		<concept id="537" rubric="adiar"/>
@@ -249,7 +257,7 @@
 		<concept id="551" rubric="notificar conclusão"/>
 		<concept id="552" rubric="notificar cancelamento"/>
 	</group>
-	<group name="relacionamento de sujeito" id="subject relationship">
+	<group name="relacionamento de sujeito">
 		<concept id="0" rubric="próprio"/>
 		<concept id="3" rubric="feto"/>
 		<concept id="10" rubric="mãe"/>
@@ -287,12 +295,12 @@
 		<concept id="25" rubric="meio-irmão"/>
 		<concept id="26" rubric="meia-irmã"/>
 	</group>
-	<group name="propósito de mapeamento de termo" id="term mapping purpose">
+	<group name="propósito de mapeamento de termo">
 		<concept id="669" rubric="saúde pública"/>
 		<concept id="670" rubric="reembolso"/>
 		<concept id="671" rubric="pesquisa"/>
 	</group>
-	<group name="função matemática de evento" id="event math function">
+	<group name="função matemática de evento">
 		<concept id="145" rubric="mínimo"/>
 		<concept id="144" rubric="máximo"/>
 		<concept id="267" rubric="moda"/>
@@ -305,7 +313,7 @@
 		<concept id="522" rubric="acréscimo"/>
 		<concept id="640" rubric="real"/>
 	</group>
-	<group name="configuração" id="setting">>
+	<group name="configuração">
 		<concept id="225" rubric="domiciliar"/>
 		<concept id="227" rubric="cuidado emergencial"/>
 		<concept id="228" rubric="medicina primária"/>
@@ -318,6 +326,25 @@
 		<concept id="235" rubric="cuidado complementar"/>
 		<concept id="236" rubric="cuidado odontológico"/>
 		<concept id="237" rubric="enfermagem domiciliar"/>
+		<concept id="802" rubric="*mental healthcare(en)"/>
 		<concept id="238" rubric="outro cuidado"/>
+	</group>
+	<group name="extract content type">
+		<concept id="803" rubric="*openEHR EHR(en)"/>
+		<concept id="804" rubric="*openEHR Demographic(en)"/>
+		<concept id="805" rubric="*openEHR synchronisation(en)"/>
+		<concept id="806" rubric="*openEHR generic(en)"/>
+		<concept id="807" rubric="*generic EMR(en)"/>
+		<concept id="808" rubric="*other(en)"/>
+	</group>
+	<group name="extract action type">
+		<concept id="809" rubric="*cancel(en)"/>
+		<concept id="810" rubric="*resend(en)"/>
+		<concept id="811" rubric="*send new(en)"/>
+	</group>
+	<group name="extract update trigger event type">
+		<concept id="812" rubric="*any change(en)"/>
+		<concept id="813" rubric="*correction(en)"/>
+		<concept id="814" rubric="*update(en)"/>
 	</group>
 </terminology>

--- a/openehr-terminology/src/main/resources/openEHR_RM/pt/openehr_terminology.xml
+++ b/openehr-terminology/src/main/resources/openEHR_RM/pt/openehr_terminology.xml
@@ -24,11 +24,11 @@
 		<code value="LL"/> 
 		<code value="LLL"/>
 	</codeset>
-	<group name="razão de atestação">
+	<group name="razão de atestação" id="attestation reason">
 		<concept id="240" rubric="assinou"/>
 		<concept id="648" rubric="testemunhou"/>
 	</group>
-	<group name="tipo de auditoria de modificação">
+	<group name="tipo de auditoria de modificação" id="audit change type">
 		<concept id="249" rubric="criação"/>
 		<concept id="250" rubric="emenda"/>
 		<concept id="251" rubric="modificação"/>
@@ -37,13 +37,12 @@
 		<concept id="666" rubric="atestação"/>
 		<concept id="253" rubric="desconhecido"/>
 	</group>
-	<group name="categoria de composição">
+	<group name="categoria de composição" id="composition category">
 		<concept id="431" rubric="persistente"/>
 		<concept id="433" rubric="evento"/>
 		<concept id="451" rubric="*episodic(en)"/>
 	</group>
-	<!--
-	<group name="multimídia">
+	<group name="multimídia" id="MultiMedia">
 		<concept id="387" rubric="audio/DVI4" />
 		<concept id="388" rubric="audio/G722" />
 		<concept id="389" rubric="audio/G723" />
@@ -94,8 +93,7 @@
 		<concept id="682" rubric="application/vnd.oasis.opendocument.text" />
 		<concept id="683" rubric="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
 	</group>
-	-->
-	<group name="propriedade">
+	<group name="propriedade" id="property">
 		<concept id="339" rubric="aceleração"/>
 		<concept id="342" rubric="aceleração, angular"/>
 		<concept id="381" rubric="quantidade (Eq)"/>
@@ -111,7 +109,7 @@
 		<concept id="502" rubric="condutância elétrica"/>
 		<concept id="334" rubric="corrente elétrica"/>
 		<concept id="377" rubric="força de campo elétrico"/>
-		<concept id="655" rubric="potencial elétrico"/>
+		<concept id="655" rubric="tempo de potencial elétrico"/>
 		<concept id="121" rubric="energia"/>
 		<concept id="366" rubric="densidade de energia"/>
 		<concept id="508" rubric="dose de energia"/>
@@ -173,23 +171,23 @@
 		<concept id="130" rubric="trabalho"/>
 		<concept id="685" rubric="potência dióptrica"/>
 	</group>
-	<group name="estado de ciclo de vida de versão">
+	<group name="estado de ciclo de vida de versão" id="version lifecycle state">
 		<concept id="532" rubric="completo"/><!-- warning: the rubric for this concept is 'completed' in the 'instruction states' group (known issue, see SPECPR-51) -->
 		<concept id="553" rubric="incompleto"/>
 		<concept id="523" rubric="removido"/>
 		<concept id="800" rubric="*inactive(en)"/>
 		<concept id="801" rubric="*abandoned(en)"/>
 	</group>
-	<group name="função de participação">
+	<group name="função de participação" id="participation function">
 		<concept id="253" rubric="desconhecido"/>
 	</group>
-	<group name="null flavours">
+	<group name="null flavours" id="null flavours">
 		<concept id="271" rubric="sem informação"/>
 		<concept id="253" rubric="desconhecido"/>
 		<concept id="272" rubric="mascarado"/>
 		<concept id="273" rubric="não aplicável"/>
 	</group>
-	<group name="modo de participação">
+	<group name="modo de participação" id="participation mode">
 		<concept id="193" rubric="não especificado"/>
 		<concept id="216" rubric="comunicação cara-a-cara"/>
 		<concept id="223" rubric="comuicação interpretada cara-a-cara"/>
@@ -223,7 +221,7 @@
 		<concept id="219" rubric="fisicamente presente"/>
 		<concept id="220" rubric="fisicamente remoto"/>
 	</group>
-	<group name="estados de instrução">
+	<group name="estados de instrução" id="instruction states">
 		<concept id="524" rubric="inicial"/>
 		<concept id="526" rubric="planejado"/>
 		<concept id="527" rubric="adiado"/>
@@ -235,7 +233,7 @@
 		<concept id="532" rubric="concluído"/><!-- warning: the rubric for this concept is 'complete' in the 'version lifecycle state' group (known issue, see SPECPR-51) -->
 		<concept id="533" rubric="expirado"/>
 	</group>
-	<group name="transições de instrução">
+	<group name="transições de instrução" id="instruction transitions">
 		<concept id="535" rubric="iniciar"/>
 		<concept id="536" rubric="planejar etapa"/>
 		<concept id="537" rubric="adiar"/>
@@ -257,7 +255,7 @@
 		<concept id="551" rubric="notificar conclusão"/>
 		<concept id="552" rubric="notificar cancelamento"/>
 	</group>
-	<group name="relacionamento de sujeito">
+	<group name="relacionamento de sujeito" id="subject relationship">
 		<concept id="0" rubric="próprio"/>
 		<concept id="3" rubric="feto"/>
 		<concept id="10" rubric="mãe"/>
@@ -295,12 +293,12 @@
 		<concept id="25" rubric="meio-irmão"/>
 		<concept id="26" rubric="meia-irmã"/>
 	</group>
-	<group name="propósito de mapeamento de termo">
+	<group name="propósito de mapeamento de termo" id="term mapping purpose">
 		<concept id="669" rubric="saúde pública"/>
 		<concept id="670" rubric="reembolso"/>
 		<concept id="671" rubric="pesquisa"/>
 	</group>
-	<group name="função matemática de evento">
+	<group name="função matemática de evento" id="event math function">
 		<concept id="145" rubric="mínimo"/>
 		<concept id="144" rubric="máximo"/>
 		<concept id="267" rubric="moda"/>
@@ -313,7 +311,7 @@
 		<concept id="522" rubric="acréscimo"/>
 		<concept id="640" rubric="real"/>
 	</group>
-	<group name="configuração">
+	<group name="configuração" id="setting">>
 		<concept id="225" rubric="domiciliar"/>
 		<concept id="227" rubric="cuidado emergencial"/>
 		<concept id="228" rubric="medicina primária"/>
@@ -329,7 +327,7 @@
 		<concept id="802" rubric="*mental healthcare(en)"/>
 		<concept id="238" rubric="outro cuidado"/>
 	</group>
-	<group name="extract content type">
+	<group name="extract content type" id="extract content type">
 		<concept id="803" rubric="*openEHR EHR(en)"/>
 		<concept id="804" rubric="*openEHR Demographic(en)"/>
 		<concept id="805" rubric="*openEHR synchronisation(en)"/>
@@ -337,12 +335,12 @@
 		<concept id="807" rubric="*generic EMR(en)"/>
 		<concept id="808" rubric="*other(en)"/>
 	</group>
-	<group name="extract action type">
+	<group name="extract action type" id="extract action type">
 		<concept id="809" rubric="*cancel(en)"/>
 		<concept id="810" rubric="*resend(en)"/>
 		<concept id="811" rubric="*send new(en)"/>
 	</group>
-	<group name="extract update trigger event type">
+	<group name="extract update trigger event type" id="extract update trigger event type">
 		<concept id="812" rubric="*any change(en)"/>
 		<concept id="813" rubric="*correction(en)"/>
 		<concept id="814" rubric="*update(en)"/>

--- a/openehr-terminology/src/test/java/com/nedap/archie/terminology/OpenEHRTerminologyAccessTest.java
+++ b/openehr-terminology/src/test/java/com/nedap/archie/terminology/OpenEHRTerminologyAccessTest.java
@@ -60,7 +60,7 @@ public class OpenEHRTerminologyAccessTest {
         TermCode episodic = compositionCategories.get(1);
         TermCode event = compositionCategories.get(2);
         assertEquals("431", persistent.getCodeString());
-        assertEquals("435", episodic.getCodeString());
+        assertEquals("451", episodic.getCodeString());
         assertEquals("433", event.getCodeString());
         assertEquals("persistent", persistent.getDescription());
         assertEquals("episodic", episodic.getDescription());
@@ -103,7 +103,7 @@ public class OpenEHRTerminologyAccessTest {
 
         assertEquals("431", groupContent.get(0).getCodeString());
         assertEquals("persistent", groupContent.get(0).getDescription());
-        assertEquals("435", groupContent.get(1).getCodeString());
+        assertEquals("451", groupContent.get(1).getCodeString());
         assertEquals("episodic", groupContent.get(1).getDescription());
         assertEquals("433", groupContent.get(2).getCodeString());
         assertEquals("event", groupContent.get(2).getDescription());


### PR DESCRIPTION
Update the terminology information to release 2.4.0

This uses the XML files from https://github.com/openEHR/specifications-TERM/tree/Release-2.4.0/computable/XML with two modifications:
* Re-enabled the MultiMedia group not to cause breaking changes, as these codes are still used in older archetypes
* ids (re-)added to groups so groups can be matched across different languages
  * The previous group ids of two groups in the Japanese language file contained typos, these are also fixed.

The `fullTermFile.json` is regenerated according to the [README](https://github.com/openEHR/archie/blob/148b979796dd4f43e07bb7ab87ff1e73a2335e10/openehr-terminology/README.md) and tests are updated to match the changes in the terminology files.

The terminology information is not yet updated to release 3.0.0 as it contains breaking changes. This should probably be done in a major version update of Archie itself.