### PR TITLE
Upgrade to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(8)
+            languageVersion = JavaLanguageVersion.of(17)
         }
 
         withJavadocJar()


### PR DESCRIPTION
## Upgrade to Java 17

Resolves #792.

`build.gradle` declares the Gradle toolchain as Java 8, but the project already
requires **JDK 11** to build: the ANTLR 4 `Tool` on the `generateGrammarSource`
classpath is compiled for class file version 55 (Java 11), so a genuine Java 8
build fails at `:grammars:generateGrammarSource`. This PR raises the toolchain to
**Java 17**.

### Change

A single line in the `subprojects` block of `build.gradle`:

```diff
-            languageVersion = JavaLanguageVersion.of(8)
+            languageVersion = JavaLanguageVersion.of(17)
```

The Gradle wrapper is already 8.14.4, so no wrapper change was needed, and no
source changes were required.

### Verification

Full `./gradlew test` across all 14 modules, before and after:

| build JDK | tests | passed | failures | errors | skipped |
|---|---|---|---|---|---|
| 11 (baseline) | 966 | 964 | 0 | 0 | 2 |
| 17 (this PR)  | 966 | 964 | 0 | 0 | 2 |

No previously-passing test is lost; the suite is green under Java 17.

---

Bumped with the [`bump-java-version`](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
