### PR TITLE
ADL serializer improvements

### DIFF
--- a/aom/src/main/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializer.java
@@ -69,6 +69,7 @@ public class ADLDefinitionSerializer {
         }
         Archetype archetype = cobj.getArchetype();
         String originalLanguage = ofNullable(archetype)
+                .map(a -> a instanceof TemplateOverlay ? ((TemplateOverlay) a).getOwningTemplate() : a)
                 .flatMap(a -> ofNullable(a.getOriginalLanguage()))
                 .map(TerminologyCode::getCodeString)
                 .orElse(null);

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/ADLStringBuilder.java
@@ -84,7 +84,11 @@ public class ADLStringBuilder implements StructuredStringAppendable {
 
     public ADLStringBuilder lineComment(String comment) {
         if (comment != null) {
-            append(StructureStringBuilder.padRight("", 4)).append("-- ").append(comment);
+            // Remove line breaks and surrounding spaces
+            comment = comment.replaceAll("\\s*(\n\\s*)+", " ").trim();
+            if (!comment.isEmpty()) {
+                append(StructureStringBuilder.padRight("", 4)).append("-- ").append(comment);
+            }
         }
         return this;
     }

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectProxySerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectProxySerializer.java
@@ -20,7 +20,7 @@ public class CComplexObjectProxySerializer extends ConstraintSerializer<CComplex
                 .append(nodeIdString(cobj.getNodeId()));
         appendOccurrences(cobj);
         builder.ensureSpace().append(cobj.getTargetPath())
-                //.lineComment("Should be comment here - not implemented")
+                .lineComment(serializer.getTermText(cobj))
                 .unindent();
     }
 

--- a/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
+++ b/aom/src/main/java/com/nedap/archie/serializer/adl/constraints/CComplexObjectSerializer.java
@@ -14,6 +14,7 @@ import org.openehr.odin.jackson.ODINPrettyPrinter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -195,6 +196,11 @@ public class CComplexObjectSerializer<T extends CComplexObject> extends Constrai
                 builder.append(",");
             }
 
+            cObjectTuple.getMembers().stream()
+                    .map(serializer::getSimpleCommentText)
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .ifPresent(builder::lineComment);
         }
         builder.unindent().newline();
         builder.append("}");

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -335,18 +335,19 @@ public class ADLDefinitionSerializerTest {
 
         CComplexObject parentCObj = archetype.getDefinition();
 
-        assertThat(serializeConstraint(parentCObj.itemAtPath("/items[id2]")).trim(),
-                // Should not have a comment as the text is empty
-                equalTo("ELEMENT[id2] matches {\n" +
-                        "        value matches {\n" +
-                        "            DV_TEXT[id21]\n" +
-                        "        }\n" +
-                        "    }"));
-        assertThat(serializeConstraint(parentCObj.itemAtPath("/items[id3]")).trim(),
-                // Comment should be on a single line
-                equalTo("ELEMENT[id3] matches {    -- This text has multiple lines!\n" +
-                        "        value matches {\n" +
-                        "            DV_CODED_TEXT[id31]\n" +
+        assertThat(serializeConstraint(parentCObj).trim(),
+                equalTo("CLUSTER[id1] matches {    -- Prescription\n" + // This comment is trimmed
+                        "        items matches {\n" +
+                        "            ELEMENT[id2] matches {\n" + // Should not have a comment as the text is empty
+                        "                value matches {\n" +
+                        "                    DV_TEXT[id21]\n" +
+                        "                }\n" +
+                        "            }\n" +
+                        "            ELEMENT[id3] matches {    -- This text has multiple lines!\n" + // Comment should be on a single line
+                        "                value matches {\n" +
+                        "                    DV_CODED_TEXT[id31]\n" +
+                        "                }\n" +
+                        "            }\n" +
                         "        }\n" +
                         "    }"));
     }

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -2,10 +2,7 @@ package com.nedap.archie.serializer.adl;
 
 import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
-import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.ArchetypeSlot;
-import com.nedap.archie.aom.CComplexObject;
-import com.nedap.archie.aom.CObject;
+import com.nedap.archie.aom.*;
 import com.nedap.archie.base.MultiplicityInterval;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -315,6 +312,21 @@ public class ADLDefinitionSerializerTest {
                 equalTo("use_node ADDRESS[id12] /contacts[id6]/addresses[id8]"));
         assertThat(serializeConstraint(ccobjProxies.get(2)).trim(),
                 equalTo("use_node ADDRESS[id13] occurrences matches {1..3} /contacts[id6]/addresses[id9]"));
+    }
+
+    @Test
+    public void serializeTemplateOverlay() throws IOException, ADLParseException {
+        Template template = (Template) loadRoot("com/nedap/archie/archetypevalidator/openEHR-EHR-OBSERVATION.specialized_template_observation.v1.0.0.adls");
+
+        TemplateOverlay templateOverlay = template.getTemplateOverlay("openEHR-EHR-CLUSTER.simple_test_cluster-ovl.v1.0.0");
+        CObject clusterCObj = templateOverlay.getDefinition();
+
+        assertThat(serializeConstraint(clusterCObj).trim(),
+                equalTo("CLUSTER[id1.1] matches {    -- Simple test cluster\n" +
+                        "        items matches {\n" +
+                        "            ELEMENT[id2.1]    -- Just a DV_TEXT that is specialized in a Template Overlay\n" +
+                        "        }\n" +
+                        "    }"));
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -307,11 +307,11 @@ public class ADLDefinitionSerializerTest {
         List<CObject> ccobjProxies = parentCObj.getAttribute("addresses").getChildren();
 
         assertThat(serializeConstraint(ccobjProxies.get(0)).trim(),
-                equalTo("use_node ADDRESS[id11] /contacts[id6]/addresses[id7]"));
+                equalTo("use_node ADDRESS[id11] /contacts[id6]/addresses[id7]    -- work fax number"));
         assertThat(serializeConstraint(ccobjProxies.get(1)).trim(),
-                equalTo("use_node ADDRESS[id12] /contacts[id6]/addresses[id8]"));
+                equalTo("use_node ADDRESS[id12] /contacts[id6]/addresses[id8]    -- work email address"));
         assertThat(serializeConstraint(ccobjProxies.get(2)).trim(),
-                equalTo("use_node ADDRESS[id13] occurrences matches {1..3} /contacts[id6]/addresses[id9]"));
+                equalTo("use_node ADDRESS[id13] occurrences matches {1..3} /contacts[id6]/addresses[id9]    -- work contact"));
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -226,9 +226,9 @@ public class ADLDefinitionSerializerTest {
         assertThat(serialized, equalTo("\n" +
                 "    ORDINAL[id3] matches {\n" +
                 "        [symbol, value] matches {\n" +
-                "            [{[at1]}, {0.0}],\n" +
-                "            [{[at2]}, {1.0}],\n" +
-                "            [{[at3]}, {2.0}]\n" +
+                "            [{[at1]}, {0.0}],    -- min\n" +
+                "            [{[at2]}, {1.0}],    -- med\n" +
+                "            [{[at3]}, {2.0}]    -- max\n" +
                 "        }\n" +
                 "    }"));
     }

--- a/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
+++ b/tools/src/test/java/com/nedap/archie/serializer/adl/ADLDefinitionSerializerTest.java
@@ -318,6 +318,28 @@ public class ADLDefinitionSerializerTest {
     }
 
     @Test
+    public void serializeComments() throws IOException, ADLParseException {
+        Archetype archetype = load("openEHR-EHR-CLUSTER.comments.v1.adls");
+
+        CComplexObject parentCObj = archetype.getDefinition();
+
+        assertThat(serializeConstraint(parentCObj.itemAtPath("/items[id2]")).trim(),
+                // Should not have a comment as the text is empty
+                equalTo("ELEMENT[id2] matches {\n" +
+                        "        value matches {\n" +
+                        "            DV_TEXT[id21]\n" +
+                        "        }\n" +
+                        "    }"));
+        assertThat(serializeConstraint(parentCObj.itemAtPath("/items[id3]")).trim(),
+                // Comment should be on a single line
+                equalTo("ELEMENT[id3] matches {    -- This text has multiple lines!\n" +
+                        "        value matches {\n" +
+                        "            DV_CODED_TEXT[id31]\n" +
+                        "        }\n" +
+                        "    }"));
+    }
+
+    @Test
     public void serializeOccurrencesTest() {
         checkOccurrences("5..*", MultiplicityInterval.createUpperUnbounded(5));
         checkOccurrences("1", MultiplicityInterval.createMandatory());

--- a/tools/src/test/resources/com/nedap/archie/serializer/adl/openEHR-EHR-CLUSTER.comments.v1.adls
+++ b/tools/src/test/resources/com/nedap/archie/serializer/adl/openEHR-EHR-CLUSTER.comments.v1.adls
@@ -1,0 +1,55 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2)
+	openEHR-EHR-CLUSTER.comments.v1.0.0
+
+language
+	original_language = <[ISO_639-1::en]>
+
+description
+	original_author = <
+		["name"] = <"Jelte Zeilstra">
+		["organisation"] = <"Nedap <https://www.nedap.com>">
+	>
+	details = <
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"A very simple cluster archetype for testing comments">
+		>
+	>
+
+definition
+	CLUSTER[id1] matches {	-- Prescription
+		items matches {
+		    ELEMENT[id2] matches {
+		        value matches {
+		            DV_TEXT[id21]
+                }
+		    }
+		    ELEMENT[id3] matches {
+		        value matches {
+		            DV_CODED_TEXT[id31]
+                }
+		    }
+		}
+	}
+
+terminology
+	term_definitions = <
+		["en"] = <
+			["id1"] = <
+				text = <"   Prescription   ">
+				description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
+			>
+			["id2"] = <
+                text = <" ">
+                description = <"Empty text">
+            >
+			["id3"] = <
+				text = <"This
+text has multiple
+
+
+lines! ">
+				description = <"Multiple lines of text">
+			>
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/serializer/adl/openEHR-EHR-CLUSTER.comments.v1.adls
+++ b/tools/src/test/resources/com/nedap/archie/serializer/adl/openEHR-EHR-CLUSTER.comments.v1.adls
@@ -1,55 +1,55 @@
 archetype (adl_version=2.0.5; rm_release=1.0.2)
-	openEHR-EHR-CLUSTER.comments.v1.0.0
+    openEHR-EHR-CLUSTER.comments.v1.0.0
 
 language
-	original_language = <[ISO_639-1::en]>
+    original_language = <[ISO_639-1::en]>
 
 description
-	original_author = <
-		["name"] = <"Jelte Zeilstra">
-		["organisation"] = <"Nedap <https://www.nedap.com>">
-	>
-	details = <
-		["en"] = <
-			language = <[ISO_639-1::en]>
-			purpose = <"A very simple cluster archetype for testing comments">
-		>
-	>
+    original_author = <
+        ["name"] = <"Jelte Zeilstra">
+        ["organisation"] = <"Nedap <https://www.nedap.com>">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"A very simple cluster archetype for testing comments">
+        >
+    >
 
 definition
-	CLUSTER[id1] matches {	-- Prescription
-		items matches {
-		    ELEMENT[id2] matches {
-		        value matches {
-		            DV_TEXT[id21]
+    CLUSTER[id1] matches {
+        items matches {
+            ELEMENT[id2] matches {
+                value matches {
+                    DV_TEXT[id21]
                 }
-		    }
-		    ELEMENT[id3] matches {
-		        value matches {
-		            DV_CODED_TEXT[id31]
+            }
+            ELEMENT[id3] matches {
+                value matches {
+                    DV_CODED_TEXT[id31]
                 }
-		    }
-		}
-	}
+            }
+        }
+    }
 
 terminology
-	term_definitions = <
-		["en"] = <
-			["id1"] = <
-				text = <"   Prescription   ">
-				description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
-			>
-			["id2"] = <
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"   Prescription   ">
+                description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
+            >
+            ["id2"] = <
                 text = <" ">
                 description = <"Empty text">
             >
-			["id3"] = <
-				text = <"This
+            ["id3"] = <
+                text = <"This
 text has multiple
 
 
 lines! ">
-				description = <"Multiple lines of text">
-			>
+                description = <"Multiple lines of text">
+            >
         >
     >


### PR DESCRIPTION
Various improvements to the ADL serializer:

* Trim comments, remove line breaks and remove empty comments
* Add comments for tuples
* Fix comments in template overlays
* Add comments to use_node
