### PR TITLE
Various ADL serializer improvements

### DIFF
--- a/aom/src/main/java/com/nedap/archie/serializer/adl/ADLArchetypeSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/ADLArchetypeSerializer.java
@@ -87,7 +87,7 @@ abstract public class ADLArchetypeSerializer<T extends Archetype> {
 
         builder.newline().append("rules").newIndentedLine();
         rulesSerializer.appendRules(archetype.getRules());
-        builder.newUnindentedLine();
+        builder.unindent().tryNewLine();
     }
 
     protected void appendRmOverlay() {

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
@@ -49,7 +49,7 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
         builder.lineComment(serializer.getTermText(cobj));
         boolean hasContent = false;
 
-        ADLRulesSerializer serializer = new ADLRulesSerializer(builder, super.serializer);
+        ADLRulesSerializer rulesSerializer = new ADLRulesSerializer(builder, super.serializer);
         if (cobj.getIncludes() != null && cobj.getIncludes().size() > 0) {
             hasContent = true;
             builder.indent().newline()
@@ -58,7 +58,7 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
 
             for (Assertion a : cobj.getIncludes()) {
                 builder.newline();
-                serializer.serializeRuleElement(a.getExpression());
+                rulesSerializer.serializeRuleElement(a.getExpression());
             }
             builder.unindent().unindent();
         }
@@ -69,7 +69,7 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
                     .indent();
             for (Assertion a : cobj.getExcludes()) {
                 builder.newline();
-                serializer.serializeRuleElement(a.getExpression());
+                rulesSerializer.serializeRuleElement(a.getExpression());
             }
             builder.unindent().unindent();
         }
@@ -79,6 +79,7 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
             builder.newline().append("}");
         } else {
             builder.revert(mark);
+            builder.lineComment(serializer.getTermText(cobj));
         }
     }
 }

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
@@ -30,6 +30,7 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
                 .append(cobj.getRmTypeName()).append("[").append(cobj.getNodeId()).append("]");
         if(cobj.isClosed()) {
             builder.append(" closed");
+            builder.lineComment(serializer.getTermText(cobj));
         } else {
             if (cobj.getOccurrences() != null) {
                 builder.append(" occurrences matches {");

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ArchetypeSlotSerializer.java
@@ -45,7 +45,7 @@ public class ArchetypeSlotSerializer extends ConstraintSerializer<ArchetypeSlot>
 
     private void appendMatches(ArchetypeSlot cobj) {
         int mark = builder.mark();
-        builder.append(" matches { ");
+        builder.append(" matches {");
         builder.lineComment(serializer.getTermText(cobj));
         boolean hasContent = false;
 

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CArchetypeRootSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CArchetypeRootSerializer.java
@@ -43,6 +43,8 @@ public class CArchetypeRootSerializer extends CComplexObjectSerializer<CArchetyp
             builder.lineComment(serializer.getTermText(cobj));
             buildAttributesAndTuples(cobj);
             builder.append("}");
+        } else {
+            builder.lineComment(serializer.getTermText(cobj));
         }
 
 

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
@@ -33,12 +33,11 @@ public class CComplexObjectSerializer<T extends CComplexObject> extends Constrai
         if (cobj.getNodeId() != null) {
             builder.append("[").append(cobj.getNodeId()).append("]");
         }
-        builder.append(" ");
         appendOccurrences(cobj);
         if (cobj.getAttributes().isEmpty() && cobj.getAttributeTuples().isEmpty() && cobj.getDefaultValue() == null) {
             builder.lineComment(serializer.getTermText(cobj));
         } else {
-            builder.append("matches {");
+            builder.ensureSpace().append("matches {");
             builder.lineComment(serializer.getTermText(cobj));
             buildAttributesAndTuples(cobj);
 

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ConstraintSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/ConstraintSerializer.java
@@ -38,7 +38,7 @@ public abstract class ConstraintSerializer<T extends CObject> {
             builder.ensureSpace();
             builder.append("occurrences matches {");
             buildOccurrences(builder, cobj.getOccurrences());
-            builder.append("} ");
+            builder.append("}");
         }
     }
 

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -207,6 +207,18 @@ public class ADLDefinitionSerializerTest {
     }
 
     @Test
+    public void serializeBasicCComplexObject() throws Exception {
+        Archetype archetype = loadRoot("adl2-tests/features/aom_structures/basic/openEHR-TEST_PKG-WHOLE.most_minimal.v1.0.0.adls");
+        CComplexObject whole = archetype.getDefinition();
+        String serialized = serializeConstraint(whole);
+        assertThat(serialized, equalTo("\n    WHOLE[id1]    -- most minimal"));
+
+        whole.setOccurrences(MultiplicityInterval.createMandatory());
+        String serialized2 = serializeConstraint(whole);
+        assertThat(serialized2, equalTo("\n    WHOLE[id1] occurrences matches {1}    -- most minimal"));
+    }
+
+    @Test
     public void serializeTupleOrdinal() throws Exception {
         Archetype archetype = loadRoot("adl2-tests/features/aom_structures/tuples/CIMI-CORE-ITEM_GROUP.real_ordinal.v1.0.0.adls");
         CComplexObject ordinal = archetype.itemAtPath("/item[id2]/value[id3]");

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -279,6 +279,11 @@ public class ADLDefinitionSerializerTest {
                 "            archetype_id/value matches {/openEHR-EHR-OBSERVATION\\.blood_pressure([a-zA-Z0-9_]+)*\\.v1/}\n" +
                 "    }", serialized);
 
+        archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_include_empty_exclude_empty.v1.0.0.adls");
+        slot = archetype.itemAtPath("/items[id2]");
+        serialized = serializeConstraint(slot);
+        assertEquals("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1}    -- Vital signs", serialized);
+
         archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls");
         slot = archetype.itemAtPath("/items[id2]");
         serialized = serializeConstraint(slot);

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -297,9 +297,9 @@ public class ADLDefinitionSerializerTest {
         List<CObject> archetypeRoots = archetype.getDefinition().getAttribute("content").getChildren();
 
         assertThat(serializeConstraint(archetypeRoots.get(0)).trim(),
-                equalTo("use_archetype SECTION[id2, openEHR-EHR-SECTION.section_parent.v1] occurrences matches {0..1}"));
+                equalTo("use_archetype SECTION[id2, openEHR-EHR-SECTION.section_parent.v1] occurrences matches {0..1}    -- Section"));
         assertThat(serializeConstraint(archetypeRoots.get(1)).trim(),
-                equalTo("use_archetype OBSERVATION[id3, openEHR-EHR-OBSERVATION.spec_test_obs.v1] occurrences matches {1}"));
+                equalTo("use_archetype OBSERVATION[id3, openEHR-EHR-OBSERVATION.spec_test_obs.v1] occurrences matches {1}    -- Observation"));
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -282,7 +282,7 @@ public class ADLDefinitionSerializerTest {
         archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_closed.v1.0.0.adls");
         slot = archetype.itemAtPath("/items[id2]");
         serialized = serializeConstraint(slot);
-        assertEquals("\n    allow_archetype OBSERVATION[id2] closed", serialized);
+        assertEquals("\n    allow_archetype OBSERVATION[id2] closed    -- Vital signs", serialized);
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -256,7 +256,7 @@ public class ADLDefinitionSerializerTest {
         Archetype archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_include_any_exclude_empty.v1.0.0.adls");
         ArchetypeSlot slot = archetype.itemAtPath("/items[id2]");
         String serialized = serializeConstraint(slot);
-        assertEquals("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {     -- Vital signs\n" +
+        assertEquals("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {    -- Vital signs\n" +
                 "        include\n" +
                 "            archetype_id/value matches {/.*/}\n" +
                 "    }", serialized);
@@ -265,7 +265,7 @@ public class ADLDefinitionSerializerTest {
         archetype = load("openEHR-EHR-CLUSTER.device.v1.adls");
         slot = archetype.itemAtPath("/items[id10]");
         serialized = serializeConstraint(slot);
-        assertEquals("\n    allow_archetype CLUSTER[id10] occurrences matches {0..*} matches {     -- Properties\n" +
+        assertEquals("\n    allow_archetype CLUSTER[id10] occurrences matches {0..*} matches {    -- Properties\n" +
                 "        include\n" +
                 "            archetype_id/value matches {/openEHR-EHR-CLUSTER\\.dimensions(-a-zA-Z0-9_]+)*\\.v1|openEHR-EHR-CLUSTER\\.catheter(-a-zA-Z0-9_]+)*\\.v1/}\n" +
                 "    }", serialized);
@@ -274,7 +274,7 @@ public class ADLDefinitionSerializerTest {
         archetype = loadRoot("adl2-tests/features/aom_structures/slots/openEHR-EHR-SECTION.slot_include_empty_exclude_non_any.v1.0.0.adls");
         slot = archetype.itemAtPath("/items[id2]");
         serialized = serializeConstraint(slot);
-        assertEquals("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {     -- Vital signs\n" +
+        assertEquals("\n    allow_archetype OBSERVATION[id2] occurrences matches {0..1} matches {    -- Vital signs\n" +
                 "        exclude\n" +
                 "            archetype_id/value matches {/openEHR-EHR-OBSERVATION\\.blood_pressure([a-zA-Z0-9_]+)*\\.v1/}\n" +
                 "    }", serialized);


### PR DESCRIPTION
Various small improvements in ADL serialization:
* Fix double newline after rules section
* Prevent trailing whitespace after complex object constraints
* Add comment after closed archetype slots
* Remove extra space in archetype slots
* Add comment after archetype slots without constraints
* Add comment after archetype roots without attributes