### PR TITLE
Improve handling NullpointerException by APathQuery

### DIFF
--- a/utils/src/main/java/com/nedap/archie/query/APathQuery.java
+++ b/utils/src/main/java/com/nedap/archie/query/APathQuery.java
@@ -42,10 +42,17 @@ public class APathQuery {
                 throw new UnsupportedOperationException("absolute path starting with // not yet supported");
             }
             RelativeLocationPathContext relativeLocationPathContext;
+            Throwable exception;
             if(absoluteLocationPathNorootContext == null) {
                 relativeLocationPathContext = locationPathContext.relativeLocationPath();
+                exception = locationPathContext.exception;
             } else {
                 relativeLocationPathContext = absoluteLocationPathNorootContext.relativeLocationPath();
+                exception = absoluteLocationPathNorootContext.exception;
+            }
+
+            if(relativeLocationPathContext == null) {
+                throw new IllegalArgumentException("invalid relative path expression: " + query, exception);
             }
 
             if (!relativeLocationPathContext.getTokens(XPathLexer.ABRPATH).isEmpty()) {
@@ -55,6 +62,9 @@ public class APathQuery {
 
             List<StepContext> stepContexts = relativeLocationPathContext.step();
             for (StepContext stepContext : stepContexts) {
+                if (stepContext.nodeTest() == null) {
+                    throw new IllegalArgumentException("invalid relative path expression: " + query, stepContext.exception);
+                }
                 String nodeName = stepContext.nodeTest().getText();
                 List<PredicateContext> predicateContexts = stepContext.predicate();
                 PathSegment pathSegment = new PathSegment(nodeName);

--- a/utils/src/test/java/com/nedap/archie/query/APathQueryTest.java
+++ b/utils/src/test/java/com/nedap/archie/query/APathQueryTest.java
@@ -1,10 +1,7 @@
 package com.nedap.archie.query;
 
-import com.nedap.archie.paths.PathSegment;
 import org.antlr.v4.runtime.InputMismatchException;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,25 +17,25 @@ public class APathQueryTest {
 
     @Test
     public void nullRelativeLocationPathContext() {
-        Throwable t = assertInvalidPath("[");
+        Throwable t = assertIllegalPath("[");
         assertEquals("invalid relative path expression: [", t.getMessage());
         assertEquals("[", ((InputMismatchException) t.getCause()).getOffendingToken().getText());
     }
 
     @Test
     public void nullStepNodeTest() {
-        Throwable t1 = assertInvalidPath("/2");
+        Throwable t1 = assertIllegalPath("/2");
         assertEquals("invalid relative path expression: /2", t1.getMessage());
         assertEquals("2", ((InputMismatchException) t1.getCause()).getOffendingToken().getText());
 
-        Throwable t2 = assertInvalidPath("/value/");
+        Throwable t2 = assertIllegalPath("/value/");
         assertEquals("invalid relative path expression: /value/", t2.getMessage());
         assertEquals("<EOF>", ((InputMismatchException) t2.getCause()).getOffendingToken().getText());
     }
 
     @Test
     public void invalidSlashes() {
-        Throwable t = assertInvalidPath(" /");
+        Throwable t = assertIllegalPath(" /");
         assertEquals("invalid relative path expression:  /", t.getMessage());
         assertEquals("<EOF>", ((InputMismatchException) t.getCause()).getOffendingToken().getText());
 
@@ -46,10 +43,10 @@ public class APathQueryTest {
     }
 
     // -------------------------------------------------------------------------
-    // helpers
+    // Helpers
     // -------------------------------------------------------------------------
 
-    private static Throwable assertInvalidPath(String query) {
+    private static Throwable assertIllegalPath(String query) {
         return assertThrows(IllegalArgumentException.class, () -> new APathQuery(query));
     }
 }

--- a/utils/src/test/java/com/nedap/archie/query/APathQueryTest.java
+++ b/utils/src/test/java/com/nedap/archie/query/APathQueryTest.java
@@ -1,0 +1,55 @@
+package com.nedap.archie.query;
+
+import com.nedap.archie.paths.PathSegment;
+import org.antlr.v4.runtime.InputMismatchException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class APathQueryTest {
+
+    @Test
+    public void validPaths() {
+        assertDoesNotThrow(() -> new APathQuery("/items[at0001]"));
+        assertDoesNotThrow(() -> new APathQuery("/value"));
+        assertDoesNotThrow(() -> new APathQuery("/items[at0001]/value"));
+        assertDoesNotThrow(() -> new APathQuery("/[at0001]"));
+    }
+
+    @Test
+    public void nullRelativeLocationPathContext() {
+        Throwable t = assertInvalidPath("[");
+        assertEquals("invalid relative path expression: [", t.getMessage());
+        assertEquals("[", ((InputMismatchException) t.getCause()).getOffendingToken().getText());
+    }
+
+    @Test
+    public void nullStepNodeTest() {
+        Throwable t1 = assertInvalidPath("/2");
+        assertEquals("invalid relative path expression: /2", t1.getMessage());
+        assertEquals("2", ((InputMismatchException) t1.getCause()).getOffendingToken().getText());
+
+        Throwable t2 = assertInvalidPath("/value/");
+        assertEquals("invalid relative path expression: /value/", t2.getMessage());
+        assertEquals("<EOF>", ((InputMismatchException) t2.getCause()).getOffendingToken().getText());
+    }
+
+    @Test
+    public void invalidSlashes() {
+        Throwable t = assertInvalidPath(" /");
+        assertEquals("invalid relative path expression:  /", t.getMessage());
+        assertEquals("<EOF>", ((InputMismatchException) t.getCause()).getOffendingToken().getText());
+
+        assertThrows(UnsupportedOperationException.class, () -> new APathQuery("/slash//"));
+    }
+
+    // -------------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------------
+
+    private static Throwable assertInvalidPath(String query) {
+        return assertThrows(IllegalArgumentException.class, () -> new APathQuery(query));
+    }
+}


### PR DESCRIPTION
Improves user feedback corresponding to #741

There were 2 places that could by relative 'simple' paths result in NullpointerException.
This PR makes the Throwable more clear to the user.