### PR TITLE
Fix indenting of multiline ODIN strings in ADL

### DIFF
--- a/aom/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
@@ -1,10 +1,12 @@
 package com.nedap.archie.serializer.adl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.nedap.archie.serializer.adl.jackson.ArchetypeODINMapperFactory;
 import com.nedap.archie.serializer.odin.StructureStringBuilder;
 import com.nedap.archie.serializer.odin.StructuredStringAppendable;
 import org.openehr.odin.jackson.ODINMapper;
+import org.openehr.odin.jackson.ODINPrettyPrinter;
 
 import static com.nedap.archie.serializer.odin.OdinStringBuilder.quoteText;
 
@@ -53,8 +55,11 @@ public class ADLStringBuilder implements StructuredStringAppendable {
 
     public ADLStringBuilder odin(Object structure) {
         try {
-            String odin = odinMapper.writeValueAsString(structure);
-            appendMultipleLines(odin);
+            // Pass the current ident depth to the ODINPrettyPrinter
+            ObjectWriter objectWriter = odinMapper.writer().with(new ODINPrettyPrinter(builder.getIndentDepth()));
+
+            String odin = objectWriter.writeValueAsString(structure).trim();
+            builder.append(odin).newline();
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/odin/src/main/java/com/nedap/archie/serializer/odin/StructureStringBuilder.java
+++ b/odin/src/main/java/com/nedap/archie/serializer/odin/StructureStringBuilder.java
@@ -129,6 +129,10 @@ public class StructureStringBuilder implements StructuredStringAppendable {
         return currentLineLength;
     }
 
+    public int getIndentDepth() {
+        return indentDepth;
+    }
+
     @Override
     public String toString() {
         return builder.toString();

--- a/odin/src/main/java/org/openehr/odin/jackson/ODINMapper.java
+++ b/odin/src/main/java/org/openehr/odin/jackson/ODINMapper.java
@@ -53,6 +53,8 @@ public class ODINMapper extends ObjectMapper
         setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
         disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS);
+        enable(SerializationFeature.INDENT_OUTPUT);
+        setDefaultPrettyPrinter(new ODINPrettyPrinter());
         setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         enableDefaultTyping(DefaultTyping.JAVA_LANG_OBJECT);

--- a/odin/src/main/java/org/openehr/odin/jackson/ODINPrettyPrinter.java
+++ b/odin/src/main/java/org/openehr/odin/jackson/ODINPrettyPrinter.java
@@ -1,0 +1,242 @@
+package org.openehr.odin.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.core.SerializableString;
+import com.fasterxml.jackson.core.io.SerializedString;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.Indenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter.NopIndenter;
+import com.fasterxml.jackson.core.util.Instantiatable;
+import com.fasterxml.jackson.core.util.Separators;
+
+import java.io.IOException;
+
+/**
+ * PrettyPrinter for ODIN with the ability to set an initial indent level.
+ * <p>
+ * Based on {@link com.fasterxml.jackson.core.util.DefaultPrettyPrinter}
+ */
+public class ODINPrettyPrinter
+        implements PrettyPrinter, Instantiatable<ODINPrettyPrinter>,
+        java.io.Serializable {
+    private static final long serialVersionUID = 1;
+
+    // // // Config, indentation
+
+    /**
+     * By default, let's use linefeed-adding indenter for separate
+     * object entries. We'll further configure indenter to use
+     * system-specific linefeeds, and 4 spaces per level (as opposed to,
+     * say, single tabs)
+     */
+    protected Indenter _objectIndenter = new DefaultIndenter("    ", DefaultIndenter.SYS_LF);
+
+    /**
+     * String printed between root-level values, if any.
+     */
+    protected SerializableString _rootSeparator;
+
+    // // // State:
+
+    /**
+     * Number of open levels of nesting. Used to determine amount of
+     * indentation to use.
+     */
+    protected transient int _nesting;
+
+    protected Separators _separators;
+
+    protected String _objectFieldValueSeparatorWithSpaces;
+
+    /**
+     * String to use in empty Object to separate start and end markers.
+     * Default is single space, resulting in output of {@code < >}.
+     */
+    protected String _objectEmptySeparator;
+
+    protected String _arrayValueSeparator;
+
+    /**
+     * String to use in empty Array to separate start and end markers.
+     * Default is single space, resulting in output of {@code < >}.
+     */
+    protected String _arrayEmptySeparator;
+
+    /*
+    /**********************************************************
+    /* Life-cycle (construct, configure)
+    /**********************************************************
+    */
+
+    public ODINPrettyPrinter() {
+        this(0);
+    }
+
+    public ODINPrettyPrinter(int nesting) {
+        this(new Separators('=', ' ' /* unused */, ','), nesting);
+    }
+
+    public ODINPrettyPrinter(Separators separators, int nesting) {
+        _separators = separators;
+
+        _rootSeparator = separators.getRootSeparator() == null ? null : new SerializedString(separators.getRootSeparator());
+        _objectFieldValueSeparatorWithSpaces = separators.getObjectFieldValueSpacing().apply(
+                separators.getObjectFieldValueSeparator());
+        _objectEmptySeparator = separators.getObjectEmptySeparator();
+        _arrayValueSeparator = separators.getArrayValueSpacing().apply(separators.getArrayValueSeparator());
+        _arrayEmptySeparator = separators.getArrayEmptySeparator();
+
+        _nesting = nesting;
+    }
+
+    /**
+     * Copy constructor
+     */
+    public ODINPrettyPrinter(ODINPrettyPrinter base) {
+        _rootSeparator = base._rootSeparator;
+
+        _objectIndenter = base._objectIndenter;
+        _nesting = base._nesting;
+
+        _separators = base._separators;
+        _objectFieldValueSeparatorWithSpaces = base._objectFieldValueSeparatorWithSpaces;
+        _objectEmptySeparator = base._objectEmptySeparator;
+        _arrayValueSeparator = base._arrayValueSeparator;
+        _arrayEmptySeparator = base._arrayEmptySeparator;
+    }
+
+    public void indentObjectsWith(Indenter i) {
+        _objectIndenter = (i == null) ? NopIndenter.instance : i;
+    }
+
+    public ODINPrettyPrinter withObjectIndenter(Indenter i) {
+        if (i == null) {
+            i = NopIndenter.instance;
+        }
+        if (_objectIndenter == i) {
+            return this;
+        }
+        ODINPrettyPrinter pp = new ODINPrettyPrinter(this);
+        pp._objectIndenter = i;
+        return pp;
+    }
+
+    /**
+     * Method for configuring separators
+     *
+     * @param separators Separator definitions to use
+     * @return Copy of this pretty-printer instance with given separators
+     */
+    public ODINPrettyPrinter withSeparators(Separators separators) {
+        ODINPrettyPrinter result = new ODINPrettyPrinter(this);
+        result._separators = separators;
+
+        result._rootSeparator = separators.getRootSeparator() == null ? null : new SerializedString(separators.getRootSeparator());
+        result._objectFieldValueSeparatorWithSpaces = separators.getObjectFieldValueSpacing().apply(
+                separators.getObjectFieldValueSeparator());
+        result._objectEmptySeparator = separators.getObjectEmptySeparator();
+        result._arrayValueSeparator = separators.getArrayValueSpacing().apply(separators.getArrayValueSeparator());
+        result._arrayEmptySeparator = separators.getArrayEmptySeparator();
+
+        return result;
+    }
+
+    /*
+    /**********************************************************
+    /* Instantiatable impl
+    /**********************************************************
+     */
+
+    @Override
+    public ODINPrettyPrinter createInstance() {
+        if (getClass() != ODINPrettyPrinter.class) { // since 2.10
+            throw new IllegalStateException("Failed `createInstance()`: " + getClass().getName()
+                    + " does not override method; it has to");
+        }
+        return new ODINPrettyPrinter(this);
+    }
+
+    /*
+    /**********************************************************
+    /* PrettyPrinter impl
+    /**********************************************************
+     */
+
+    @Override
+    public void writeRootValueSeparator(JsonGenerator g) throws IOException {
+        if (_rootSeparator != null) {
+            g.writeRaw(_rootSeparator);
+        }
+    }
+
+    @Override
+    public void writeStartObject(JsonGenerator g) throws IOException {
+        g.writeRaw('<');
+        if (!_objectIndenter.isInline()) {
+            ++_nesting;
+        }
+    }
+
+    @Override
+    public void beforeObjectEntries(JsonGenerator g) throws IOException {
+        // No indent and newline on first level
+        if(_nesting > 0) {
+            _objectIndenter.writeIndentation(g, _nesting);
+        }
+    }
+
+    @Override
+    public void writeObjectFieldValueSeparator(JsonGenerator g) throws IOException {
+        g.writeRaw(_objectFieldValueSeparatorWithSpaces);
+    }
+
+    @Override
+    public void writeObjectEntrySeparator(JsonGenerator g) throws IOException {
+        _objectIndenter.writeIndentation(g, _nesting);
+    }
+
+    @Override
+    public void writeEndObject(JsonGenerator g, int nrOfEntries) throws IOException {
+        if (!_objectIndenter.isInline()) {
+            --_nesting;
+        }
+        if (nrOfEntries > 0) {
+            _objectIndenter.writeIndentation(g, _nesting);
+        } else {
+            g.writeRaw(_objectEmptySeparator);
+        }
+        g.writeRaw('>');
+    }
+
+    @Override
+    public void writeStartArray(JsonGenerator g) throws IOException {
+        // g.writeRaw('<') is already done by ODINGeneator.writeStartObject
+        if (!_objectIndenter.isInline()) {
+            ++_nesting;
+        }
+    }
+
+    @Override
+    public void beforeArrayValues(JsonGenerator g) throws IOException {
+        _objectIndenter.writeIndentation(g, _nesting);
+    }
+
+    @Override
+    public void writeArrayValueSeparator(JsonGenerator g) throws IOException {
+        _objectIndenter.writeIndentation(g, _nesting);
+    }
+
+    @Override
+    public void writeEndArray(JsonGenerator g, int nrOfValues) throws IOException {
+        if (!_objectIndenter.isInline()) {
+            --_nesting;
+        }
+        if (nrOfValues > 0) {
+            _objectIndenter.writeIndentation(g, _nesting);
+        } else {
+            g.writeRaw(_arrayEmptySeparator);
+        }
+        g.writeRaw('>');
+    }
+}

--- a/tools/src/test/resources/com/nedap/archie/serializer/adl/openEHR-EHR-CLUSTER.default_values.v1.adls
+++ b/tools/src/test/resources/com/nedap/archie/serializer/adl/openEHR-EHR-CLUSTER.default_values.v1.adls
@@ -1,0 +1,75 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2)
+    openEHR-EHR-CLUSTER.default_values.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Jelte Zeilstra">
+        ["organisation"] = <"Nedap <https://www.nedap.com>">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"A very simple cluster archetype for testing default values">
+        >
+    >
+
+definition
+    CLUSTER[id1] matches {    -- Prescription
+        items matches {
+            ELEMENT[id2] matches {
+                value matches {
+                    DV_TEXT[id21] matches {
+                        _default = (DV_TEXT) <
+                            value = <"some default value
+with multiple lines">
+                        >
+                    }
+                }
+            }
+            ELEMENT[id3] matches {
+                value matches {
+                    DV_CODED_TEXT[id31] matches {
+                        _default = (json) <#
+                            {
+                              "_type" : "DV_CODED_TEXT",
+                              "value" : "some default value\nwith multiple lines",
+                              "defining_code" : {
+                                "terminology_id" : {
+                                  "value" : "local"
+                                },
+                                "code_string" : "at5"
+                              }
+                            }
+                        #>
+                    }
+                }
+            }
+        }
+        _default = (someotherformat) <#
+            This is some other format which cannot be parsed.
+The indentation of
+    this format
+  shouldn't be changed by the serializer.
+        #>
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"Prescription">
+                description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
+            >
+            ["id2"] = <
+                text = <"dv text">
+                description = <"dv text">
+            >
+            ["id3"] = <
+                text = <"dv coded text">
+                description = <"dv coded text">
+            >
+        >
+    >


### PR DESCRIPTION
When serializing Archetypes, ODIN strings which contain multiple lines (e.g. in the description or terminology) incorrectly got indentation applied. Each time an ADL file with multiline ODIN strings was parsed and serialized, spaces were added to ODIN strings to each line after the first.

This happend because the ODIN blocks in the ADL were serialized separately and then indented as a whole to the correct level. This indenting was also applied inside multiline strings.

This PR implements a ODINPrettyPrinter based on the DefaultPrettyPrinter from Jackson. This ODINPrettyPrinter can get an initial indentation level. This way the ODIN block can be indented at the right level directly during serialization, removing the need to indent the ODIN block further after serialization.

The ODINGenerator class is changed to use the new ODINPrettyPrinter. This is more in line with other JsonGenerators in the Jackson library.

As a result of this change, serialization of archetypes is now mostly idempotent. That means: serializing an archetype, then parsing the ADL and then serializing the parsed result again, will result in the same ADL. There are some edge cases around default values that are not idempotent yet. These will be resolved in a future PR.

The ADLArchetypeSerializerParserRoundtripTest now validates that the serialization is now idempotent, also for the existing test set of CKM archetypes.

I have also confirmed that serialization of BMM files did not change as result of these changes.
