### PR TITLE
Update release configuration for central.sonatype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+}
+
 repositories {
   mavenCentral()
 }

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -8,24 +8,19 @@ if(gradle.ext.shouldSign) {
     }
   }
 }
-//define the repositories on global level, not per project, or you get many of them
-publishing {
-  repositories {
-    maven {
-      name = "ossrh"
-      // OSSRH URLS
-      def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-      def snapshotsRepoUrl = 'ttps://oss.sonatype.org/content/repositories/snapshots/'
-      url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
-      credentials {
-        username = project.hasProperty('ossrhUsername') ? ossrhUsername : "Unknown user"
-        password = project.hasProperty('ossrhPassword') ? ossrhPassword : "Unknown password"
-      }
+nexusPublishing {
+  repositories {
+    // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
+    sonatype {
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+
+      username = project.hasProperty("centralTokenUsername") ? centralTokenUsername : "Unknown username"
+      password = project.hasProperty("centralTokenPassword") ? centralTokenPassword : "Unknown password"
     }
   }
 }
-
 
 //now uploading will have to be configured on a per subproject basis
 subprojects {


### PR DESCRIPTION
Since June 30th 2025, https://oss.sonatype.org/ is end-of-life. So the release process needs to be migrated to central.sonatype (https://central.sonatype.org/pages/ossrh-eol/#process-to-migrate)

This PR changes the configuration by using a [new publishing plugin](https://github.com/gradle-nexus/publish-plugin/).

Also the Wiki has been updating to reflect the changes: https://github.com/openEHR/archie/wiki/Releasing-&-deploying