### PR TITLE
Use RMObject setters instead of private field declaration

### DIFF
--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Archetyped.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Archetyped.java
@@ -37,14 +37,14 @@ public class Archetyped extends RMObject {
     }
 
     public Archetyped(ArchetypeID archetypeId, String rmVersion) {
-        this.archetypeId = archetypeId;
-        this.rmVersion = rmVersion;
+        setArchetypeId(archetypeId);
+        setRmVersion(rmVersion);
     }
 
     public Archetyped(ArchetypeID archetypeId, @Nullable TemplateId templateId, String rmVersion) {
-        this.archetypeId = archetypeId;
-        this.templateId = templateId;
-        this.rmVersion = rmVersion;
+        setArchetypeId(archetypeId);
+        setTemplateId(templateId);
+        setRmVersion(rmVersion);
     }
 
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/FeederAudit.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/FeederAudit.java
@@ -40,11 +40,11 @@ public class FeederAudit extends RMObject {
     }
 
     public FeederAudit(FeederAuditDetails originatingSystemAudit, @Nullable List<DvIdentifier> originatingSystemItemIds, @Nullable FeederAuditDetails feederSystemAudit, @Nullable List<DvIdentifier> feederSystemItemIds, @Nullable DvEncapsulated originalContent) {
-        this.originatingSystemItemIds = originatingSystemItemIds;
-        this.feederSystemItemIds = feederSystemItemIds;
-        this.originalContent = originalContent;
-        this.originatingSystemAudit = originatingSystemAudit;
-        this.feederSystemAudit = feederSystemAudit;
+        setOriginatingSystemItemIds(originatingSystemItemIds);
+        setFeederSystemItemIds(feederSystemItemIds);
+        setOriginalContent(originalContent);
+        setOriginatingSystemAudit(originatingSystemAudit);
+        setFeederSystemAudit(feederSystemAudit);
     }
 
     public List<DvIdentifier> getOriginatingSystemItemIds() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/FeederAuditDetails.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/FeederAuditDetails.java
@@ -43,17 +43,17 @@ public class FeederAuditDetails extends RMObject {
     }
 
     public FeederAuditDetails(String systemId) {
-        this.systemId = systemId;
+        setSystemId(systemId);
     }
 
     public FeederAuditDetails(String systemId, @Nullable PartyIdentified provider, @Nullable PartyIdentified location, @Nullable DvDateTime time, @Nullable PartyProxy subject, @Nullable String versionId, @Nullable ItemStructure otherDetails) {
-        this.systemId = systemId;
-        this.location = location;
-        this.provider = provider;
-        this.subject = subject;
-        this.time = time;
-        this.versionId = versionId;
-        this.otherDetails = otherDetails;
+        setSystemId(systemId);
+        setLocation(location);
+        setProvider(provider);
+        setSubject(subject);
+        setTime(time);
+        setVersionId(versionId);
+        setOtherDetails(otherDetails);
     }
 
     public String getSystemId() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Link.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Link.java
@@ -24,9 +24,9 @@ public class Link extends RMObject {
     }
 
     public Link(DvText meaning, DvText type, DvEHRURI target) {
-        this.meaning = meaning;
-        this.type = type;
-        this.target = target;
+        setMeaning(meaning);
+        setType(type);
+        setTarget(target);
     }
 
     public DvText getMeaning() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Locatable.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Locatable.java
@@ -50,18 +50,18 @@ public abstract class Locatable extends Pathable {
     }
 
     public Locatable(String archetypeNodeId, DvText name) {
-        this.name = name;
-        this.archetypeNodeId = archetypeNodeId;
+        setName(name);
+        setArchetypeNodeId(archetypeNodeId);
     }
 
     public Locatable(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName) {
         super(parent, parentAttributeName);
-        this.name = name;
-        this.archetypeNodeId = archetypeNodeId;
-        this.uid = uid;
-        this.archetypeDetails = archetypeDetails;
-        this.feederAudit = feederAudit;
-        this.links = links;
+        setName(name);
+        setArchetypeNodeId(archetypeNodeId);
+        setUid(uid);
+        setArchetypeDetails(archetypeDetails);
+        setFeederAudit(feederAudit);
+        setLinks(links);
     }
 
     public DvText getName() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Pathable.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/archetyped/Pathable.java
@@ -42,8 +42,8 @@ public abstract class Pathable extends RMObject {
     }
 
     public Pathable(@Nullable Pathable parent, @Nullable String parentAttributeName) {
-        this.parent = parent;
-        this.parentAttributeName = parentAttributeName;
+        setParent(parent);
+        setParentAttributeName(parentAttributeName);
     }
 
     public Object itemAtPath(String s) {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/Contribution.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/Contribution.java
@@ -32,9 +32,9 @@ public class Contribution extends RMObject {
     }
 
     public Contribution(HierObjectId uid, List<ObjectRef<? extends ObjectId>> versions, AuditDetails audit) {
-        this.uid = uid;
-        this.versions = versions;
-        this.audit = audit;
+        setUid(uid);
+        setVersions(versions);
+        setAudit(audit);
     }
 
     public HierObjectId getUid() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/ImportedVersion.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/ImportedVersion.java
@@ -24,7 +24,7 @@ public class ImportedVersion<T> extends Version<T> {
 
     public ImportedVersion(AuditDetails commitAudit, ObjectRef<? extends ObjectId> contribution, @Nullable String signature, OriginalVersion<T> item) {
         super(commitAudit, contribution, signature);
-        this.item = item;
+        setItem(item);
     }
 
     @Override
@@ -60,6 +60,10 @@ public class ImportedVersion<T> extends Version<T> {
 
     public OriginalVersion<T> getItem() {
         return item;
+    }
+
+    public void setItem(OriginalVersion<T> item) {
+        this.item = item;
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/OriginalVersion.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/OriginalVersion.java
@@ -56,12 +56,12 @@ public class    OriginalVersion<Type> extends Version<Type> {
 
     public OriginalVersion(ObjectVersionId uid, @Nullable ObjectVersionId precedingVersionUid, @Nullable Type data, DvCodedText lifecycleState, AuditDetails commitAudit, ObjectRef<? extends ObjectId> contribution, @Nullable String signature, @Nullable List<ObjectVersionId> otherInputVersionUids, @Nullable List<Attestation> attestations) {
         super(commitAudit, contribution, signature);
-        this.uid = uid;
-        this.precedingVersionUid = precedingVersionUid;
-        this.otherInputVersionUids = otherInputVersionUids;
-        this.lifecycleState = lifecycleState;
-        this.attestations = attestations;
-        this.data = data;
+        setUid(uid);
+        setPrecedingVersionUid(precedingVersionUid);
+        setOtherInputVersionUids(otherInputVersionUids);
+        setLifecycleState(lifecycleState);
+        setAttestations(attestations);
+        setData(data);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/Version.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/Version.java
@@ -41,9 +41,9 @@ public abstract class Version<Type> extends RMObject {
     }
 
     public Version(AuditDetails commitAudit, ObjectRef<? extends ObjectId> contribution, @Nullable String signature) {
-        this.contribution = contribution;
-        this.signature = signature;
-        this.commitAudit = commitAudit;
+        setContribution(contribution);
+        setSignature(signature);
+        setCommitAudit(commitAudit);
     }
 
     public ObjectRef<? extends ObjectId> getContribution() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/VersionedObject.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/changecontrol/VersionedObject.java
@@ -33,9 +33,9 @@ public class VersionedObject<Type> extends RMObject {
     }
 
     public VersionedObject(HierObjectId uid, ObjectRef<? extends ObjectId> ownerId, DvDateTime timeCreated) {
-        this.uid = uid;
-        this.ownerId = ownerId;
-        this.timeCreated = timeCreated;
+        setUid(uid);
+        setOwnerId(ownerId);
+        setTimeCreated(timeCreated);
     }
 
     public HierObjectId getUid() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Action.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Action.java
@@ -47,10 +47,10 @@ public class Action extends CareEntry {
 
     public Action(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations, @Nullable ItemStructure protocol, @Nullable ObjectRef<? extends ObjectId> guidelineId, DvDateTime time, ItemStructure description, IsmTransition ismTransition, @Nullable InstructionDetails instructionDetails) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, language, encoding, subject, provider, workflowId, otherParticipations, protocol, guidelineId);
-        this.time = time;
-        this.description = description;
-        this.ismTransition = ismTransition;
-        this.instructionDetails = instructionDetails;
+        setTime(time);
+        setDescription(description);
+        setIsmTransition(ismTransition);
+        setInstructionDetails(instructionDetails);
     }
 
     public DvDateTime getTime() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Activity.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Activity.java
@@ -47,16 +47,16 @@ public class Activity extends Locatable {
 
     public Activity(String archetypeNodeId, DvText name, ItemStructure description, @Nullable DvParsable timing, String actionArchetypeId) {
         super(archetypeNodeId, name);
-        this.description = description;
-        this.timing = timing;
-        this.actionArchetypeId = actionArchetypeId;
+        setDescription(description);
+        setTiming(timing);
+        setActionArchetypeId(actionArchetypeId);
     }
 
     public Activity(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, ItemStructure description, @Nullable DvParsable timing, String actionArchetypeId) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.description = description;
-        this.timing = timing;
-        this.actionArchetypeId = actionArchetypeId;
+        setDescription(description);
+        setTiming(timing);
+        setActionArchetypeId(actionArchetypeId);
     }
 
     public ItemStructure getDescription() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/AdminEntry.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/AdminEntry.java
@@ -35,7 +35,7 @@ public class AdminEntry extends Entry {
 
     public AdminEntry(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations, ItemStructure data) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, language, encoding, subject, provider, workflowId, otherParticipations);
-        this.data = data;
+        setData(data);
     }
 
     public ItemStructure getData() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/CareEntry.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/CareEntry.java
@@ -42,8 +42,8 @@ public abstract class CareEntry extends Entry {
 
     public CareEntry(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations, @Nullable ItemStructure protocol, @Nullable ObjectRef<? extends ObjectId> guidelineId) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, language, encoding, subject, provider, workflowId, otherParticipations);
-        this.protocol = protocol;
-        this.guidelineId = guidelineId;
+        setProtocol(protocol);
+        setGuidelineId(guidelineId);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Composition.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Composition.java
@@ -52,22 +52,22 @@ public class Composition extends Locatable {
 
     public Composition(String archetypeNodeId, DvText name, @Nullable List<ContentItem> content, CodePhrase language, @Nullable EventContext context, PartyProxy composer, DvCodedText category, CodePhrase territory) {
         super(archetypeNodeId, name);
-        this.language = language;
-        this.territory = territory;
-        this.category = category;
-        this.composer = composer;
-        this.context = context;
-        this.content = content;
+        setLanguage(language);
+        setTerritory(territory);
+        setCategory(category);
+        setComposer(composer);
+        setContext(context);
+        setContent(content);
     }
 
     public Composition(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, @Nullable List<ContentItem> content, CodePhrase language, @Nullable EventContext context, PartyProxy composer, DvCodedText category, CodePhrase territory) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.language = language;
-        this.territory = territory;
-        this.category = category;
-        this.composer = composer;
-        this.context = context;
-        this.content = content;
+        setLanguage(language);
+        setTerritory(territory);
+        setCategory(category);
+        setComposer(composer);
+        setContext(context);
+        setContent(content);
     }
 
     @JsonProperty

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Entry.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Entry.java
@@ -58,12 +58,12 @@ public abstract class Entry extends ContentItem {
 
     public Entry(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.language = language;
-        this.encoding = encoding;
-        this.workflowId = workflowId;
-        this.subject = subject;
-        this.provider = provider;
-        this.otherParticipations = otherParticipations;
+        setLanguage(language);
+        setEncoding(encoding);
+        setWorkflowId(workflowId);
+        setSubject(subject);
+        setProvider(provider);
+        setOtherParticipations(otherParticipations);
     }
 
     public PartyProxy getSubject() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Evaluation.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Evaluation.java
@@ -40,13 +40,13 @@ public class Evaluation extends CareEntry {
 
     public Evaluation(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations, @Nullable ItemStructure protocol, @Nullable ObjectRef<? extends ObjectId> guidelineId, ItemStructure data) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, language, encoding, subject, provider, workflowId, otherParticipations, protocol, guidelineId);
-        this.data = data;
+        setData(data);
     }
 
     public Evaluation(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations, @Nullable ItemStructure protocol, @Nullable ObjectRef<? extends ObjectId> guidelineId, @Nullable DvDateTime timeAsserted, ItemStructure data) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, language, encoding, subject, provider, workflowId, otherParticipations, protocol, guidelineId);
-        this.timeAsserted = timeAsserted;
-        this.data = data;
+        setTimeAsserted(timeAsserted);
+        setData(data);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/EventContext.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/EventContext.java
@@ -56,18 +56,18 @@ public class EventContext extends Pathable {
     }
 
     public EventContext(DvDateTime startTime, DvCodedText setting) {
-        this.startTime = startTime;
-        this.setting = setting;
+        setStartTime(startTime);
+        setSetting(setting);
     }
 
     public EventContext(@Nullable PartyIdentified healthCareFacility, DvDateTime startTime, @Nullable DvDateTime endTime, @Nullable List<Participation> participations, @Nullable String location, DvCodedText setting, @Nullable ItemStructure otherContext) {
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.location = location;
-        this.setting = setting;
-        this.otherContext = otherContext;
-        this.healthCareFacility = healthCareFacility;
-        this.participations = participations;
+        setStartTime(startTime);
+        setEndTime(endTime);
+        setLocation(location);
+        setSetting(setting);
+        setOtherContext(otherContext);
+        setHealthCareFacility(healthCareFacility);
+        setParticipations(participations);
     }
 
     public DvDateTime getStartTime() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Instruction.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Instruction.java
@@ -55,10 +55,10 @@ public class Instruction extends CareEntry {
 
     public Instruction(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations, @Nullable ItemStructure protocol, @Nullable ObjectRef<? extends ObjectId> guidelineId, DvText narrative, @Nullable List<Activity> activities, @Nullable DvDateTime expiryTime, @Nullable DvParsable wfDefinition) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, language, encoding, subject, provider, workflowId, otherParticipations, protocol, guidelineId);
-        this.narrative = narrative;
-        this.expiryTime = expiryTime;
-        this.wfDefinition = wfDefinition;
-        this.activities = activities;
+        setNarrative(narrative);
+        setExpiryTime(expiryTime);
+        setWfDefinition(wfDefinition);
+        setActivities(activities);
     }
 
     public DvText getNarrative() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/InstructionDetails.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/InstructionDetails.java
@@ -36,9 +36,9 @@ public class InstructionDetails extends Pathable {
     }
 
     public InstructionDetails(LocatableRef instructionId, String activityId, @Nullable ItemStructure wfDetails) {
-        this.instructionId = instructionId;
-        this.activityId = activityId;
-        this.wfDetails = wfDetails;
+        setInstructionId(instructionId);
+        setActivityId(activityId);
+        setWfDetails(wfDetails);
     }
 
     public LocatableRef getInstructionId() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/IsmTransition.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/IsmTransition.java
@@ -43,10 +43,10 @@ public class IsmTransition extends Pathable {
     }
 
     public IsmTransition(DvCodedText currentState, @Nullable DvCodedText transition, @Nullable DvCodedText careflowStep, @Nullable List<DvText> reason) {
-        this.currentState = currentState;
-        this.transition = transition;
-        this.careflowStep = careflowStep;
-        this.reason = reason;
+        setCurrentState(currentState);
+        setTransition(transition);
+        setCareflowStep(careflowStep);
+        setReason(reason);
     }
 
     public DvCodedText getCurrentState() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Observation.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Observation.java
@@ -43,8 +43,8 @@ public class Observation extends CareEntry {
 
     public Observation(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, CodePhrase language, CodePhrase encoding, PartyProxy subject, @Nullable PartyProxy provider, @Nullable ObjectRef<? extends ObjectId> workflowId, @Nullable List<Participation> otherParticipations, @Nullable ItemStructure protocol, @Nullable ObjectRef<? extends ObjectId> guidelineId, History<ItemStructure> data, @Nullable History<ItemStructure> state) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, language, encoding, subject, provider, workflowId, otherParticipations, protocol, guidelineId);
-        this.state = state;
-        this.data = data;
+        setState(state);
+        setData(data);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Section.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/composition/Section.java
@@ -36,12 +36,12 @@ public class Section extends ContentItem {
 
     public Section(String archetypeNodeId, DvText name, @Nullable List<ContentItem> items) {
         super(archetypeNodeId, name);
-        this.items = items;
+        setItems(items);
     }
 
     public Section(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, @Nullable List<ContentItem> items) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.items = items;
+        setItems(items);
     }
 
     public List<ContentItem> getItems() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Cluster.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Cluster.java
@@ -47,9 +47,7 @@ public class Cluster extends Item {
 
     public void setItems(List<Item> items) {
         this.items = items;
-
         setThisAsParent(items, "items");
-
     }
 
     public void addItem(Item item) {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Element.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Element.java
@@ -45,16 +45,16 @@ public class Element extends Item implements SingleValuedDataValue<DataValue> {
 
     public Element(String archetypeNodeId, DvText name, @Nullable DataValue value) {
         super(archetypeNodeId, name);
-        this.value = value;
+        setValue(value);
     }
 
     public Element(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails,
                    @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName,
                    @Nullable DataValue value, @Nullable DvCodedText nullFlavour, DvText nullReason) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.value = value;
-        this.nullFlavour = nullFlavour;
-        this.nullReason = nullReason;
+        setValue(value);
+        setNullFlavour(nullFlavour);
+        setNullReason(nullReason);
     }
 
     public DvCodedText getNullFlavour() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Event.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/Event.java
@@ -39,16 +39,16 @@ public abstract class Event<Type extends ItemStructure> extends Locatable {
 
     public Event(String archetypeNodeId, DvText name, DvDateTime time, Type data) {
         super(archetypeNodeId, name);
-        this.time = time;
-        this.data = data;
+        setTime(time);
+        setData(data);
     }
 
 
     public Event(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, DvDateTime time, Type data, @Nullable Type state) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.time = time;
-        this.state = state;
-        this.data = data;
+        setTime(time);
+        setState(state);
+        setData(data);
     }
 
     public DvDateTime getTime() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/History.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/History.java
@@ -49,17 +49,17 @@ public final class History<Type extends ItemStructure> extends DataStructure {
 
     public History(String archetypeNodeId, DvText name, DvDateTime origin, @Nullable List<Event<Type>> events) {
         super(archetypeNodeId, name);
-        this.origin = origin;
-        this.events = events;
+        setOrigin(origin);
+        setEvents(events);
     }
 
     public History(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, DvDateTime origin, @Nullable List<Event<Type>> events, @Nullable DvDuration period, @Nullable DvDuration duration, @Nullable Type summary) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.origin = origin;
-        this.period = period;
-        this.duration = duration;
-        this.summary = summary;
-        this.events = events;
+        setOrigin(origin);
+        setPeriod(period);
+        setDuration(duration);
+        setSummary(summary);
+        setEvents(events);
     }
 
     public DvDateTime getOrigin() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/IntervalEvent.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/IntervalEvent.java
@@ -44,9 +44,9 @@ public class IntervalEvent<Type extends ItemStructure> extends Event<Type> {
 
     public IntervalEvent(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, DvDateTime time, Type data, @Nullable Type state, DvDuration width, DvCodedText mathFunction, @Nullable Long sampleCount) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName, time, data, state);
-        this.width = width;
-        this.sampleCount = sampleCount;
-        this.mathFunction = mathFunction;
+        setWidth(width);
+        setSampleCount(sampleCount);
+        setMathFunction(mathFunction);
     }
 
     public DvDuration getWidth() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datastructures/ItemSingle.java
@@ -36,12 +36,12 @@ public class ItemSingle extends ItemStructure {
 
     public ItemSingle(String archetypeNodeId, DvText name, Element item) {
         super(archetypeNodeId, name);
-        this.item = item;
+        setItem(item);
     }
 
     public ItemSingle(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, Element item) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.item = item;
+        setItem(item);
     }
 
     public Element getItem() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datatypes/CodePhrase.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datatypes/CodePhrase.java
@@ -43,9 +43,9 @@ public class CodePhrase extends RMObject {
     }
 
     public CodePhrase(TerminologyId terminologyId, String codeString, String preferredTerm) {
-        this.terminologyId = terminologyId;
-        this.codeString = codeString;
-        this.preferredTerm = preferredTerm;
+        setTerminologyId(terminologyId);
+        setCodeString(codeString);
+        setPreferredTerm(preferredTerm);
     }
 
     /**

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvBoolean.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvBoolean.java
@@ -20,7 +20,7 @@ public class DvBoolean extends DataValue implements SingleValuedDataValue<Boolea
     }
 
     public DvBoolean(Boolean value) {
-        this.value = value;
+        setValue(value);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvCodedText.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvCodedText.java
@@ -28,17 +28,17 @@ public class DvCodedText extends DvText {
 
     public DvCodedText(String value, CodePhrase definingCode) {
         super(value);
-        this.definingCode = definingCode;
+        setDefiningCode(definingCode);
     }
 
     public DvCodedText(String value, String definingCode) {
         super(value);
-        this.definingCode = new CodePhrase(definingCode);
+        setDefiningCode(new CodePhrase(definingCode));
     }
 
     public DvCodedText(String value, @Nullable CodePhrase language, @Nullable CodePhrase encoding, CodePhrase definingCode) {
         super(value, language, encoding);
-        this.definingCode = definingCode;
+        setDefiningCode(definingCode);
     }
 
     public CodePhrase getDefiningCode() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvText.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvText.java
@@ -45,13 +45,13 @@ public class DvText extends DataValue implements SingleValuedDataValue<String> {
     }
 
     public DvText(String value) {
-        this.value = value;
+        setValue(value);
     }
 
     public DvText(String value, @Nullable CodePhrase language, @Nullable CodePhrase encoding) {
-        this.value = value;
-        this.language = language;
-        this.encoding = encoding;
+        setValue(value);
+        setLanguage(language);
+        setEncoding(encoding);
     }
 
     public List<TermMapping> getMappings() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvURI.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/DvURI.java
@@ -24,7 +24,7 @@ public class DvURI extends DataValue implements SingleValuedDataValue<URI> {
     }
 
     public DvURI(URI value) {
-        this.value = value;
+        setValue(value);
     }
 
     /**
@@ -33,7 +33,7 @@ public class DvURI extends DataValue implements SingleValuedDataValue<URI> {
      * @param uri
      */
     public DvURI(String uri) {
-        this.value = URI.create(uri);
+        setValue(URI.create(uri));
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/TermMapping.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/TermMapping.java
@@ -12,7 +12,6 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -49,9 +48,9 @@ public class TermMapping extends RMObject {
     }
 
     public TermMapping(CodePhrase target, Character match, @Nullable DvCodedText purpose) {
-        this.match = match;
-        this.purpose = purpose;
-        this.target = target;
+        setMatch(match);
+        setPurpose(purpose);
+        setTarget(target);
     }
 
     public char getMatch() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvEncapsulated.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvEncapsulated.java
@@ -30,8 +30,8 @@ public abstract class DvEncapsulated extends DataValue {
     }
 
     public DvEncapsulated(@Nullable CodePhrase charset, @Nullable CodePhrase language) {
-        this.charset = charset;
-        this.language = language;
+        setCharset(charset);
+        setLanguage(language);
     }
 
     public CodePhrase getCharset() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvParsable.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/encapsulated/DvParsable.java
@@ -30,14 +30,14 @@ public class DvParsable extends DvEncapsulated implements SingleValuedDataValue<
     }
 
     public DvParsable(String value, String formalism) {
-        this.value = value;
-        this.formalism = formalism;
+        setValue(value);
+        setFormalism(formalism);
     }
 
     public DvParsable(@Nullable CodePhrase charset, @Nullable CodePhrase language, String value, String formalism) {
         super(charset, language);
-        this.value = value;
-        this.formalism = formalism;
+        setValue(value);
+        setFormalism(formalism);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvAmount.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvAmount.java
@@ -35,8 +35,8 @@ public abstract class DvAmount<DataValueType extends DvAmount<DataValueType, Mag
 
     public DvAmount(@Nullable List<ReferenceRange<DataValueType>> otherReferenceRanges, @Nullable DvInterval<DataValueType> normalRange, @Nullable CodePhrase normalStatus, @Nullable Double accuracy, @Nullable Boolean accuracyIsPercent, @Nullable String magnitudeStatus) {
         super(otherReferenceRanges, normalRange, normalStatus, magnitudeStatus);
-        this.accuracy = accuracy;
-        this.accuracyIsPercent = accuracyIsPercent;
+        setAccuracy(accuracy);
+        setAccuracyIsPercent(accuracyIsPercent);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvCount.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvCount.java
@@ -22,12 +22,12 @@ public class DvCount extends DvAmount<DvCount, Long> {
     }
 
     public DvCount(Long magnitude) {
-        this.magnitude = magnitude;
+        setMagnitude(magnitude);
     }
 
     public DvCount(@Nullable List<ReferenceRange<DvCount>> otherReferenceRanges, @Nullable DvInterval<DvCount> normalRange, @Nullable CodePhrase normalStatus, @Nullable Double accuracy, @Nullable Boolean accuracyIsPercent, @Nullable String magnitudeStatus, Long magnitude) {
         super(otherReferenceRanges, normalRange, normalStatus, accuracy, accuracyIsPercent, magnitudeStatus);
-        this.magnitude = magnitude;
+        setMagnitude(magnitude);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvInterval.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvInterval.java
@@ -3,14 +3,9 @@ package com.nedap.archie.rm.datavalues.quantity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nedap.archie.base.Interval;
 import com.nedap.archie.rm.datavalues.DataValue;
-import com.nedap.archie.rminfo.Invariant;
 
 import javax.annotation.Nullable;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.*;
 import java.util.Objects;
 
 /**

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvOrdered.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvOrdered.java
@@ -43,14 +43,14 @@ public abstract class DvOrdered<DataValueType extends DvOrdered<DataValueType>> 
     }
 
     public DvOrdered(@Nullable List<ReferenceRange<DataValueType>> otherReferenceRanges, @Nullable DvInterval<DataValueType> normalRange) {
-        this.normalRange = normalRange;
-        this.otherReferenceRanges = otherReferenceRanges;
+        setNormalRange(normalRange);
+        setOtherReferenceRanges(otherReferenceRanges);
     }
 
     protected DvOrdered(@Nullable List<ReferenceRange<DataValueType>> otherReferenceRanges, @Nullable DvInterval<DataValueType> normalRange, @Nullable CodePhrase normalStatus) {
-        this.normalStatus = normalStatus;
-        this.normalRange = normalRange;
-        this.otherReferenceRanges = otherReferenceRanges;
+        setNormalStatus(normalStatus);
+        setNormalRange(normalRange);
+        setOtherReferenceRanges(otherReferenceRanges);
     }
 
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvOrdinal.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvOrdinal.java
@@ -27,14 +27,14 @@ public class DvOrdinal extends DvOrdered<DvOrdinal> implements SingleValuedDataV
     }
 
     public DvOrdinal(Long value, DvCodedText symbol) {
-        this.symbol = symbol;
-        this.value = value;
+        setSymbol(symbol);
+        setValue(value);
     }
 
     public DvOrdinal(@Nullable List<ReferenceRange<DvOrdinal>> otherReferenceRanges, @Nullable DvInterval<DvOrdinal> normalRange, Long value, DvCodedText symbol) {
         super(otherReferenceRanges, normalRange);
-        this.symbol = symbol;
-        this.value = value;
+        setSymbol(symbol);
+        setValue(value);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvProportion.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvProportion.java
@@ -39,18 +39,18 @@ public class DvProportion extends DvAmount<DvProportion, Double> {
     }
 
     public DvProportion(Double numerator, Double denominator, Long type, Long precision) {
-        this.numerator = numerator;
-        this.denominator = denominator;
-        this.type = type;
-        this.precision = precision;
+        setNumerator(numerator);
+        setDenominator(denominator);
+        setType(type);
+        setPrecision(precision);
     }
 
     public DvProportion(@Nullable List<ReferenceRange<DvProportion>> otherReferenceRanges, @Nullable DvInterval<DvProportion> normalRange, @Nullable CodePhrase normalStatus, @Nullable Double accuracy, @Nullable Boolean accuracyIsPercent, @Nullable String magnitudeStatus, Double numerator, Double denominator, Long type, @Nullable Long precision) {
         super(otherReferenceRanges, normalRange, normalStatus, accuracy, accuracyIsPercent, magnitudeStatus);
-        this.numerator = numerator;
-        this.denominator = denominator;
-        this.type = type;
-        this.precision = precision;
+        setNumerator(numerator);
+        setDenominator(denominator);
+        setType(type);
+        setPrecision(precision);
     }
 
     public Double getNumerator() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantified.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantified.java
@@ -10,8 +10,6 @@ import com.nedap.archie.rminfo.RMProperty;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.*;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -40,7 +38,7 @@ public abstract class DvQuantified<DataValueType extends DvQuantified<DataValueT
 
     public DvQuantified(@Nullable List<ReferenceRange<DataValueType>> otherReferenceRanges, @Nullable DvInterval<DataValueType> normalRange, @Nullable CodePhrase normalStatus, @Nullable String magnitudeStatus) {
         super(otherReferenceRanges, normalRange, normalStatus);
-        this.magnitudeStatus = magnitudeStatus;
+        setMagnitudeStatus(magnitudeStatus);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvQuantity.java
@@ -52,16 +52,16 @@ public class DvQuantity extends DvAmount<DvQuantity, Double> {
     }
 
     public DvQuantity(String units, Double magnitude, @Nullable Long precision) {
-        this.precision = precision;
-        this.units = units;
-        this.magnitude = magnitude;
+        setPrecision(precision);
+        setUnits(units);
+        setMagnitude(magnitude);
     }
 
     public DvQuantity(@Nullable List<ReferenceRange<DvQuantity>> otherReferenceRanges, @Nullable DvInterval<DvQuantity> normalRange, @Nullable CodePhrase normalStatus, @Nullable Double accuracy, @Nullable Boolean accuracyIsPercent, @Nullable String magnitudeStatus, String units, Double magnitude, @Nullable Long precision) {
         super(otherReferenceRanges, normalRange, normalStatus, accuracy, accuracyIsPercent, magnitudeStatus);
-        this.precision = precision;
-        this.units = units;
-        this.magnitude = magnitude;
+        setPrecision(precision);
+        setUnits(units);
+        setMagnitude(magnitude);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvScale.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/DvScale.java
@@ -27,14 +27,14 @@ public class DvScale extends DvOrdered<DvScale> implements SingleValuedDataValue
     }
 
     public DvScale(Double value, DvCodedText symbol) {
-        this.symbol = symbol;
-        this.value = value;
+        setSymbol(symbol);
+        setValue(value);
     }
 
     public DvScale(@Nullable List<ReferenceRange<DvScale>> otherReferenceRanges, @Nullable DvInterval<DvScale> normalRange, Double value, DvCodedText symbol) {
         super(otherReferenceRanges, normalRange);
-        this.symbol = symbol;
-        this.value = value;
+        setSymbol(symbol);
+        setValue(value);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/ReferenceRange.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/ReferenceRange.java
@@ -26,8 +26,8 @@ public class ReferenceRange<T extends DvOrdered<T>> extends RMObject {
     }
 
     public ReferenceRange(DvText meaning, DvInterval<T> range) {
-        this.range = range;
-        this.meaning = meaning;
+        setRange(range);
+        setMeaning(meaning);
     }
 
     public DvInterval<T> getRange() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDate.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDate.java
@@ -66,13 +66,12 @@ public class DvDate extends DvTemporal<DvDate, Long> implements SingleValuedData
      * @param iso8601Date
      */
     public DvDate(String iso8601Date) {
-
         setValue(DateTimeParsers.parseDateValue(iso8601Date));
     }
 
     public DvDate(@Nullable List<ReferenceRange<DvDate>> otherReferenceRanges, @Nullable DvInterval<DvDate> normalRange, @Nullable CodePhrase normalStatus, @Nullable String magnitudeStatus, @Nullable DvDuration accuracy, Temporal value) {
         super(otherReferenceRanges, normalRange, normalStatus, magnitudeStatus, accuracy);
-        this.value = value;
+        setValue(value);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
@@ -47,7 +47,7 @@ public class DvDateTime extends DvTemporal<DvDateTime, Long> implements SingleVa
 	}
 
 	public DvDateTime(TemporalAccessor value) {
-		this.value = value;
+		setValue(value);
 	}
 
 	/**
@@ -62,7 +62,7 @@ public class DvDateTime extends DvTemporal<DvDateTime, Long> implements SingleVa
 
 	public DvDateTime(@Nullable List<ReferenceRange<DvDateTime>> otherReferenceRanges, @Nullable DvInterval<DvDateTime> normalRange, @Nullable CodePhrase normalStatus, @Nullable String magnitudeStatus, @Nullable DvDuration accuracy, TemporalAccessor value) {
 		super(otherReferenceRanges, normalRange, normalStatus, magnitudeStatus, accuracy);
-		this.value = value;
+		setValue(value);
 	}
 
 	@Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDateTime.java
@@ -56,7 +56,7 @@ public class DvDateTime extends DvTemporal<DvDateTime, Long> implements SingleVa
 	 * @param iso8601DateTime
 	 */
 	public DvDateTime(String iso8601DateTime) {
-		this.value = DateTimeParsers.parseDateTimeValue(iso8601DateTime);
+		setValue(DateTimeParsers.parseDateTimeValue(iso8601DateTime));
 	}
 
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDuration.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDuration.java
@@ -45,7 +45,7 @@ public class DvDuration extends DvAmount<DvDuration, Double> implements SingleVa
 	 * @param iso8601Duration
 	 */
 	public DvDuration(String iso8601Duration) {
-		this.value = DateTimeParsers.parseDurationValue(iso8601Duration);
+		setValue(DateTimeParsers.parseDurationValue(iso8601Duration));
 	}
 
 	public DvDuration(@Nullable List<ReferenceRange<DvDuration>> otherReferenceRanges, @Nullable DvInterval<DvDuration> normalRange, @Nullable CodePhrase normalStatus, @Nullable Double accuracy, @Nullable Boolean accuracyIsPercent, @Nullable String magnitudeStatus, TemporalAmount value) {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDuration.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvDuration.java
@@ -36,7 +36,7 @@ public class DvDuration extends DvAmount<DvDuration, Double> implements SingleVa
 	}
 
 	public DvDuration(TemporalAmount value) {
-		this.value = value;
+		setValue(value);
 	}
 
 	/**
@@ -50,7 +50,7 @@ public class DvDuration extends DvAmount<DvDuration, Double> implements SingleVa
 
 	public DvDuration(@Nullable List<ReferenceRange<DvDuration>> otherReferenceRanges, @Nullable DvInterval<DvDuration> normalRange, @Nullable CodePhrase normalStatus, @Nullable Double accuracy, @Nullable Boolean accuracyIsPercent, @Nullable String magnitudeStatus, TemporalAmount value) {
 		super(otherReferenceRanges, normalRange, normalStatus, accuracy, accuracyIsPercent, magnitudeStatus);
-		this.value = value;
+		setValue(value);
 	}
 
 	@Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTemporal.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTemporal.java
@@ -26,12 +26,12 @@ public abstract class DvTemporal<DataValueType extends DvTemporal<DataValueType,
     }
 
     public DvTemporal(@Nullable DvDuration accuracy) {
-        this.accuracy = accuracy;
+        setAccuracy(accuracy);
     }
 
     public DvTemporal(@Nullable List<ReferenceRange<DataValueType>> otherReferenceRanges, @Nullable DvInterval<DataValueType> normalRange, @Nullable CodePhrase normalStatus, @Nullable String magnitudeStatus, @Nullable DvDuration accuracy) {
         super(otherReferenceRanges, normalRange, normalStatus, magnitudeStatus);
-        this.accuracy = accuracy;
+        setAccuracy(accuracy);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
@@ -46,7 +46,7 @@ public class DvTime extends DvTemporal<DvTime, Double> implements SingleValuedDa
     }
 
     public DvTime(TemporalAccessor value) {
-        this.value = value;
+        setValue(value);
     }
 
     /**
@@ -60,7 +60,7 @@ public class DvTime extends DvTemporal<DvTime, Double> implements SingleValuedDa
 
     public DvTime(@Nullable List<ReferenceRange<DvTime>> otherReferenceRanges, @Nullable DvInterval<DvTime> normalRange, @Nullable CodePhrase normalStatus, @Nullable String magnitudeStatus, @Nullable DvDuration accuracy, TemporalAccessor value) {
         super(otherReferenceRanges, normalRange, normalStatus, magnitudeStatus, accuracy);
-        this.value = value;
+        setValue(value);
     }
 
     @Override

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/quantity/datetime/DvTime.java
@@ -55,7 +55,7 @@ public class DvTime extends DvTemporal<DvTime, Double> implements SingleValuedDa
      * @param iso8601Time
      */
     public DvTime(String iso8601Time) {
-        this.value = DateTimeParsers.parseTimeValue(iso8601Time);
+        setValue(DateTimeParsers.parseTimeValue(iso8601Time));
     }
 
     public DvTime(@Nullable List<ReferenceRange<DvTime>> otherReferenceRanges, @Nullable DvInterval<DvTime> normalRange, @Nullable CodePhrase normalStatus, @Nullable String magnitudeStatus, @Nullable DvDuration accuracy, TemporalAccessor value) {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/timespecification/DvTimeSpecification.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/datavalues/timespecification/DvTimeSpecification.java
@@ -21,7 +21,7 @@ public abstract class DvTimeSpecification extends DataValue {
 	}
 
 	public DvTimeSpecification(DvParsable value) {
-		this.value = value;
+		setValue(value);
 	}
 
     public DvParsable getValue() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/directory/Folder.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/directory/Folder.java
@@ -42,16 +42,16 @@ public class Folder extends Locatable {
 
     public Folder(String archetypeNodeId, DvText name, ItemStructure details, @Nullable List<ObjectRef<? extends ObjectId>> items, @Nullable List<Folder> folders) {
         super(archetypeNodeId, name);
-        this.items = items;
-        this.folders = folders;
-        this.details = details;
+        setItems(items);
+        setFolders(folders);
+        setDetails(details);
     }
 
     public Folder(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, ItemStructure details, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, @Nullable List<ObjectRef<? extends ObjectId>> items, @Nullable List<Folder> folders) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.items = items;
-        this.folders = folders;
-        this.details = details;
+        setItems(items);
+        setFolders(folders);
+        setDetails(details);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/Ehr.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/Ehr.java
@@ -60,14 +60,14 @@ public class Ehr extends RMObject {
     }
 
     public Ehr(HierObjectId systemId, HierObjectId ehrId, DvDateTime timeCreated, List<ObjectRef<? extends ObjectId>> contributions, ObjectRef<? extends ObjectId> ehrStatus, ObjectRef<? extends ObjectId> ehrAccess, @Nullable ObjectRef<? extends ObjectId> directory, @Nullable List<ObjectRef<? extends ObjectId>> compositions) {
-        this.systemId = systemId;
-        this.ehrId = ehrId;
-        this.contributions = contributions;
-        this.ehrStatus = ehrStatus;
-        this.ehrAccess = ehrAccess;
-        this.compositions = compositions;
-        this.directory = directory;
-        this.timeCreated = timeCreated;
+        setSystemId(systemId);
+        setEhrId(ehrId);
+        setContributions(contributions);
+        setEhrStatus(ehrStatus);
+        setEhrAccess(ehrAccess);
+        setCompositions(compositions);
+        setDirectory(directory);
+        setTimeCreated(timeCreated);
     }
 
     public HierObjectId getSystemId() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/EhrAccess.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/EhrAccess.java
@@ -4,8 +4,6 @@ import com.nedap.archie.rm.archetyped.*;
 import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.security.AccessControlSettings;
 import com.nedap.archie.rm.support.identification.UIDBasedId;
-import com.nedap.archie.rminfo.Invariant;
-import com.nedap.archie.rmutil.InvariantUtil;
 
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -29,12 +27,12 @@ public class EhrAccess extends Locatable {
 
     public EhrAccess(String archetypeNodeId, DvText name, @Nullable AccessControlSettings settings) {
         super(archetypeNodeId, name);
-        this.settings = settings;
+        setSettings(settings);
     }
 
     public EhrAccess(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, @Nullable AccessControlSettings settings) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.settings = settings;
+        setSettings(settings);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/EhrStatus.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/ehr/EhrStatus.java
@@ -43,18 +43,18 @@ public class EhrStatus extends Locatable {
 
     public EhrStatus(String archetypeNodeId, DvText name, PartySelf subject, boolean isQueryable, boolean isModifiable, @Nullable ItemStructure otherDetails) {
         super(archetypeNodeId, name);
-        this.subject = subject;
-        this.isQueryable = isQueryable;
-        this.isModifiable = isModifiable;
-        this.otherDetails = otherDetails;
+        setSubject(subject);
+        setQueryable(isQueryable);
+        setModifiable(isModifiable);
+        setOtherDetails(otherDetails);
     }
 
     public EhrStatus(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, PartySelf subject, boolean isQueryable, boolean isModifiable, @Nullable ItemStructure otherDetails) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.subject = subject;
-        this.isQueryable = isQueryable;
-        this.isModifiable = isModifiable;
-        this.otherDetails = otherDetails;
+        setSubject(subject);
+        setQueryable(isQueryable);
+        setModifiable(isModifiable);
+        setOtherDetails(otherDetails);
     }
 
     public PartySelf getSubject() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/Attestation.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/Attestation.java
@@ -42,11 +42,11 @@ public class Attestation extends AuditDetails {
 
     public Attestation(String systemId, PartyProxy committer, DvDateTime timeCommitted, DvCodedText changeType, @Nullable DvText description, @Nullable DvMultimedia attestedView, @Nullable String proof, @Nullable List<DvEHRURI> items, DvText reason, boolean isPending) {
         super(systemId, committer, timeCommitted, changeType, description);
-        this.attestedView = attestedView;
-        this.proof = proof;
-        this.items = items;
-        this.reason = reason;
-        this.isPending = isPending;
+        setAttestedView(attestedView);
+        setProof(proof);
+        setItems(items);
+        setReason(reason);
+        setPending(isPending);
     }
 
     @Nullable

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/AuditDetails.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/AuditDetails.java
@@ -43,11 +43,11 @@ public class AuditDetails extends RMObject {
 
 
     public AuditDetails(String systemId, PartyProxy committer, DvDateTime timeCommitted, DvCodedText changeType, @Nullable DvText description) {
-        this.systemId = systemId;
-        this.timeCommitted = timeCommitted;
-        this.changeType = changeType;
-        this.description = description;
-        this.committer = committer;
+        setSystemId(systemId);
+        setTimeCommitted(timeCommitted);
+        setChangeType(changeType);
+        setDescription(description);
+        setCommitter(committer);
     }
 
     public String getSystemId() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/Participation.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/Participation.java
@@ -37,10 +37,10 @@ public class Participation extends RMObject {
     }
 
     public Participation(PartyProxy performer, DvText function, @Nullable DvCodedText mode, @Nullable DvInterval<DvDateTime> time) {
-        this.function = function;
-        this.mode = mode;
-        this.time = time;
-        this.performer = performer;
+        setFunction(function);
+        setMode(mode);
+        setTime(time);
+        setPerformer(performer);
     }
 
     public DvText getFunction() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/PartyIdentified.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/PartyIdentified.java
@@ -32,8 +32,8 @@ public class PartyIdentified extends PartyProxy {
 
     public PartyIdentified(@Nullable PartyRef externalRef, @Nullable String name, @Nullable List<DvIdentifier> identifiers) {
         super(externalRef);
-        this.name = name;
-        this.identifiers = identifiers;
+        setName(name);
+        setIdentifiers(identifiers);
     }
 
     public String getName() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/PartyProxy.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/PartyProxy.java
@@ -28,7 +28,7 @@ public abstract class PartyProxy extends RMObject {
     }
 
     public PartyProxy(@Nullable PartyRef externalRef) {
-        this.externalRef = externalRef;
+        setExternalRef(externalRef);
     }
 
     public PartyRef getExternalRef() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/PartyRelated.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/PartyRelated.java
@@ -26,7 +26,7 @@ public class PartyRelated extends PartyIdentified {
 
     public PartyRelated(@Nullable PartyRef externalRef, @Nullable String name, @Nullable List<DvIdentifier> identifiers, DvCodedText relationship) {
         super(externalRef, name, identifiers);
-        this.relationship = relationship;
+        setRelationship(relationship);
     }
 
     public DvCodedText getRelationship() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/RevisionHistory.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/RevisionHistory.java
@@ -21,7 +21,7 @@ public class RevisionHistory extends RMObject {
     }
 
     public RevisionHistory(List<RevisionHistoryItem> items) {
-        this.items = items;
+        setItems(items);
     }
 
     private List<RevisionHistoryItem> items = new ArrayList<>();

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/generic/RevisionHistoryItem.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/generic/RevisionHistoryItem.java
@@ -26,8 +26,8 @@ public class RevisionHistoryItem extends RMObject {
     }
 
     public RevisionHistoryItem(ObjectVersionId versionId, List<AuditDetails> audits) {
-        this.versionId = versionId;
-        this.audits = audits;
+        setVersionId(versionId);
+        setAudits(audits);
     }
 
     public ObjectVersionId getVersionId() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/integration/GenericEntry.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/integration/GenericEntry.java
@@ -30,12 +30,12 @@ public class GenericEntry extends ContentItem {
 
     public GenericEntry(String archetypeNodeId, DvText name, ItemTree data) {
         super(archetypeNodeId, name);
-        this.data = data;
+        setData(data);
     }
 
     public GenericEntry(@Nullable UIDBasedId uid, String archetypeNodeId, DvText name, @Nullable Archetyped archetypeDetails, @Nullable FeederAudit feederAudit, @Nullable List<Link> links, @Nullable Pathable parent, @Nullable String parentAttributeName, ItemTree data) {
         super(uid, archetypeNodeId, name, archetypeDetails, feederAudit, links, parent, parentAttributeName);
-        this.data = data;
+        setData(data);
     }
 
     public ItemTree getData() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ArchetypeID.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ArchetypeID.java
@@ -96,13 +96,13 @@ public class ArchetypeID extends ObjectId {
             parseValue(value);
             setValue(value);
         } else {
-            this.qualifiedRmEntity = qualifiedRmEntity;
-            this.domainConcept = domainConcept;
-            this.rmOriginator = rmOriginator;
-            this.rmName = rmName;
-            this.rmEntity = rmEntity;
-            this.specialisation = specialisation;
-            this.versionId = versionId;
+            setQualifiedRmEntity(qualifiedRmEntity);
+            setDomainConcept(domainConcept);
+            setRmOriginator(rmOriginator);
+            setRmName(rmName);
+            setRmEntity(rmEntity);
+            setSpecialisation(specialisation);
+            setVersionId(versionId);
             setValue(getFullId());
         }
 

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/GenericId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/GenericId.java
@@ -21,7 +21,7 @@ public class GenericId extends ObjectId {
 
     public GenericId(String value, String scheme) {
         super(value);
-        this.scheme = scheme;
+        setScheme(scheme);
     }
 
     public String getScheme() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/LocatableRef.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/LocatableRef.java
@@ -22,7 +22,7 @@ public class LocatableRef extends ObjectRef<UIDBasedId> {
 
     public LocatableRef(UIDBasedId id, String namespace, String type, String path) {
         super(id, namespace, type);
-        this.path = path;
+        setPath(path);
     }
 
     public String getPath() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectId.java
@@ -23,7 +23,7 @@ public abstract class ObjectId extends RMObject {
     }
 
     public ObjectId(String value) {
-        this.value = value;
+        setValue(value);
     }
 
     public String getValue() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectRef.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/ObjectRef.java
@@ -30,9 +30,9 @@ public class ObjectRef<Idtype extends ObjectId> extends RMObject {
     }
 
     public ObjectRef(Idtype id, String namespace, String type) {
-        this.namespace = namespace;
-        this.type = type;
-        this.id = id;
+        setNamespace(namespace);
+        setType(type);
+        setId(id);
     }
 
     public String getNamespace() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UID.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/UID.java
@@ -17,7 +17,7 @@ public abstract class UID extends RMObject {
     }
 
     public UID(String value) {
-        this.value = value;
+        setValue(value);
     }
 
     public String getValue() {

--- a/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
+++ b/openehr-rm/src/main/java/com/nedap/archie/rm/support/identification/VersionTreeId.java
@@ -24,7 +24,7 @@ public class VersionTreeId extends RMObject {
     }
 
     public VersionTreeId(String value) {
-        this.value = value;
+        setValue(value);
     }
 
     public String getValue() {


### PR DESCRIPTION
Fixes #621 

**Internal remarks**
* Use RMObject setters instead of private field declaration
* Some setters include a call to `setThisAsParent`, this should be included everywhere to get the correct references.
* Also use setters of fields that do not call to `setThisAsParent` for consistency and future compatibility if something is added to the setter later on.
* While going through the classes Intellij also decided to optimize the imports. Let me know if we want to exclude those changes