### PR TITLE
Validate the type of default values in archetypes

### DIFF
--- a/aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java
+++ b/aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java
@@ -86,7 +86,7 @@ public enum ErrorType implements MessageCode {
     OVERLAY_VALIDATION_FAILED(I18n.register("The validation of a template overlay failed")),
     PARENT_VALIDATION_FAILED(I18n.register("The validation of the parent archetype failed")),
     ADL14_INCOMPATIBLE_NODE_IDS(I18n.register("Node id numbers should be unique without their ac, at or id-prefix, to ensure the possibility of converting the archetype to ADL 1.4")),
-    VCDVT(I18n.register("object constraint default value type validity: the type of the default value of an object constraint must conform to the type of the constraint"));
+    DEFAULT_OBJECT_TYPE_VALIDITY(I18n.register("object constraint default value type validity: the type of the default value of an object constraint must conform to the type of the constraint"));
 
     private final String description;
 

--- a/aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java
+++ b/aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java
@@ -85,7 +85,8 @@ public enum ErrorType implements MessageCode {
     VALUESET_REDEFINITION_ERROR(I18n.register("A redefined value set can only be a subset of its parent value set, nothing can be added")),
     OVERLAY_VALIDATION_FAILED(I18n.register("The validation of a template overlay failed")),
     PARENT_VALIDATION_FAILED(I18n.register("The validation of the parent archetype failed")),
-    ADL14_INCOMPATIBLE_NODE_IDS(I18n.register("Node id numbers should be unique without their ac, at or id-prefix, to ensure the possibility of converting the archetype to ADL 1.4"));
+    ADL14_INCOMPATIBLE_NODE_IDS(I18n.register("Node id numbers should be unique without their ac, at or id-prefix, to ensure the possibility of converting the archetype to ADL 1.4")),
+    VCDVT(I18n.register("object constraint default value type validity: the type of the default value of an object constraint must conform to the type of the constraint"));
 
     private final String description;
 

--- a/i18n/po/i18n_en.po
+++ b/i18n/po/i18n_en.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-26 09:39+0100\n"
+"POT-Creation-Date: 2026-03-30 14:54+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Pieter Bos <pieter.bos@nedap.com>\n"
 "Language-Team: \n"
@@ -136,13 +136,13 @@ msgstr ""
 msgid "Attribute {0} of class {1} does not match existence {2}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:63
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:75
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:82
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:94
 #, java-format
 msgid "Attribute {0}.{1} cannot be constrained by a {2}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:41
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:60
 #, java-format
 msgid "Attribute {0}.{1} cannot contain type {2}"
 msgstr ""
@@ -203,6 +203,11 @@ msgstr ""
 #: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/SpecializedDefinitionValidation.java:59
 #, java-format
 msgid "Could not find parent object for {0} but it should have been prechecked. Could you report this as a bug?"
+msgstr ""
+
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:40
+#, java-format
+msgid "Default value of type {0} does not conform to constraint type {1}"
 msgstr ""
 
 #: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/DefinitionStructureValidation.java:67
@@ -687,7 +692,7 @@ msgstr ""
 msgid "Sibling order {0} refers to missing node id"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:144
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:163
 msgid "Single valued attributes can not have a cardinality"
 msgstr ""
 
@@ -761,12 +766,12 @@ msgstr ""
 msgid "The attribute {0} of type {1} can only have a single value, but the occurrences of the C_OBJECTS below has an upper limit of more than 1"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:128
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:147
 #, java-format
 msgid "The cardinality of Attribute {0}.{1} is the same as in the reference model - this is not allowed due to strict multiplicities validation being enabled"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:136
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:155
 #, java-format
 msgid "The cardinality {0} of attribute {2}.{3} does not match cardinality {1} of the reference model"
 msgstr ""
@@ -786,12 +791,12 @@ msgstr ""
 msgid "The constraint interval for this {0} has lower > upper, this is not allowed"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:109
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:128
 #, java-format
 msgid "The existence of attribute {0}.{1} is the same as in the reference model - this is not allowed due to strict existence validation being enabled"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:117
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:136
 #, java-format
 msgid "The existence {0} of attribute {2}.{3} does not match existence {1} of the reference model"
 msgstr ""
@@ -885,7 +890,7 @@ msgstr ""
 msgid "Tuple member attribute {0} is not an attribute of type {1}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:28
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:47
 #, java-format
 msgid "Type name {0} does not exist"
 msgstr ""
@@ -1115,6 +1120,10 @@ msgstr ""
 msgid "node id must be defined in flat terminology"
 msgstr ""
 
+#: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:89
+msgid "object constraint default value type validity: the type of the default value of an object constraint must conform to the type of the constraint"
+msgstr ""
+
 #: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:12
 msgid "object constraint type name existence: a type name introducing an object constraint block must be defined in the underlying information model"
 msgstr ""
@@ -1311,7 +1320,7 @@ msgstr ""
 msgid "{0} and {1}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:99
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:118
 #, java-format
 msgid "{0} is not a known attribute of {1}"
 msgstr ""

--- a/i18n/po/i18n_nl.po
+++ b/i18n/po/i18n_nl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-26 09:39+0100\n"
+"POT-Creation-Date: 2026-03-30 14:54+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Pieter Bos <pieter.bos@nedap.com>\n"
 "Language-Team: \n"
@@ -136,13 +136,13 @@ msgstr "Attribuut {0} is geen tuple in het archetype dat gespecializeerd wordt, 
 msgid "Attribute {0} of class {1} does not match existence {2}"
 msgstr "Attribuut {0} van class {1} komt niet overeen met existence {2}"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:63
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:75
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:82
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:94
 #, java-format
 msgid "Attribute {0}.{1} cannot be constrained by a {2}"
 msgstr "Attribuut {0}.{1} kan niet worden beperkt met een {2}"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:41
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:60
 #, java-format
 msgid "Attribute {0}.{1} cannot contain type {2}"
 msgstr "Attribuut {0}.{1} mag geen type {2}  bevatten"
@@ -204,6 +204,10 @@ msgstr ""
 #, java-format
 msgid "Could not find parent object for {0} but it should have been prechecked. Could you report this as a bug?"
 msgstr "Kan parent object voor {0} niet vinden. Deze melding is waarschijnlijk een bug, zou u dat kunnen melden?"
+
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:40
+msgid "Default value of type {0} does not conform to constraint type {1}"
+msgstr "Default waarde van type {0} komt niet overeen met constraint type {1}"
 
 #: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/DefinitionStructureValidation.java:67
 #, java-format
@@ -687,7 +691,7 @@ msgstr ""
 msgid "Sibling order {0} refers to missing node id"
 msgstr "Sibling order {0} verwijst naar een ontbrekende node id"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:144
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:163
 msgid "Single valued attributes can not have a cardinality"
 msgstr "Attributen die maar één waarde kunnen bevatten mogen geen cardinaliteit hebben"
 
@@ -761,12 +765,12 @@ msgstr "Het attribuut bevat {0} waarden die verplicht zijn, maar heeft een maxim
 msgid "The attribute {0} of type {1} can only have a single value, but the occurrences of the C_OBJECTS below has an upper limit of more than 1"
 msgstr "Het attribuut {0} van type {1} kan maar één waarde hebben, maar de occurrences van de C_OBJECTS in dit attibuut heeft een maximale limiet van meer dan 1"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:128
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:147
 #, java-format
 msgid "The cardinality of Attribute {0}.{1} is the same as in the reference model - this is not allowed due to strict multiplicities validation being enabled"
 msgstr "De cardinaliteit van attribuut {0}.{1} is hetzelfde als in het referentiemodel. Dit is niet toegestaan als strikte validatie is ingeschakeld"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:136
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:155
 #, java-format
 msgid "The cardinality {0} of attribute {2}.{3} does not match cardinality {1} of the reference model"
 msgstr "De cardinaliteit {0} van attribuut {2}.{3} klopt niet met de cardinaliteit {1} uit het referentiemodel"
@@ -786,12 +790,12 @@ msgstr ""
 msgid "The constraint interval for this {0} has lower > upper, this is not allowed"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:109
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:128
 #, java-format
 msgid "The existence of attribute {0}.{1} is the same as in the reference model - this is not allowed due to strict existence validation being enabled"
 msgstr "De existence van attribuut {0}.{1} is hetzelfde als in het referentiemodel. Dit is niet toegestaan als strikte validatie ingeschakeld is"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:117
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:136
 #, java-format
 msgid "The existence {0} of attribute {2}.{3} does not match existence {1} of the reference model"
 msgstr "De existence {0} van attribuut {2}.{3} klopt niet bij existence {1} van het referentiemodel"
@@ -885,7 +889,7 @@ msgstr "De beschrijving van de vertaling {0} zou een gelijke sleutelwaarde als d
 msgid "Tuple member attribute {0} is not an attribute of type {1}"
 msgstr "Onderdeel van tupel {0} is geen attribuut van type {1}"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:28
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:47
 #, java-format
 msgid "Type name {0} does not exist"
 msgstr "Type met naam {0} bestaat niet"
@@ -1115,6 +1119,10 @@ msgstr "kleiner dan {0}"
 msgid "node id must be defined in flat terminology"
 msgstr "node id ontbreekt in de flat terminologie"
 
+#: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:89
+msgid "object constraint default value type validity: the type of the default value of an object constraint must conform to the type of the constraint"
+msgstr ""
+
 #: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:12
 msgid "object constraint type name existence: a type name introducing an object constraint block must be defined in the underlying information model"
 msgstr ""
@@ -1311,7 +1319,7 @@ msgstr "value-set waardes uniek. Elke waarde mag maar één keer gebruikt worden
 msgid "{0} and {1}"
 msgstr "{0} en {1}"
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:99
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:118
 #, java-format
 msgid "{0} is not a known attribute of {1}"
 msgstr "{0} is niet een bekend attribuut van {1}"

--- a/i18n/po/i18n_nl.po
+++ b/i18n/po/i18n_nl.po
@@ -1121,7 +1121,7 @@ msgstr "node id ontbreekt in de flat terminologie"
 
 #: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:89
 msgid "object constraint default value type validity: the type of the default value of an object constraint must conform to the type of the constraint"
-msgstr ""
+msgstr "Object constraint default waarde type validiteit: het type van de default waarde van een object constraint moet conformen met het type van de constraint"
 
 #: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:12
 msgid "object constraint type name existence: a type name introducing an object constraint block must be defined in the underlying information model"

--- a/i18n/po/keys.pot
+++ b/i18n/po/keys.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-26 09:39+0100\n"
+"POT-Creation-Date: 2026-03-30 14:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,13 +141,13 @@ msgstr ""
 msgid "Attribute {0} of class {1} does not match existence {2}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:63
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:75
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:82
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:94
 #, java-format
 msgid "Attribute {0}.{1} cannot be constrained by a {2}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:41
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:60
 #, java-format
 msgid "Attribute {0}.{1} cannot contain type {2}"
 msgstr ""
@@ -208,6 +208,11 @@ msgstr ""
 #: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/SpecializedDefinitionValidation.java:59
 #, java-format
 msgid "Could not find parent object for {0} but it should have been prechecked. Could you report this as a bug?"
+msgstr ""
+
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:40
+#, java-format
+msgid "Default value of type {0} does not conform to constraint type {1}"
 msgstr ""
 
 #: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/DefinitionStructureValidation.java:67
@@ -692,7 +697,7 @@ msgstr ""
 msgid "Sibling order {0} refers to missing node id"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:144
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:163
 msgid "Single valued attributes can not have a cardinality"
 msgstr ""
 
@@ -766,12 +771,12 @@ msgstr ""
 msgid "The attribute {0} of type {1} can only have a single value, but the occurrences of the C_OBJECTS below has an upper limit of more than 1"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:128
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:147
 #, java-format
 msgid "The cardinality of Attribute {0}.{1} is the same as in the reference model - this is not allowed due to strict multiplicities validation being enabled"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:136
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:155
 #, java-format
 msgid "The cardinality {0} of attribute {2}.{3} does not match cardinality {1} of the reference model"
 msgstr ""
@@ -791,12 +796,12 @@ msgstr ""
 msgid "The constraint interval for this {0} has lower > upper, this is not allowed"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:109
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:128
 #, java-format
 msgid "The existence of attribute {0}.{1} is the same as in the reference model - this is not allowed due to strict existence validation being enabled"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:117
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:136
 #, java-format
 msgid "The existence {0} of attribute {2}.{3} does not match existence {1} of the reference model"
 msgstr ""
@@ -890,7 +895,7 @@ msgstr ""
 msgid "Tuple member attribute {0} is not an attribute of type {1}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:28
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:47
 #, java-format
 msgid "Type name {0} does not exist"
 msgstr ""
@@ -1120,6 +1125,10 @@ msgstr ""
 msgid "node id must be defined in flat terminology"
 msgstr ""
 
+#: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:89
+msgid "object constraint default value type validity: the type of the default value of an object constraint must conform to the type of the constraint"
+msgstr ""
+
 #: ../aom/src/main/java/com/nedap/archie/archetypevalidator/ErrorType.java:12
 msgid "object constraint type name existence: a type name introducing an object constraint block must be defined in the underlying information model"
 msgstr ""
@@ -1316,7 +1325,7 @@ msgstr ""
 msgid "{0} and {1}"
 msgstr ""
 
-#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:99
+#: ../tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java:118
 #, java-format
 msgid "{0} is not a known attribute of {1}"
 msgstr ""

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java
@@ -36,7 +36,7 @@ public class ValidateAgainstReferenceModel extends ValidatingVisitor {
 
         String defaultValueTypeName = typeInfo.getRmName();
         if (!metaModel.rmTypesConformant(defaultValueTypeName, cObject.getRmTypeName())) {
-            addMessageWithPath(ErrorType.VCDVT, cObject.getPath(),
+            addMessageWithPath(ErrorType.DEFAULT_OBJECT_TYPE_VALIDITY, cObject.getPath(),
                     I18n.t("Default value of type {0} does not conform to constraint type {1}",
                             defaultValueTypeName, cObject.getRmTypeName()));
         }

--- a/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java
+++ b/tools/src/main/java/com/nedap/archie/archetypevalidator/validations/ValidateAgainstReferenceModel.java
@@ -5,6 +5,8 @@ import com.nedap.archie.aom.*;
 import com.nedap.archie.aom.utils.AOMUtils;
 import com.nedap.archie.archetypevalidator.ErrorType;
 import com.nedap.archie.archetypevalidator.ValidatingVisitor;
+import com.nedap.archie.base.OpenEHRBase;
+import com.nedap.archie.rminfo.RMTypeInfo;
 import org.openehr.utils.message.I18n;
 
 /**
@@ -21,6 +23,23 @@ public class ValidateAgainstReferenceModel extends ValidatingVisitor {
     @Override
     protected void validate(CComplexObject cObject) {
         validateTypes(cObject);
+        validateDefaultValueType(cObject);
+    }
+
+    private void validateDefaultValueType(CComplexObject cObject) {
+        OpenEHRBase defaultValue = cObject.getDefaultValue();
+        RMTypeInfo typeInfo;
+        if (defaultValue == null || defaultValue instanceof DefaultValueContainer || metaModel.getModelInfoLookup() == null ||
+                (typeInfo = metaModel.getModelInfoLookup().getTypeInfo(defaultValue.getClass())) == null) {
+            return;
+        }
+
+        String defaultValueTypeName = typeInfo.getRmName();
+        if (!metaModel.rmTypesConformant(defaultValueTypeName, cObject.getRmTypeName())) {
+            addMessageWithPath(ErrorType.VCDVT, cObject.getPath(),
+                    I18n.t("Default value of type {0} does not conform to constraint type {1}",
+                            defaultValueTypeName, cObject.getRmTypeName()));
+        }
     }
 
     private void validateTypes(CObject cObject) {

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -12,7 +12,9 @@ import com.nedap.archie.rm.datavalues.DvText;
 import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
 import com.nedap.archie.rm.support.identification.TerminologyId;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
+import com.nedap.archie.rminfo.MetaModelProvider;
 import com.nedap.archie.rminfo.ReferenceModels;
+import org.apache.commons.lang3.arch.Processor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openehr.referencemodels.BuiltinReferenceModels;
@@ -28,14 +30,12 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class ArchetypeValidatorTest {
 
-    private ADLParser parser;
     private Archetype archetype;
 
     private ReferenceModels models;
 
     @BeforeEach
     public void setup() {
-        parser = new ADLParser();
         models = new ReferenceModels();
         models.registerModel(ArchieRMInfoLookup.getInstance());
         models.registerModel(TestRMInfoLookup.getInstance());
@@ -349,13 +349,20 @@ public class ArchetypeValidatorTest {
 
     @Test
     public void defaultValueTypeNoConform() throws Exception {
-        archetype = parse("openEHR-EHR-CLUSTER.simple_test_cluster.v1.0.0.adls");
-        CComplexObject dvTextConstraint = archetype.itemAtPath("/items[id2]/value[id3]");
-        DvOrdinal dvOrdinal = new DvOrdinal(42L, new DvCodedText("symbol", new CodePhrase(new TerminologyId("local"), "at42")));
-        dvTextConstraint.setDefaultValue(dvOrdinal);
+        archetype = parse("openEHR-EHR-CLUSTER.default_values_invalid.v0.0.0.adls");
 
+        // Validation when model provided
         ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);
         assertOneError(validationResult, ErrorType.VCDVT);
+    }
+
+    @Test
+    public void defaultValueTypeNoConformNoModel() throws Exception {
+        archetype = parse("openEHR-EHR-CLUSTER.default_values_invalid.v0.0.0.adls", null);
+
+        // No validation when no model provided
+        ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);
+        assertTrue(validationResult.passes(), validationResult.toString());
     }
 
     @Test
@@ -367,6 +374,11 @@ public class ArchetypeValidatorTest {
     }
 
     private Archetype parse(String filename) throws IOException, ADLParseException {
+        return parse(filename, BuiltinReferenceModels.getMetaModelProvider());
+    }
+
+    private Archetype parse(String filename, MetaModelProvider metaModelProvider) throws IOException, ADLParseException {
+        ADLParser parser = new ADLParser(metaModelProvider);
         archetype = parser.parse(ArchetypeValidatorTest.class.getResourceAsStream(filename));
         assertThat(parser.getErrors().toString(), parser.getErrors().hasNoErrors());
         return archetype;

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -3,18 +3,11 @@ package com.nedap.archie.archetypevalidator;
 import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
-import com.nedap.archie.aom.CComplexObject;
 import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
 import com.nedap.archie.openehrtestrm.TestRMInfoLookup;
-import com.nedap.archie.rm.datatypes.CodePhrase;
-import com.nedap.archie.rm.datavalues.DvCodedText;
-import com.nedap.archie.rm.datavalues.DvText;
-import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
-import com.nedap.archie.rm.support.identification.TerminologyId;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.MetaModelProvider;
 import com.nedap.archie.rminfo.ReferenceModels;
-import org.apache.commons.lang3.arch.Processor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openehr.referencemodels.BuiltinReferenceModels;
@@ -353,7 +346,7 @@ public class ArchetypeValidatorTest {
 
         // Validation when model provided
         ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);
-        assertOneError(validationResult, ErrorType.VCDVT);
+        assertOneError(validationResult, ErrorType.DEFAULT_OBJECT_TYPE_VALIDITY);
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
+++ b/tools/src/test/java/com/nedap/archie/archetypevalidator/ArchetypeValidatorTest.java
@@ -3,8 +3,14 @@ package com.nedap.archie.archetypevalidator;
 import com.nedap.archie.adlparser.ADLParseException;
 import com.nedap.archie.adlparser.ADLParser;
 import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.aom.CComplexObject;
 import com.nedap.archie.flattener.InMemoryFullArchetypeRepository;
 import com.nedap.archie.openehrtestrm.TestRMInfoLookup;
+import com.nedap.archie.rm.datatypes.CodePhrase;
+import com.nedap.archie.rm.datavalues.DvCodedText;
+import com.nedap.archie.rm.datavalues.DvText;
+import com.nedap.archie.rm.datavalues.quantity.DvOrdinal;
+import com.nedap.archie.rm.support.identification.TerminologyId;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.ReferenceModels;
 import org.junit.jupiter.api.BeforeEach;
@@ -339,6 +345,25 @@ public class ArchetypeValidatorTest {
             assertEquals("Node id ac4 already used in archetype as at4 with a different at, id or ac prefix. The archetype will not be convertible to ADL 1.4", result.getErrors().get(4).getMessage());
             assertEquals("Node id ac12 already used in archetype as at12 with a different at, id or ac prefix. The archetype will not be convertible to ADL 1.4", result.getErrors().get(5).getMessage());
         }
+    }
+
+    @Test
+    public void defaultValueTypeNoConform() throws Exception {
+        archetype = parse("openEHR-EHR-CLUSTER.simple_test_cluster.v1.0.0.adls");
+        CComplexObject dvTextConstraint = archetype.itemAtPath("/items[id2]/value[id3]");
+        DvOrdinal dvOrdinal = new DvOrdinal(42L, new DvCodedText("symbol", new CodePhrase(new TerminologyId("local"), "at42")));
+        dvTextConstraint.setDefaultValue(dvOrdinal);
+
+        ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);
+        assertOneError(validationResult, ErrorType.VCDVT);
+    }
+
+    @Test
+    public void defaultValueTypeInheritConforms() throws Exception {
+        archetype = parse("../serializer/adl/openEHR-EHR-CLUSTER.default_values.v1.adls");
+
+        ValidationResult validationResult = new ArchetypeValidator(models).validate(archetype);
+        assertTrue(validationResult.passes(), validationResult.toString());
     }
 
     private Archetype parse(String filename) throws IOException, ADLParseException {

--- a/tools/src/test/resources/com/nedap/archie/archetypevalidator/openEHR-EHR-CLUSTER.default_values_invalid.v0.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/archetypevalidator/openEHR-EHR-CLUSTER.default_values_invalid.v0.0.0.adls
@@ -1,0 +1,68 @@
+archetype (adl_version=2.0.5; rm_release=1.0.2)
+    openEHR-EHR-CLUSTER.default_values_invalid.v0.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Jelte Zeilstra">
+        ["organisation"] = <"Nedap <https://www.nedap.com>">
+    >
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"A very simple cluster archetype for testing invalid default values">
+        >
+    >
+
+definition
+    CLUSTER[id1] matches {    -- Prescription
+        items matches {
+            ELEMENT[id2] matches {
+                value matches {
+                    DV_TEXT[id21] matches {
+                        _default = (DV_TEXT) <
+                            value = <"Some default valid value">
+                        >
+                    }
+                }
+            }
+            ELEMENT[id3] matches {
+                value matches {
+                    DV_CODED_TEXT[id31] matches {
+                        _default = (json) <#
+                            {
+                              "_type" : "DV_TEXT",
+                              "value" : "Some default invalid value"
+                            }
+                        #>
+                    }
+                }
+            }
+        }
+        _default = (someotherformat) <#
+            This is some other format which cannot be parsed.
+The indentation of
+    this format
+  shouldn't be changed by the serializer.
+        #>
+    }
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"Prescription">
+                description = <"A document authorising supply and administration of one or more medicines, vaccines or other therapeutic goods (as a collection of medication instrations) to be communicated to a dispensing or administration provider.">
+            >
+            ["id2"] = <
+                text = <"dv text">
+                description = <"dv text">
+            >
+            ["id3"] = <
+                text = <"dv coded text">
+                description = <"dv coded text">
+            >
+        >
+    >


### PR DESCRIPTION
fixes #674
Make sure the type specified in the default value json conforms to the complex object it is defined in.

#### Allowed
```
DV_TEXT[id44] matches {
    _default = (json) <#
        {
            "_type" : "DV_TEXT",
            "value" : "Some default text."
        }
    #>
}
and

DV_TEXT[id44] matches {
    _default = (json) <#
        {
            "_type" : "DV_CODED_TEXT",
            "value" : "Some default text.",
            "defining_code" : {
                "terminology_id" : {
                    "value": "local"
                },
                "code_string" : "at42"
            }
        }
    #>
}
```
#### Not allowed
```
DV_TEXT[id44] matches {
    _default = (json) <#
        {
            "_type" : "DV_ORDINAL",
            "value" : 42
        }
    #>
}
```