### PR TITLE
Add CTerminologyCode.constraint type forwards compatibility tests

### DIFF
--- a/tools/src/test/java/com/nedap/archie/json/AOMJacksonTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/AOMJacksonTest.java
@@ -276,9 +276,22 @@ public class AOMJacksonTest {
         String json = objectMapper.writeValueAsString(cTermCode);
 
         assertTrue(json.contains("\"constraint_status\" : \"preferred\""));
+        assertTrue(json.contains("\"constraint\" : [ \"ac23\" ]"));
         CTerminologyCode parsedTermCode = objectMapper.readValue(json, CTerminologyCode.class);
         assertEquals(cTermCode.getConstraint(), parsedTermCode.getConstraint());
         assertEquals(ConstraintStatus.PREFERRED, parsedTermCode.getConstraintStatus());
+    }
+
+    @Test
+    public void forwardsCompatibilityCTerminologyCodeConstraintTypeFromJsonTest() throws Exception {
+        String json = "{\n" +
+                "  \"rm_type_name\" : \"terminology_code\",\n" +
+                "  \"node_id\" : \"id9999\",\n" +
+                "  \"constraint\" : \"ac23\"\n" +
+                "}";
+        ObjectMapper objectMapper = JacksonUtil.getObjectMapper(ArchieJacksonConfiguration.createStandardsCompliant());
+        CTerminologyCode parsedTermCode = objectMapper.readValue(json, CTerminologyCode.class);
+        assertEquals("ac23", parsedTermCode.getConstraint().get(0));
     }
 
     @Test

--- a/tools/src/test/java/com/nedap/archie/xml/JAXBAOMTest.java
+++ b/tools/src/test/java/com/nedap/archie/xml/JAXBAOMTest.java
@@ -81,6 +81,7 @@ public class JAXBAOMTest {
         String xml = writer.toString();
 
         assertThat(xml, xml.contains("<constraintStatus>preferred</constraintStatus>"));
+        assertThat(xml, xml.contains("<constraint>ac23</constraint>"));
 
         Unmarshaller unmarshaller = JAXBUtil.getArchieJAXBContext().createUnmarshaller();
         Archetype unmarshalled = (Archetype) unmarshaller.unmarshal(new StringReader(xml));


### PR DESCRIPTION
Fixes #712 

Adds a test to show that the new json without array brackets can still be read in Archie 3. Note that xml was basically already tested.