### PR TITLE
Correct initialisation error for BMM enum types. Without this, BMM-ba…

### DIFF
--- a/bmm/src/main/java/org/openehr/bmm/core/BmmEnumerationInteger.java
+++ b/bmm/src/main/java/org/openehr/bmm/core/BmmEnumerationInteger.java
@@ -22,6 +22,8 @@ package org.openehr.bmm.core;
  */
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Integer-based enumeration type.
@@ -39,5 +41,20 @@ public class BmmEnumerationInteger extends BmmEnumeration<Integer> implements Se
         super();
     }
 
+    /**
+     * Sets the list of names of the enumeration. If no values are supplied, the values
+     * 0...N are used where N+1 is the size of itemNames
+     *
+     * @param itemNames
+     */
+    @Override
+    public void setItemNames(List<String> itemNames) {
+        super.setItemNames(itemNames);
+        ArrayList<Integer> vals = new ArrayList<>();
+        for (int i = 0; i < itemNames.size(); i++ )
+            vals.add(i);
+
+        setItemValues(vals);
+    }
 
 }

--- a/bmm/src/main/java/org/openehr/bmm/core/BmmEnumerationString.java
+++ b/bmm/src/main/java/org/openehr/bmm/core/BmmEnumerationString.java
@@ -22,6 +22,8 @@ package org.openehr.bmm.core;
  */
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * String-based enumeration type.
@@ -39,4 +41,15 @@ public class BmmEnumerationString extends BmmEnumeration<String> implements Seri
         super();
     }
 
+    /**
+     * Sets the list of names of the enumeration. If no values are supplied, the string values
+     * mimicking the literals are assumed
+     *
+     * @param itemNames
+     */
+    @Override
+    public void setItemNames(List<String> itemNames) {
+        super.setItemNames(itemNames);
+        setItemValues(new ArrayList<>(itemNames));
+    }
 }


### PR DESCRIPTION
…sed validation of archetype CString and CInteger types fails, if no itemValues have been explicitly set in the BMM source files.