### PR TITLE
Set rm_version from OPT in OpenEhrRmInstanceGenerator

### DIFF
--- a/tools/src/main/java/com/nedap/archie/creation/ExampleJsonInstanceGenerator.java
+++ b/tools/src/main/java/com/nedap/archie/creation/ExampleJsonInstanceGenerator.java
@@ -38,6 +38,7 @@ public  class ExampleJsonInstanceGenerator {
     private final String language;
     private final MetaModels models;
     private OperationalTemplate archetype;
+    private String rmRelease;
     private BmmModel bmm;
     private AomProfile aomProfile;
 
@@ -56,7 +57,7 @@ public  class ExampleJsonInstanceGenerator {
 
     public Map<String, Object> generate(OperationalTemplate archetype) {
         this.archetype = archetype;
-        String rmRelease = archetype.getRmRelease();
+        rmRelease = archetype.getRmRelease();
         //rm release 1.0.4 and 1.1.0 supported. if other versions, switch to 1.1.0 automatically to support other archetypes
         if(rmRelease == null ||
                 !(rmRelease.equalsIgnoreCase("1.0.4") || rmRelease.equalsIgnoreCase("1.1.0"))) {
@@ -504,5 +505,9 @@ public  class ExampleJsonInstanceGenerator {
 
     protected OperationalTemplate getArchetype() {
         return archetype;
+    }
+
+    protected String getRmRelease() {
+        return rmRelease;
     }
 }

--- a/tools/src/main/java/com/nedap/archie/creation/OpenEhrRmInstanceGenerator.java
+++ b/tools/src/main/java/com/nedap/archie/creation/OpenEhrRmInstanceGenerator.java
@@ -142,7 +142,7 @@ class OpenEhrRmInstanceGenerator {
         archetypeId.put(typePropertyName, "ARCHETYPE_ID");
         archetypeId.put("value", archetypeIdValue);
         archetypeDetails.put("archetype_id", archetypeId); //TODO: add template id?
-        archetypeDetails.put("rm_version", "1.0.4");
+        archetypeDetails.put("rm_version", generator.getRmRelease());
         return archetypeDetails;
     }
 

--- a/tools/src/test/java/com/nedap/archie/creation/ExampleJsonInstanceGeneratorTest.java
+++ b/tools/src/test/java/com/nedap/archie/creation/ExampleJsonInstanceGeneratorTest.java
@@ -145,6 +145,45 @@ public class ExampleJsonInstanceGeneratorTest {
         assertTrue(s.contains("{\"_type\":\"DV_ORDINAL\",\"value\":0,\"symbol\":{\"_type\":\"DV_CODED_TEXT\",\"value\":\"Absent\",\"defining_code\":{\"_type\":\"CODE_PHRASE\",\"terminology_id\":{\"_type\":\"TERMINOLOGY_ID\",\"value\":\"local\"},\"code_string\":\"at11\"}}}"));
     }
 
+    @Test
+    public void rmRelease104() throws Exception {
+        // This archetype has rm_release=1.0.4
+        OperationalTemplate opt = createOPT("/com/nedap/archie/rules/evaluation/construct_archetype_slot.adls");
+        ExampleJsonInstanceGenerator structureGenerator = createExampleJsonInstanceGenerator();
+
+        Map<String, Object> structure = structureGenerator.generate(opt);
+        String json = serializeToJson(structure, false);
+        Observation observation = getArchieObjectMapper().readValue(json, Observation.class);
+
+        assertEquals("1.0.4", observation.getArchetypeDetails().getRmVersion());
+    }
+
+    @Test
+    public void rmRelease110() throws Exception {
+        // This archetype has rm_release=1.1.0
+        OperationalTemplate opt = createOPT("/com/nedap/archie/diff/openEHR-EHR-OBSERVATION.basic_annotations.v1.0.0.adls");
+        ExampleJsonInstanceGenerator structureGenerator = createExampleJsonInstanceGenerator();
+
+        Map<String, Object> structure = structureGenerator.generate(opt);
+        String json = serializeToJson(structure, false);
+        Observation observation = getArchieObjectMapper().readValue(json, Observation.class);
+
+        assertEquals("1.1.0", observation.getArchetypeDetails().getRmVersion());
+    }
+
+    @Test
+    public void rmReleaseFallback() throws Exception {
+        // This archetype has rm_release=1.0.2, which should fall back to 1.1.0
+        OperationalTemplate opt = createOPT("/adl2-tests/features/aom_structures/tuples/openEHR-EHR-OBSERVATION.ordinal_tuple.v1.0.0.adls");
+        ExampleJsonInstanceGenerator structureGenerator = createExampleJsonInstanceGenerator();
+
+        Map<String, Object> structure = structureGenerator.generate(opt);
+        String json = serializeToJson(structure, false);
+        Observation observation = getArchieObjectMapper().readValue(json, Observation.class);
+
+        assertEquals("1.1.0", observation.getArchetypeDetails().getRmVersion());
+    }
+
     /**
      * Tests all CKM examples with the Archie JSON Schema, that properly handles polymorphism
      * This probably will go away once we have a proper solution


### PR DESCRIPTION
Instead of the hard coded rm_version, set the rm_version from the operation template in OpenEhrRmInstanceGenerator