### PR TITLE
Fix the indentation of default values during ADL serialization

### DIFF
--- a/aom/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
@@ -130,6 +130,10 @@ public class ADLStringBuilder implements StructuredStringAppendable {
         return builder.getCurrentLineLength();
     }
 
+    public int getIndentDepth() {
+        return builder.getIndentDepth();
+    }
+
     public ODINMapper getOdinMapper() {
         return odinMapper;
     }


### PR DESCRIPTION
Follow-up of #651

When serializing Archetypes, indentation was applied incorrectly to default values. Spaces were added to multiline ODIN strings to each line after the first and serialization of unparsed JSON got extra unnecessary indentation applied.

For the indentation to work correctly the process is split into three cases:

* Unparsed values in `DefaultValueContainer`s (e.g. when no metamodels or mappers are available or the format is unknown): These will be serialized as-is in the `DefaultValueContainer`. For ODIN this will be unformatted, as any formatting is lost during parsing. For JSON and other formats the serialization will be the same as in the original ADL, keeping any original indentation without adding any extra.
* Parsed values serialized as JSON: This will use the current process of serializing the default value to JSON and then indenting each line in the serialized JSON to the correct level, as this can be safely done with JSON.
* Parsed values serialized as ODIN: This will use the new ODINPrettyPrinter introduced in #651 to directly serialize the ODIN with the correct indentation.

This will make the roundtrip serialization of unparsed values and parsed values as ODIN idempotent, as the seriazization of parsed values as JSON already was.
