### PR TITLE
Add original language to component terminologies during operational template creation

### DIFF
--- a/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/OperationalTemplateCreator.java
@@ -246,6 +246,10 @@ class OperationalTemplateCreator {
                 }
             }
 
+            if (terminology.getOriginalLanguage() == null && result.getOriginalLanguage() != null) {
+                terminology.setOriginalLanguage(result.getOriginalLanguage().getCodeString());
+            }
+
             result.addComponentTerminology(newNodeId, terminology);
 
             // Replaces dashes and convert to lower case, as dashes and variables starting with an upper case letter

--- a/tools/src/test/java/com/nedap/archie/flattener/OperationalTemplateCreatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/flattener/OperationalTemplateCreatorTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.*;
+import com.nedap.archie.aom.terminology.ArchetypeTerminology;
 import com.nedap.archie.archetypevalidator.ArchetypeValidator;
 import com.nedap.archie.archetypevalidator.ValidationResult;
 import com.nedap.archie.base.MultiplicityInterval;
@@ -155,6 +156,41 @@ public class OperationalTemplateCreatorTest {
                 Lists.newArrayList("id6.1", "id7.1"),
                 nodeIds
         );
+    }
+
+    @Test
+    public void testTemplateOverlayOriginalLanguage() throws Exception {
+        SimpleArchetypeRepository repository = new SimpleArchetypeRepository();
+
+        try (InputStream stream = getClass().getResourceAsStream("openEHR-EHR-OBSERVATION.height.v1.adls")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModelProvider()).parse(stream);
+            repository.addArchetype(archetype);
+        }
+
+        try (InputStream stream = getClass().getResourceAsStream("openEHR-EHR-COMPOSITION.report.v1.adls")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModelProvider()).parse(stream);
+            repository.addArchetype(archetype);
+        }
+
+        try (InputStream stream = getClass().getResourceAsStream("openEHR-EHR-COMPOSITION.report-result.v1.adls")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModelProvider()).parse(stream);
+            repository.addArchetype(archetype);
+        }
+
+        try (InputStream stream = getClass().getResourceAsStream("openEHR-EHR-COMPOSITION.length.v1.0.0.adlt")) {
+            Archetype archetype = new ADLParser(BuiltinReferenceModels.getMetaModelProvider()).parse(stream);
+            FlattenerConfiguration flattenerConfiguration = FlattenerConfiguration.forOperationalTemplate();
+            flattenerConfiguration.setFailOnMissingUsedArchetype(true);
+            Flattener flattener = new Flattener(repository, BuiltinReferenceModels.getMetaModelProvider(), flattenerConfiguration);
+            OperationalTemplate template = (OperationalTemplate) flattener.flatten(archetype);
+
+            // The node id for the used archetype
+            String newNodeId = "openEHR-EHR-OBSERVATION.ovl-length-height-001.v1.0.0";
+            ArchetypeTerminology componentTerminology = template.getComponentTerminologies().get(newNodeId);
+
+            assertNotNull(componentTerminology, "Component terminology should be present. Available keys: " + template.getComponentTerminologies().keySet());
+            assertEquals("en", componentTerminology.getOriginalLanguage(), "Original language of component terminology should be 'en'");
+        }
     }
 
     private Archetype parseAndCreateOPTWithConfig(String fileName, InMemoryFullArchetypeRepository repository, FlattenerConfiguration config) throws IOException, ADLParseException {


### PR DESCRIPTION
Fixes #702 

Adds the original language of the parent archetype to the component terminologies of the operational template when it is not set.