### PR TITLE
Revert rigorous cleanup of ADL14Converter

### DIFF
--- a/aom/src/main/java/com/nedap/archie/adl14/ADL2ConversionResult.java
+++ b/aom/src/main/java/com/nedap/archie/adl14/ADL2ConversionResult.java
@@ -56,6 +56,11 @@ public class ADL2ConversionResult {
     }
 
     /* SETTERS **/
+
+    public void setArchetypeId(String archetypeId) {
+        this.archetypeId = archetypeId;
+    }
+
     public void setArchetype(Archetype archetype) {
         this.archetype = archetype;
     }

--- a/tools/src/main/java/com/nedap/archie/adl14/DefaultRmStructureRemover.java
+++ b/tools/src/main/java/com/nedap/archie/adl14/DefaultRmStructureRemover.java
@@ -27,6 +27,15 @@ public class DefaultRmStructureRemover {
     private BMMConstraintImposer constraintImposer;
 
     /**
+     * Construct a DefaultRmStructureRemover that does not remove empty attributes
+     * @param metaModels the metamodels containing metamodel information for the preset archetypes
+     * Part of the public API, do not remove
+     */
+    public DefaultRmStructureRemover(MetaModels metaModels) {
+        this(metaModels, false);
+    }
+
+    /**
      * Construct a DefaultRmStructureRemover
      *
      * @param metaModels            the metamodels containing metamodel information for the preset archetypes


### PR DESCRIPTION
In https://github.com/openEHR/archie/pull/648, 2 public methods were removed that could be used by parties using the archie library. This PR adds them back.