### PR TITLE
Lazy initialize Jackson ObjectMappers in MetaModelMake sure the mappers are initialized once

### DIFF
--- a/aom/src/main/java/com/nedap/archie/rminfo/MetaModel.java
+++ b/aom/src/main/java/com/nedap/archie/rminfo/MetaModel.java
@@ -19,9 +19,10 @@ public class MetaModel implements MetaModelInterface {
     private final ModelInfoLookup modelInfoLookup;
     private final BmmModel bmmModel;
     private final AomProfile aomProfile;
-    private final ObjectMapper odinInputObjectMapper;
-    private final ObjectMapper odinOutputObjectMapper;
-    private final ObjectMapper jsonObjectMapper;
+    private final RMObjectMapperProvider objectMapperProvider;
+    private volatile ObjectMapper odinInputObjectMapper;
+    private volatile ObjectMapper odinOutputObjectMapper;
+    private volatile ObjectMapper jsonObjectMapper;
 
     public MetaModel(ModelInfoLookup modelInfoLookup, BmmModel bmmModel) {
         this(modelInfoLookup, bmmModel, null);
@@ -38,15 +39,7 @@ public class MetaModel implements MetaModelInterface {
         this.modelInfoLookup = modelInfoLookup;
         this.bmmModel = bmmModel;
         this.aomProfile = aomProfile;
-        if (provider != null) {
-            this.odinInputObjectMapper = provider.getInputOdinObjectMapper();
-            this.odinOutputObjectMapper = provider.getOutputOdinObjectMapper();
-            this.jsonObjectMapper = provider.getJsonObjectMapper();
-        } else {
-            this.odinInputObjectMapper = null;
-            this.odinOutputObjectMapper = null;
-            this.jsonObjectMapper = null;
-        }
+        this.objectMapperProvider = provider;
     }
 
     /**
@@ -93,7 +86,17 @@ public class MetaModel implements MetaModelInterface {
      * @return the object mapper to use for JSON converted from ODIN to parse this model
      */
     public ObjectMapper getOdinInputObjectMapper() {
-        return odinInputObjectMapper;
+        ObjectMapper mapper = odinInputObjectMapper;
+        if (mapper == null && objectMapperProvider != null) {
+            synchronized (this) {
+                mapper = odinInputObjectMapper;
+                if (mapper == null) {
+                    mapper = objectMapperProvider.getInputOdinObjectMapper();
+                    odinInputObjectMapper = mapper;
+                }
+            }
+        }
+        return mapper;
     }
 
     /**
@@ -104,11 +107,31 @@ public class MetaModel implements MetaModelInterface {
      * @return Get the object mapper to output ODIN from this model
      */
     public ObjectMapper getOdinOutputObjectMapper() {
-        return odinOutputObjectMapper;
+        ObjectMapper mapper = odinOutputObjectMapper;
+        if (mapper == null && objectMapperProvider != null) {
+            synchronized (this) {
+                mapper = odinOutputObjectMapper;
+                if (mapper == null) {
+                    mapper = objectMapperProvider.getOutputOdinObjectMapper();
+                    odinOutputObjectMapper = mapper;
+                }
+            }
+        }
+        return mapper;
     }
 
     public ObjectMapper getJsonObjectMapper() {
-        return jsonObjectMapper;
+        ObjectMapper mapper = jsonObjectMapper;
+        if (mapper == null && objectMapperProvider != null) {
+            synchronized (this) {
+                mapper = jsonObjectMapper;
+                if (mapper == null) {
+                    mapper = objectMapperProvider.getJsonObjectMapper();
+                    jsonObjectMapper = mapper;
+                }
+            }
+        }
+        return mapper;
     }
 
     /**

--- a/aom/src/test/java/com/nedap/archie/rminfo/MetaModelTest.java
+++ b/aom/src/test/java/com/nedap/archie/rminfo/MetaModelTest.java
@@ -1,0 +1,65 @@
+package com.nedap.archie.rminfo;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.openehr.bmm.core.BmmModel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class MetaModelTest {
+
+    private static class CountingProvider implements RMObjectMapperProvider {
+        int inputCalls;
+        int outputCalls;
+        int jsonCalls;
+
+        @Override
+        public ObjectMapper getInputOdinObjectMapper() {
+            inputCalls++;
+            return new ObjectMapper();
+        }
+
+        @Override
+        public ObjectMapper getOutputOdinObjectMapper() {
+            outputCalls++;
+            return new ObjectMapper();
+        }
+
+        @Override
+        public ObjectMapper getJsonObjectMapper() {
+            jsonCalls++;
+            return new ObjectMapper();
+        }
+    }
+
+    @Test
+    public void eachObjectMapperIsFetchedOnceAndCached() {
+        CountingProvider provider = new CountingProvider();
+        MetaModel metaModel = new MetaModel(null, new BmmModel(), null, provider);
+
+        metaModel.getOdinInputObjectMapper();
+        assertEquals(1, provider.inputCalls);
+        assertEquals(0, provider.outputCalls);
+        assertEquals(0, provider.jsonCalls);
+
+        metaModel.getOdinOutputObjectMapper();
+        assertEquals(1, provider.inputCalls);
+        assertEquals(1, provider.outputCalls);
+        assertEquals(0, provider.jsonCalls);
+
+        metaModel.getJsonObjectMapper();
+        assertEquals(1, provider.inputCalls);
+        assertEquals(1, provider.outputCalls);
+        assertEquals(1, provider.jsonCalls);
+
+        metaModel.getOdinInputObjectMapper();
+        metaModel.getOdinOutputObjectMapper();
+        metaModel.getJsonObjectMapper();
+        assertEquals(1, provider.inputCalls);
+        assertEquals(1, provider.outputCalls);
+        assertEquals(1, provider.jsonCalls);
+    }
+}


### PR DESCRIPTION
fixes #779 

  ## Summary
  - Lazily initialize the three Jackson `ObjectMapper`s in `MetaModel` so they are only fetched from the `RMObjectMapperProvider` the first time the corresponding getter (`getOdinInputObjectMapper`,
  `getOdinOutputObjectMapper`, `getJsonObjectMapper`) is called, instead of all three being fetched up-front in the constructor.
  - Uses `volatile` fields with double-checked locking so each mapper is fetched from the provider at most once, even under concurrent access.
  - Adds `MetaModelTest` covering: no provider calls happen at construction time, each mapper is fetched once and cached across repeated reads, and the no-provider path still returns `null` from all three
  getters.