### PR TITLE
Correctly flatten TemporalAmount

### DIFF
--- a/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
+++ b/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
@@ -293,8 +293,8 @@ public class FlatJsonGenerator {
                     storeValue(result, newPath, DateTimeSerializerFormatters.ISO_8601_TIME.format(t));
                 }
             } else if (child instanceof TemporalAmount) {
-                //duration or period. now just a toString, should this be a specific formatter?
-                storeValue(result, newPath, child);
+                // Serialize using DateTimeSerializerFormatters.serializeDuration to correctly handle negative durations
+                storeValue(result, newPath, DateTimeSerializerFormatters.serializeDuration((TemporalAmount) child));
             } else if(child instanceof byte[]) {
                 storeValue(result, newPath, Base64.getEncoder().encodeToString((byte[]) child));
             } else {

--- a/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
@@ -18,15 +18,19 @@ import com.nedap.archie.rm.datastructures.Element;
 import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.datavalues.encapsulated.DvMultimedia;
 import com.nedap.archie.rm.datavalues.quantity.DvCount;
+import com.nedap.archie.rm.datavalues.quantity.datetime.DvDuration;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.MetaModel;
 import com.nedap.archie.rminfo.MetaModelProvider;
 import org.junit.After;
 import org.junit.Test;
 import org.openehr.referencemodels.BuiltinReferenceModels;
+import org.threeten.extra.PeriodDuration;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.time.Period;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -130,6 +134,21 @@ public class FlatJsonGeneratorTest {
         assertEquals(0l, ((Long) stringObjectMap.get("/data[id2]/events[id7,1]/data[id4]/items[id5,1]/value/precision")).longValue());
         //test indices
         assertEquals("Systolic", stringObjectMap.get("/data[id2]/events[id7,2]/data[id4]/items[id5,1]/name/value"));
+    }
+
+    @Test
+    public void testDurationFlattening() throws Exception {
+        FlatJsonGenerator flatJsonGenerator = new FlatJsonGenerator(ArchieRMInfoLookup.getInstance(), FlatJsonFormatConfiguration.nedapInternalFormat());
+
+        // Test a positive duration, make sure the value is a String and not a Duration object
+        DvDuration duration = new DvDuration(PeriodDuration.of(Period.of(1,0,0), Duration.ofHours(13)));
+        Map<String, Object> pathsAndValues = flatJsonGenerator.buildPathsAndValues(duration);
+        assertEquals("P1YT13H", pathsAndValues.get("/value"));
+
+        // Also test a negative duration
+        DvDuration negativeDuration = new DvDuration(PeriodDuration.of(Period.of(-1,-2,-4), Duration.ofSeconds(-5736)));
+        Map<String, Object> secondPathsAndValues = flatJsonGenerator.buildPathsAndValues(negativeDuration);
+        assertEquals("-P1Y2M4DT1H35M36S", secondPathsAndValues.get("/value"));
     }
 
     @Test

--- a/utils/src/test/java/com/nedap/archie/datetime/DateTimeParserTest.java
+++ b/utils/src/test/java/com/nedap/archie/datetime/DateTimeParserTest.java
@@ -82,6 +82,9 @@ public class DateTimeParserTest {
 
         TemporalAmount minusOneYear2Hours = DateTimeParsers.parseDurationValue("-P1YT2H");
         assertEquals(PeriodDuration.of(Period.of(-1 ,0, 0), Duration.of(-2, ChronoUnit.HOURS)), minusOneYear2Hours);
+
+        TemporalAmount minusMultiplePeriodDuration = DateTimeParsers.parseDurationValue("-P1Y2M4DT1H35M36S");
+        assertEquals(PeriodDuration.of(Period.of(-1,-2,-4), Duration.ofSeconds(-5736)), minusMultiplePeriodDuration);
     }
 
 }

--- a/utils/src/test/java/com/nedap/archie/datetime/DateTimeSerializerFormattersTest.java
+++ b/utils/src/test/java/com/nedap/archie/datetime/DateTimeSerializerFormattersTest.java
@@ -57,6 +57,7 @@ public class DateTimeSerializerFormattersTest {
         TemporalAmount minusOneYearOneHour = PeriodDuration.of(Period.of(-1 ,0, 0), Duration.of(-2, ChronoUnit.HOURS));
         TemporalAmount minusTwoHoursPeriodDuration = PeriodDuration.of(Period.ZERO, Duration.of(-2, ChronoUnit.HOURS));
         TemporalAmount minusOneYearPeriodDuration = PeriodDuration.of(Period.of(-1 ,0, 0), Duration.ZERO);
+        TemporalAmount minusMultiplePeriodDuration = PeriodDuration.of(Period.of(-1,-2,-4), Duration.ofSeconds(-5736));
 
         assertEquals("-PT2S", DateTimeSerializerFormatters.serializeDuration(minusTwoSeconds));
         assertEquals("-P2Y", DateTimeSerializerFormatters.serializeDuration(minusTwoYears));
@@ -64,6 +65,7 @@ public class DateTimeSerializerFormattersTest {
         assertEquals("-P1YT2H", DateTimeSerializerFormatters.serializeDuration(minusOneYearOneHour));
         assertEquals("-PT2H", DateTimeSerializerFormatters.serializeDuration(minusTwoHoursPeriodDuration));
         assertEquals("-P1Y", DateTimeSerializerFormatters.serializeDuration(minusOneYearPeriodDuration));
+        assertEquals("-P1Y2M4DT1H35M36S", DateTimeSerializerFormatters.serializeDuration(minusMultiplePeriodDuration));
 
     }
 


### PR DESCRIPTION
Fixes #681 

Flatten TemporalAmount objects as strings using the durationSerializer.
Includes tests for the flattener and some other test cases.