### PR TITLE
Fix NullPointerException in FlatJsonGenerator.buildPathsAndValuesInner

### DIFF
--- a/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
+++ b/tools/src/main/java/com/nedap/archie/json/flat/FlatJsonGenerator.java
@@ -121,7 +121,7 @@ public class FlatJsonGenerator {
             CAttribute cAttribute = cObject == null ? null : cObject.getAttribute(attributeName);
             RMAttributeInfo attributeInfo = typeInfo.getAttributes().get(attributeName);
             if(!attributeInfo.isComputed() && !isIgnored(typeInfo, attributeName) && attributeInfo.getGetMethod() != null) {
-                if(filterNames && cObject != null && isNameAttribute(typeInfo, attributeName)) {
+                if(filterNames && name != null && cObject != null && isNameAttribute(typeInfo, attributeName)) {
                     ArchetypeTerm term = cObject.getTerm();
                     if(term != null && name.equals(term.getText())) {
                         continue;

--- a/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/flat/FlatJsonGeneratorTest.java
@@ -34,6 +34,7 @@ import java.time.Period;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -78,7 +79,15 @@ public class FlatJsonGeneratorTest {
 
     }
 
+    @Test
+    public void testBloodPressureEmpty() throws Exception {
+        OperationalTemplate bloodPressureOpt = parseBloodPressure();
+        FlatJsonGenerator flatJsonGenerator = new FlatJsonGenerator(ArchieRMInfoLookup.getInstance(), FlatJsonFormatConfiguration.nedapInternalFormat());
 
+        Map<String, Object> pathsAndValues = flatJsonGenerator.buildPathsAndValues(new Observation(), bloodPressureOpt, "en");
+
+        assertTrue(pathsAndValues.isEmpty());
+    }
 
     @Test
     public void testBloodPressureExampleWithPipesForFinalFields() throws Exception {


### PR DESCRIPTION
Fix NullPointerException in `FlatJsonGenerator.buildPathsAndValuesInner` when `FlatJsonFormatConfiguration.filterNames` is true and an object with a null name was provided.