### PR TITLE
Add ADL1.4 to ADL2 converter tests

### DIFF
--- a/tools/src/test/java/com/nedap/archie/adl14/ADL14ToADL2Test.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/ADL14ToADL2Test.java
@@ -9,6 +9,7 @@ import org.openehr.referencemodels.BuiltinReferenceModels;
 
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -21,18 +22,18 @@ public class ADL14ToADL2Test {
     public void demoFromAdl14ToAdl2IdCodedTest() throws Exception {
         Archetype adl14;
         try (InputStream stream = getClass().getResourceAsStream(path + "openEHR-EHR-OBSERVATION.demo_adl14.v1.adl")) {
-            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModelProvider());
             adl14 = parser.parse(stream, ConversionConfigForTest.getConfig());
         }
 
         // Configuration defaults to ID_CODED
-        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), new ADL14ConversionConfiguration());
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModelProvider(), new ADL14ConversionConfiguration());
 
-        ADL2ConversionResultList resultList = converter.convert(Arrays.asList(adl14));
+        ADL2ConversionResultList resultList = converter.convert(Collections.singletonList(adl14));
         Archetype result = resultList.getConversionResults().get(0).getArchetype();
 
         assertEquals(
-                CharStreams.fromStream(new BOMInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-OBSERVATION.demo_adl2_id.v1.0.0.adls"))).toString(),
+                CharStreams.fromStream(new BOMInputStream.Builder().setInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-OBSERVATION.demo_adl2_id.v1.0.0.adls")).get()).toString(),
                 ADLArchetypeSerializer.serialize(result)
         );
     }
@@ -41,28 +42,28 @@ public class ADL14ToADL2Test {
     public void examAbdomenFromAdl14ToAdl2IdCodedTest() throws Exception {
         Archetype parent;
         try (InputStream stream = getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam_adl14.v2.adl")) {
-            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModelProvider());
             parent = parser.parse(stream, ConversionConfigForTest.getConfig());
         }
         Archetype child;
         try (InputStream stream = getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam-abdomen_adl14.v0.adl")) {
-            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModelProvider());
             child = parser.parse(stream, ConversionConfigForTest.getConfig());
         }
 
         // Configuration defaults to ID_CODED
-        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), new ADL14ConversionConfiguration());
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModelProvider(), new ADL14ConversionConfiguration());
 
         ADL2ConversionResultList resultList = converter.convert(Arrays.asList(parent, child));
         Archetype parentResult = resultList.getConversionResults().get(0).getArchetype();
         Archetype childResult = resultList.getConversionResults().get(1).getArchetype();
 
         assertEquals(
-                CharStreams.fromStream(new BOMInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam_adl2_id.v2.1.3.adls"))).toString(),
+                CharStreams.fromStream(new BOMInputStream.Builder().setInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam_adl2_id.v2.1.3.adls")).get()).toString(),
                 ADLArchetypeSerializer.serialize(parentResult)
         );
         assertEquals(
-                CharStreams.fromStream(new BOMInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam-abdomen_adl2_id.v0.0.1-alpha.adls"))).toString(),
+                CharStreams.fromStream(new BOMInputStream.Builder().setInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam-abdomen_adl2_id.v0.0.1-alpha.adls")).get()).toString(),
                 ADLArchetypeSerializer.serialize(childResult)
         );
     }

--- a/tools/src/test/java/com/nedap/archie/adl14/ADL14ToADL2Test.java
+++ b/tools/src/test/java/com/nedap/archie/adl14/ADL14ToADL2Test.java
@@ -1,0 +1,69 @@
+package com.nedap.archie.adl14;
+
+import com.nedap.archie.aom.Archetype;
+import com.nedap.archie.serializer.adl.ADLArchetypeSerializer;
+import org.antlr.v4.runtime.CharStreams;
+import org.apache.commons.io.input.BOMInputStream;
+import org.junit.jupiter.api.Test;
+import org.openehr.referencemodels.BuiltinReferenceModels;
+
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class ADL14ToADL2Test {
+
+    private String path = "/com/nedap/archie/adl14/";
+
+    @Test
+    public void demoFromAdl14ToAdl2IdCodedTest() throws Exception {
+        Archetype adl14;
+        try (InputStream stream = getClass().getResourceAsStream(path + "openEHR-EHR-OBSERVATION.demo_adl14.v1.adl")) {
+            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            adl14 = parser.parse(stream, ConversionConfigForTest.getConfig());
+        }
+
+        // Configuration defaults to ID_CODED
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), new ADL14ConversionConfiguration());
+
+        ADL2ConversionResultList resultList = converter.convert(Arrays.asList(adl14));
+        Archetype result = resultList.getConversionResults().get(0).getArchetype();
+
+        assertEquals(
+                CharStreams.fromStream(new BOMInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-OBSERVATION.demo_adl2_id.v1.0.0.adls"))).toString(),
+                ADLArchetypeSerializer.serialize(result)
+        );
+    }
+
+    @Test
+    public void examAbdomenFromAdl14ToAdl2IdCodedTest() throws Exception {
+        Archetype parent;
+        try (InputStream stream = getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam_adl14.v2.adl")) {
+            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            parent = parser.parse(stream, ConversionConfigForTest.getConfig());
+        }
+        Archetype child;
+        try (InputStream stream = getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam-abdomen_adl14.v0.adl")) {
+            ADL14Parser parser = new ADL14Parser(BuiltinReferenceModels.getMetaModels());
+            child = parser.parse(stream, ConversionConfigForTest.getConfig());
+        }
+
+        // Configuration defaults to ID_CODED
+        ADL14Converter converter = new ADL14Converter(BuiltinReferenceModels.getMetaModels(), new ADL14ConversionConfiguration());
+
+        ADL2ConversionResultList resultList = converter.convert(Arrays.asList(parent, child));
+        Archetype parentResult = resultList.getConversionResults().get(0).getArchetype();
+        Archetype childResult = resultList.getConversionResults().get(1).getArchetype();
+
+        assertEquals(
+                CharStreams.fromStream(new BOMInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam_adl2_id.v2.1.3.adls"))).toString(),
+                ADLArchetypeSerializer.serialize(parentResult)
+        );
+        assertEquals(
+                CharStreams.fromStream(new BOMInputStream(getClass().getResourceAsStream(path + "openEHR-EHR-CLUSTER.exam-abdomen_adl2_id.v0.0.1-alpha.adls"))).toString(),
+                ADLArchetypeSerializer.serialize(childResult)
+        );
+    }
+}

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam-abdomen_adl14.v0.adl
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam-abdomen_adl14.v0.adl
@@ -1,0 +1,687 @@
+archetype (adl_version=1.4; uid=a965a5e8-12a6-471c-8a8e-98dfb8aa9f1f)
+	openEHR-EHR-CLUSTER.exam-abdomen.v0
+specialise
+	openEHR-EHR-CLUSTER.exam.v2
+
+concept
+	[at0000.1]	-- Examination of the abdomen
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			author = <
+				["name"] = <"Nina Schewe, Natalia Strauch, Darin Leonhardt">
+				["organisation"] = <"Medizinische Hochschule Hannover, PLRI für medizinische Informatik/ Medizinische Hochschule">
+				["email"] = <"schewe.nina@mh-hannover.de, Strauch.Natalia@mh-hannover.de, leonhardt.darin@mh-hannover.de">
+			>
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			author = <
+				["name"] = <"Erik Sundvall">
+				["organisation"] = <"Region Östergötland + Linköping University">
+				["email"] = <"erik.sundvall@regionostergotland.se">
+			>
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			author = <
+				["name"] = <"Silje Ljosland Bakke">
+				["organisation"] = <"Nasjonal IKT HF">
+			>
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			author = <
+				["name"] = <"Adriana Kitajima">
+				["organisation"] = <"Hospital Alemão Oswaldo Cruz - HAOC">
+				["email"] = <"adrianakitajima@gmail.com">
+			>
+		>
+		["el"] = <
+			language = <[ISO_639-1::el]>
+			author = <
+				["name"] = <"Erasmia Partafylla">
+				["organisation"] = <"Sigmasoft">
+				["email"] = <"c.partafylla@sigmasoft.gr">
+			>
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			author = <
+				["name"] = <"Julio de Sosa">
+				["organisation"] = <"Servei Català de la Salut">
+				["email"] = <"juliodesosa@catsalut.cat">
+			>
+		>
+	>
+description
+	original_author = <
+		["name"] = <"Heather Leslie">
+		["organisation"] = <"Atomica Informatics">
+		["email"] = <"heather.leslie@atomicainformatics.com">
+		["date"] = <"2015-06-22">
+	>
+	details = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			purpose = <"Aufzeichnung der bei der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachteten Befunde.">
+			use = <"Zur Aufzeichnung der beobachteten Befunde während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur.
+
+Dieser Archetyp wurde speziell für die Verwendung im SLOT „Untersuchungsdetails“ innerhalb des Archetyps OBSERVATION.exam oder im SLOT „Verfahrensdetails“ innerhalb des Archetyps ACTION.procedure entwickelt, kann aber auch innerhalb anderer Archetypen ENTRY oder CLUSTER verwendet werden, sofern dies klinisch sinnvoll ist. Spezialisierungen dieses Archetyps werden verwendet, um Untersuchungsergebnisse für bestimmte Körpersysteme, anatomische Strukturen oder genauere Körperstellen zu erfassen. Jede Spezialisierung behält die Grundstruktur dieses allgemeinen Archetyps als Basis bei und wird durch die Hinzufügung von Elementen erweitert, die für die Körperstelle spezifisch sind. Steht keine geeignete Spezialisierung zur Verfügung, ist dieser Archetyp zu verwenden und das untersuchte System oder die untersuchte Struktur mit dem Datenelement „System oder untersuchte Struktur“ und die Körperstelle mit dem Datenelement „Körperstelle“ oder dem SLOT „Strukturierte Körperstelle“ anzugeben.
+
+Die Interpretation der Befunde, z. B. „Keine Abnormität festgestellt“ oder „Mäßige Entzündung vorhanden“, kann mit dem Datenelement „Klinische Interpretation“ erfasst werden.
+
+Verwendung zur Bereitstellung eines Rahmens, in dem CLUSTER-Archetypen im SLOT „Untersuchungsbefund“ verschachtelt werden können, um zusätzliche strukturierte körperliche Untersuchungsbefunde zu erfassen.
+
+Der Archetyp CLUSTER.exclusion_exam kann in den SLOT „Nicht durchgeführte Untersuchung“ geschachtelt werden, um optional explizite Details über die nicht durchgeführte Untersuchung zu erfassen.
+
+Verwenden Sie das Datenelement „Klinische Beschreibung“, um die narrativen Beschreibungen klinischer Befunde innerhalb bestehender oder vorhandener klinischer Systeme in ein archetypisches Format einzubinden.">
+			misuse = <"Nicht zur Darstellung der klinischen Anamnese zu verwenden – verwenden Sie spezifische OBSERVATION- und CLUSTER-Archetypen. Zum Beispiel OBSERVATION.story und CLUSTER.symptom_sign.
+
+Nicht zur Darstellung der Ergebnisse einer bildgebenden Untersuchung verwenden – verwenden Sie für diesen Zweck die Archetypenfamilie CLUSTER.imaging_exam.">
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+			use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+			keywords = <"fynd, undersökningsfynd, fysisk undersökning, u.a., utan anmärkning", ...>
+			misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			purpose = <"For å registrere en fritekstbeskrivelse og klinisk tolkning av observerte funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+			use = <"Brukes til å registrere en fritekstbeskrivelse og klinisk tolkning av observerte funn ved fysisk undersøkelse av et spesifisert organsystem eller anatomisk struktur. Denne arketypen består kun av kjerneelementene av mønsteret for undersøkelser, og kan utvides ved hjelp av andre CLUSTER-arketyper eller brukes som grunnlag for undersøkelsesarketyper for spesifikke kroppssystemer eller anatomiske strukturer.
+
+Eksempler på detaljer som kan beskrives ved hjelp av dette CLUSTER er inspeksjon, palpasjon, auskultasjon, perkusjon og bevegelser i kroppssystemer eller anatomiske strukturer. Undersøkelsen kan støttes av enkle hjelpemidler som stetoskop, otoskop eller reflekshammer. Også funn ved mer avanserte undersøkelser kan registreres her, som ved endoskopi. I de tilfellene vil informasjon om hvilket hjelpemiddel eller utstyr brukt bli registrert i OBSERVATION.exam, elementet \"Detaljer om medisinsk utstyr\", i ACTION.procedure \"Prosedyredetaljer\" eller tilsvarende i egnet ENTRY- eller ACTION-arketype.
+
+Arketypen er laget spesifikt for å brukes i \"Undersøkelsesdetaljer\"-SLOTet i arketypen OBSERVATION.exam, men kan også brukes innen andre ENTRY- og CLUSTER-arketyper der det er klinisk passende.
+
+Denne arketypen kan benyttes for alle typer undersøkelser, alt fra enkle undersøkelser som undersøkelse av et hudområde, inspeksjon av ører og til artroskopi av et kne.
+
+Kan for eksempel nøstes i SLOTet \"Undersøkelsesdetaljer\" i arketypen OBSERVATION.exam (Norsk Funn ved fysisk undersøkelse) for å registrere ytterligere strukturerte funn ved fysiske undersøkelser.
+
+Arketypen CLUSTER.exclusion_exam kan nøstes i SLOTet \"Undersøkelse ikke utført\" der en har behov for å registrere informasjon om at en undersøkelse ikke ble utført.
+
+Brukes for å videreføre fritekstbeskrivelser av kliniske funn fra tidligere systemer inn i et arketypeformat, ved å bruke elementet \"Klinisk beskrivelse\".">
+			misuse = <"Skal ikke brukes til å ta opp frittstående klinisk observasjoner eller testresultater - bruk spesifikke OBSERVATION arketyper, for eksempel OBSERVATION.head_circumference eller OBSERVATION.glasgow_coma_scale.
+
+Skal ikke brukes til å ta opp anamnese - bruk da spesifikke OBSERVATION og CLUSTER arketyper. For eksempel OBSERVATION.story og CLUSTER.symptom_sign.">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+			use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+			misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+		>
+		["el"] = <
+			language = <[ISO_639-1::el]>
+			purpose = <"Για την καταγραφή των ευρημάτων που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+			use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+			misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.(en)">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record a narrative description and clinical interpretation of the findings observed during the physical examination of the abdomen.">
+			use = <"Use to record a narrative description and clinical interpretation of the findings observed during the physical examination of the abdomen.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element.">
+			misuse = <"Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.">
+			copyright = <"© openEHR Foundation">
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			purpose = <"Registrar los hallazgos observados durante la exploración física de un sistema corporal o una estructura anatómica.">
+			use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+			misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.(en)">
+		>
+	>
+	lifecycle_state = <"in_development">
+	other_contributors = <"Vebjørn Arntzen, Oslo University Hospital, Norway (openEHR Editor)", "Silje Ljosland Bakke, Nasjonal IKT HF, Norway (openEHR Editor)", "SB Bhattacharyya, Sudisa Consultancy Services, India", "Lisbeth Dahlhaug, Helse Midt - Norge IT, Norway", "Shahla Foozonkhah, Iran ministry of health and education, Iran", "Hildegard Franke, freshEHR Clinical Informatics Ltd., United Kingdom (openEHR Editor)", "Mikkel Gaup Grønmo, FSE, Helse Nord, Norway (Nasjonal IKT redaktør)", "Ingrid Heitmann, Oslo universitetssykehus HF, Norway", "Hilde Hollås, DIPS ASA, Norway", "Evelyn Hovenga, EJSH Consulting, Australia", "Lars Ivar Mehlum, Helse Bergen HF, Norway", "Sabine Leh, Haukeland University Hospital, Department of Pathology, Norway", "Heather Leslie, Atomica Informatics, Australia (openEHR Editor)", "Ian McNicoll, freshEHR Clinical Informatics, United Kingdom", "Lars Morgan Karlsen, DIPS ASA, Norway", "Bjørn Næss, DIPS ASA, Norway", "Andrej Orel, Marand d.o.o., Slovenia", "Vladimir Pizzo, Hospital Sírio Libanês, Brazil", "Jussara Rotzsch, UNB, Brazil", "Anoop Shah, University College London, United Kingdom", "Line Silsand, Universitetssykehuset i Nord-Norge, Norway", "Norwegian Review Summary, Nasjonal IKT HF, Norway", "Nyree Taylor, Ocean Informatics, Australia (openEHR Editor)", "Rowan Thomas, St. Vincent's Hospital Melbourne, Australia", "Jon Tysdahl, Furst medlab AS, Norway", "John Tore Valand, Helse Bergen, Norway (openEHR Editor)">
+	other_details = <
+		["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.">
+		["custodian_organisation"] = <"openEHR Foundation">
+		["current_contact"] = <"Heather Leslie, Atomica Informatics, Australia<heather.leslie@atomicainformatics.com>">
+		["original_namespace"] = <"org.openehr">
+		["original_publisher"] = <"openEHR Foundation">
+		["custodian_namespace"] = <"org.openehr">
+		["MD5-CAM-1.0.1"] = <"355409551F411079900E4744B677B74E">
+		["build_uid"] = <"837261fa-d6a9-441c-b85b-3e1e33aae00d">
+		["ip_acknowledgements"] = <"This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyrighted material of the International Health Terminology Standards Development Organisation (IHTSDO). Where an implementation of this artefact makes use of SNOMED CT content, the implementer must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/get-snomedct or info@snomed.org.">
+		["revision"] = <"0.0.1-alpha">
+	>
+
+definition
+	CLUSTER[at0000.1] matches {    -- Examination of the abdomen
+		items cardinality matches {1..*; unordered} matches {
+			ELEMENT[at0001.1] matches {    -- System or structure examined
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0012] occurrences matches {0..1} matches {    -- Body site
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			allow_archetype CLUSTER[at0011] occurrences matches {0..*} matches {    -- Structured body site
+				include
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.anatomical_location(-[a-zA-Z0-9_]+)*\.v1|openEHR-EHR-CLUSTER\.anatomical_location_circle(-[a-zA-Z0-9_]+)*\.v1|openEHR-EHR-CLUSTER\.anatomical_location_relative(-[a-zA-Z0-9_]+)*\.v2/}
+			}
+			ELEMENT[at0003] occurrences matches {0..1} matches {    -- Clinical description
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			allow_archetype CLUSTER[at0004.1] occurrences matches {0..*} matches {    -- Examination findings
+				include
+					archetype_id/value matches {/.*/}
+			}
+			allow_archetype CLUSTER[at0005] occurrences matches {0..*} matches {    -- Multimedia representation
+				include
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.media_file(-[a-zA-Z0-9_]+)*\.v1/}
+			}
+			ELEMENT[at0006] occurrences matches {0..*} matches {    -- Clinical interpretation
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0007] occurrences matches {0..1} matches {    -- Comment
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			allow_archetype CLUSTER[at0008] occurrences matches {0..*} matches {    -- Examination not done
+				include
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.exclusion_exam(-[a-zA-Z0-9_]+)*\.v1/}
+			}
+		}
+	}
+
+
+ontology
+	terminologies_available = <"SNOMED-CT", ...>
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000.1"] = <
+					text = <"Examination of the abdomen">
+					description = <"Findings observed during the physical examination of the abdomen.">
+				>
+				["at0001.1"] = <
+					text = <"System or structure examined">
+					description = <"Identification of the examined body system or anatomical structure.">
+					comment = <"For example: the very generic term \"skin\", which will likely require additional qualification using one of the 'Body site' data elements, or the complete phrase \"skin of right knee\". Coding of the system or structure examined with a terminology is preferred, where possible.">
+				>
+				["at0004.1"] = <
+					text = <"Examination findings">
+					description = <"Structured details about the physical examination findings.">
+				>
+				["at0000"] = <
+					text = <"Physical examination findings">
+					description = <"Findings observed during the physical examination of a body system or anatomical structure.">
+				>
+				["at0001"] = <
+					text = <"System or structure examined">
+					description = <"Identification of the examined body system or anatomical structure.">
+					comment = <"Coding of the system or structure examined with a terminology is preferred, where possible.">
+				>
+				["at0003"] = <
+					text = <"Clinical description">
+					description = <"Narrative description of the overall findings observed during the physical examination.">
+				>
+				["at0004"] = <
+					text = <"Examination findings">
+					description = <"Structured details about the physical examination findings.">
+				>
+				["at0005"] = <
+					text = <"Multimedia representation">
+					description = <"Digital image, video or diagram representing the physical examination findings.">
+				>
+				["at0006"] = <
+					text = <"Clinical interpretation">
+					description = <"Single word, phrase or brief description that represents the clinical meaning and significance of the physical examination findings.">
+					comment = <"For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible.">
+				>
+				["at0007"] = <
+					text = <"Comment">
+					description = <"Additional narrative about the physical examination findings, not captured in other fields.">
+				>
+				["at0008"] = <
+					text = <"Examination not done">
+					description = <"Details to explicitly record that this examination was not performed.">
+				>
+				["at0011"] = <
+					text = <"Structured body site">
+					description = <"A structured description of the area of the body under examination.">
+					comment = <"If the body site has been fully identified in the 'System or structure examined' or the 'Body site' data element, this SLOT becomes redundant.">
+				>
+				["at0012"] = <
+					text = <"Body site">
+					description = <"Identification of the area of the body under examination.">
+					comment = <"For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant.">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["at0000.1"] = <
+					text = <"*Examination of the abdomen (en)">
+					description = <"Funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+				>
+				["at0001.1"] = <
+					text = <"Undersøkt organsystem eller struktur">
+					description = <"Identifisering av det undersøkte organsystemet eller anatomiske strukturen.">
+					comment = <"For eksempel den generiske termen \"Hud\" - som mest sannsynlig vil trenge en ytterligere spesifikasjon ved å benytte dataelementet \"Anatomisk lokalisasjon\", eller en fullstendig frase, som \"Hud på høyre kne\". Det er anbefalt å kode det undersøkte systemet eller strukturen med en terminologi, der det er mulig.">
+				>
+				["at0004.1"] = <
+					text = <"Spesifikke funn">
+					description = <"Ytterligere strukturerte detaljer om undersøkelsesfunnene.">
+				>
+				["at0000"] = <
+					text = <"Funn ved fysisk undersøkelse">
+					description = <"Undersøkelsesfunn gjort ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+				>
+				["at0001"] = <
+					text = <"Undersøkt organsystem eller struktur">
+					description = <"Identifisering av det undersøkte organsystemet eller den anatomiske strukturen.">
+					comment = <"Det anbefales å kode organsystem eller den anatomiske strukturen med en terminologi dersom mulig.">
+				>
+				["at0003"] = <
+					text = <"Klinisk beskrivelse">
+					description = <"Fritekstbeskrivelse av de overordnede funnene ved den fysiske undersøkelsen.">
+				>
+				["at0004"] = <
+					text = <"Spesifikke funn">
+					description = <"Ytterligere strukturerte detaljer om undersøkelsesfunnene.">
+				>
+				["at0005"] = <
+					text = <"Multimediarepresentasjon">
+					description = <"Digitale bilder, video eller diagram som representerer undersøkelsesfunnene.">
+				>
+				["at0006"] = <
+					text = <"Fortolkning">
+					description = <"Enkelt ord, setning, frase eller kort beskrivelse som representerer den kliniske betydning og viktigheten av funnene ved den fysiske undersøkelsen.">
+					comment = <"For eksempel \"Uten anmerkning\" eller \"Moderat inflammasjon\". Det anbefales å kode \"Fortolkning\" med en terminologi dersom mulig.">
+				>
+				["at0007"] = <
+					text = <"Kommentar">
+					description = <"Ytterligere fritekst om funn ved undersøkelsen, som ikke dekkes av andre elementer.">
+				>
+				["at0008"] = <
+					text = <"Undersøkelse ikke utført">
+					description = <"Detaljer for å eksplisitt registrere at denne undersøkelsen ikke ble utført.">
+				>
+				["at0011"] = <
+					text = <"Strukturert anatomisk lokalisasjon">
+					description = <"Angivelse av en strukturert anatomisk lokalisering av det undersøkte organsystemet eller den anatomiske strukturen.">
+					comment = <"Hvis anatomisk lokalisasjon er entydig identifisert i elementet \"Undersøkt organsystem eller struktur\" er dette SLOT'et ikke nødvendig å benytte.">
+				>
+				["at0012"] = <
+					text = <"Anatomisk lokalisasjon">
+					description = <"Identifisering av et enkelt fysisk sted enten på eller i menneskekroppen.">
+					comment = <"For eksempel undersøkelse av et spesifikt område på huden. Dersom den anatomiske lokaliseringen allerede er identifisert i elementet \"Undersøkt organsystem eller struktur\" er dette dataelementet overflødig.">
+				>
+			>
+		>
+		["pt-br"] = <
+			items = <
+				["at0000.1"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Constatações observadas durante o exame físico de um sistema corporal ou estrutura anatômica.">
+				>
+				["at0001.1"] = <
+					text = <"Sistema ou estrutura examinada">
+					description = <"Identificação do sistema do corpo examinado ou da estrutura anatômica.">
+					comment = <"A codificação do sistema ou estrutura examinada com uma terminologia é preferível, sempre que possível.">
+				>
+				["at0004.1"] = <
+					text = <"Resultados do exame">
+					description = <"Detalhes estruturados sobre os resultados do exame físico.">
+				>
+				["at0000"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Constatações observadas durante o exame físico de um sistema corporal ou estrutura anatômica.">
+				>
+				["at0001"] = <
+					text = <"Sistema ou estrutura examinada">
+					description = <"Identificação do sistema do corpo examinado ou da estrutura anatômica.">
+					comment = <"A codificação do sistema ou estrutura examinada com uma terminologia é preferível, sempre que possível.">
+				>
+				["at0003"] = <
+					text = <"Descrição clínica">
+					description = <"Descrição narrativa dos achados gerais observados durante o exame físico.">
+				>
+				["at0004"] = <
+					text = <"Resultados do exame">
+					description = <"Detalhes estruturados sobre os resultados do exame físico.">
+				>
+				["at0005"] = <
+					text = <"Representação multimídia">
+					description = <"Imagem digital, vídeo ou diagrama representando os achados do exame físico.">
+				>
+				["at0006"] = <
+					text = <"Interpretação clínica">
+					description = <"Palavra, frase ou breve descrição que represente o significado clínico e o significado dos resultados do exame físico.">
+					comment = <"*For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible. (en)">
+				>
+				["at0007"] = <
+					text = <"Comentário">
+					description = <"Narrativa adicional sobre os achados do exame físico, não capturados em outros campos.">
+				>
+				["at0008"] = <
+					text = <"Exame não realizado">
+					description = <"Detalhes para registrar explicitamente que esse exame não foi realizado.">
+				>
+				["at0011"] = <
+					text = <"Local do corpo estruturado">
+					description = <"Uma descrição estruturada da área do corpo em exame.">
+					comment = <"Se o local do corpo tiver sido totalmente identificado no elemento de dados 'Sistema ou estrutura examinada' ou 'Local do corpo', esse SLOT se tornará redundante.">
+				>
+				["at0012"] = <
+					text = <"Local do corpo">
+					description = <"*Identification of the area of the body under examination. (en)">
+					comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+				>
+			>
+		>
+		["de"] = <
+			items = <
+				["at0000.1"] = <
+					text = <"Ergebnisse der körperlichen Untersuchung">
+					description = <"Während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachtete Befunde.">
+				>
+				["at0001.1"] = <
+					text = <"Untersuchtes System oder untersuchte Struktur">
+					description = <"Identifizierung des untersuchten Körpersystems oder der anatomischen Struktur.">
+					comment = <"Wenn möglich wird die Kodierung des untersuchten Systems oder der untersuchten Struktur mit einer Terminologie bevorzugt.">
+				>
+				["at0004.1"] = <
+					text = <"Untersuchungsergebnisse">
+					description = <"Strukturierte Angaben zu den Ergebnissen der körperlichen Untersuchung.">
+				>
+				["at0000"] = <
+					text = <"Ergebnisse der körperlichen Untersuchung">
+					description = <"Während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachtete Befunde.">
+				>
+				["at0001"] = <
+					text = <"Untersuchtes System oder untersuchte Struktur">
+					description = <"Identifizierung des untersuchten Körpersystems oder der anatomischen Struktur.">
+					comment = <"Wenn möglich wird die Kodierung des untersuchten Systems oder der untersuchten Struktur mit einer Terminologie bevorzugt.">
+				>
+				["at0003"] = <
+					text = <"Klinische Beschreibung">
+					description = <"Beschreibung der bei der körperlichen Untersuchung beobachteten Gesamtbefunde.">
+				>
+				["at0004"] = <
+					text = <"Untersuchungsergebnisse">
+					description = <"Strukturierte Angaben zu den Ergebnissen der körperlichen Untersuchung.">
+				>
+				["at0005"] = <
+					text = <"Multimediale Darstellung">
+					description = <"Digitales Bild, Video oder Diagramm, das die Ergebnisse der körperlichen Untersuchung darstellt.">
+				>
+				["at0006"] = <
+					text = <"Klinische Interpretation">
+					description = <"Ein einzelnes Wort, eine Phrase oder eine kurze Beschreibung, die die klinische Bedeutung und Wichtigkeit der Untersuchungsergebnisse darstellt.">
+					comment = <"Zum Beispiel: „Ohne Befund“ oder „Mäßige Entzündung vorhanden“. Wenn möglich, wird die Codierung der „Klinischen Interpretation“ mit einer Terminologie bevorzugt.">
+				>
+				["at0007"] = <
+					text = <"Kommentar">
+					description = <"Zusätzliche Beschreibung der Ergebnisse der körperlichen Untersuchung, die in anderen Bereichen nicht erfasst werden konnten.">
+				>
+				["at0008"] = <
+					text = <"Nicht durchgeführte Untersuchung">
+					description = <"Eine Aussage die ausdrücklich erfasst, dass die Untersuchung nicht durchgeführt wurde.">
+				>
+				["at0011"] = <
+					text = <"Strukturierte Körperstelle">
+					description = <"Eine strukturierte Beschreibung des zu untersuchenden Körperbereichs.">
+					comment = <"Wenn die Körperstelle im Datenelement \"Untersuchtes System oder untersuchte Struktur\" oder im Datenelement \"Körperstelle\" vollständig identifiziert wurde, wird die Verwendung dieses SLOT überflüssig.">
+				>
+				["at0012"] = <
+					text = <"Körperstelle">
+					description = <"Identifizierung des untersuchten Körperbereichs.">
+					comment = <"Zum Beispiel die Untersuchung einer bestimmten Hautpartie. Wenn die Körperstelle im Datenelement „Untersuchtes System oder Struktur“ vollständig identifiziert wurde, wird dieses Datenelement überflüssig.">
+				>
+			>
+		>
+		["sv"] = <
+			items = <
+				["at0000.1"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Observerade fynd vid fysisk undersökning av system i kroppen, eller av anatomisk struktur">
+				>
+				["at0001.1"] = <
+					text = <"System eller struktur som undersökts">
+					description = <"Identifiering av systemet eller strukturen som undersökts.">
+					comment = <"Om möjligt, koda systemet eller strukturen med hjälp av ett terminologisystem.">
+				>
+				["at0004.1"] = <
+					text = <"Fynd vid undersökning">
+					description = <"Strukturerade detaljer om fynd vid den fysiska undersökningen.">
+				>
+				["at0000"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Observerade fynd vid fysisk undersökning av system i kroppen, eller av anatomisk struktur">
+				>
+				["at0001"] = <
+					text = <"System eller struktur som undersökts">
+					description = <"Identifiering av systemet eller strukturen som undersökts.">
+					comment = <"Om möjligt, koda systemet eller strukturen med hjälp av ett terminologisystem.">
+				>
+				["at0003"] = <
+					text = <"Klinisk beskrivning">
+					description = <"En övergripande beskrivning av fynden från den fysiska undersökningen. ">
+				>
+				["at0004"] = <
+					text = <"Fynd vid undersökning">
+					description = <"Strukturerade detaljer om fynd vid den fysiska undersökningen.">
+				>
+				["at0005"] = <
+					text = <"Multimedia-representation">
+					description = <"Digital bild, video eller diagram som återger fynd från undersökningen.">
+				>
+				["at0006"] = <
+					text = <"Klinisk tolkning">
+					description = <"Ord, fras eller kort beskrivning av fyndens kliniska betydelse.">
+					comment = <"*For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible. (en)">
+				>
+				["at0007"] = <
+					text = <"Kommentar">
+					description = <"Kommentarer avseende undersökningsfynd som inte beskrivs i övriga fält.">
+				>
+				["at0008"] = <
+					text = <"Undersökning ej genomförd">
+					description = <"Detaljerad beskrivning om att undersökningen inte genomfördes.">
+				>
+				["at0011"] = <
+					text = <"Strukturerad anatomisk plats">
+					description = <"Strukturerad beskrivning av den anatomiska platsen som undersökts.">
+					comment = <"Om den anatomiska platsen kan identifieras helt via dataelementet \"System eller struktur som undersökts\" så blir denna del redundant.">
+				>
+				["at0012"] = <
+					text = <"Anatomisk plats">
+					description = <"*Identification of the area of the body under examination. (en)">
+					comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+				>
+			>
+		>
+		["el"] = <
+			items = <
+				["at0000.1"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Ευρήματα που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+				>
+				["at0001.1"] = <
+					text = <"Εξεταζόμενο σύστημα ή δομή">
+					description = <"Ταυτοποίηση του εξεταζόμενου συστήματος σώματος ή ανατομικής δομής.">
+					comment = <"Προτιμάται η κωδικοποίηση του συστήματος ή της δομής που εξετάζεται με ορολογία, όπου είναι δυνατόν.">
+				>
+				["at0004.1"] = <
+					text = <"Ευρήματα εξέτασης">
+					description = <"Δομημένες λεπτομέρειες σχετικά με τα ευρήματα της φυσικής εξέτασης.">
+				>
+				["at0000"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Ευρήματα που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+				>
+				["at0001"] = <
+					text = <"Εξεταζόμενο σύστημα ή δομή">
+					description = <"Ταυτοποίηση του εξεταζόμενου συστήματος σώματος ή ανατομικής δομής.">
+					comment = <"Προτιμάται η κωδικοποίηση του συστήματος ή της δομής που εξετάζεται με ορολογία, όπου είναι δυνατόν.">
+				>
+				["at0003"] = <
+					text = <"Κλινική Περιγραφή">
+					description = <"Αφηγηματική περιγραφή των συνολικών ευρημάτων που παρατηρήθηκαν κατά τη διάρκεια της φυσικής εξέτασης.">
+				>
+				["at0004"] = <
+					text = <"Ευρήματα εξέτασης">
+					description = <"Δομημένες λεπτομέρειες σχετικά με τα ευρήματα της φυσικής εξέτασης.">
+				>
+				["at0005"] = <
+					text = <"Αναπαράσταση πολυμέσων">
+					description = <"Ψηφιακή εικόνα, βίντεο ή διάγραμμα που αναπαριστά τα ευρήματα της φυσικής εξέτασης.">
+				>
+				["at0006"] = <
+					text = <"Κλινική αξιολόγηση">
+					description = <"Μία λέξη, φράση ή σύντομη περιγραφή που αντιπροσωπεύει την κλινική σημασία και σημασία των ευρημάτων της φυσικής εξέτασης.">
+					comment = <"Για παράδειγμα: «Δεν ανιχνεύθηκε ανωμαλία» ή «Υπάρχει μέτρια φλεγμονή». Προτιμάται η κωδικοποίηση της «κλινικής ερμηνείας» με ορολογία, όπου είναι δυνατόν.">
+				>
+				["at0007"] = <
+					text = <"Σχόλιο">
+					description = <"Πρόσθετη αφήγηση σχετικά με τα ευρήματα της φυσικής εξέτασης, που δεν αποτυπώνεται σε άλλους τομείς.">
+				>
+				["at0008"] = <
+					text = <"Λόγος διακοπής εξέτασης">
+					description = <"Λεπτομέρειες για να καταγραφεί ρητά ότι αυτή η εξέταση δεν διενεργήθηκε.">
+				>
+				["at0011"] = <
+					text = <"ω">
+					description = <"περιγραφή της περιοχής του υπό εξέταση σώματος.">
+					comment = <"*If the body site has been fully identified in the 'System or structure examined' or the 'Body site' data element, this SLOT becomes redundant.(en)">
+				>
+				["at0012"] = <
+					text = <"Περιοχή σώματος">
+					description = <"*Identification of the area of the body under examination. (en)">
+					comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+				>
+			>
+		>
+		["es"] = <
+			items = <
+				["at0000.1"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"*Findings observed during the physical examination of a body system or anatomical structure.(en)">
+				>
+				["at0001.1"] = <
+					text = <"*System or structure examined(en)">
+					description = <"*Identification of the examined body system or anatomical structure.(en)">
+					comment = <"*Coding of the system or structure examined with a terminology is preferred, where possible.(en)">
+				>
+				["at0004.1"] = <
+					text = <"*Examination findings(en)">
+					description = <"*Structured details about the physical examination findings.(en)">
+				>
+				["at0000"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"*Findings observed during the physical examination of a body system or anatomical structure.(en)">
+				>
+				["at0001"] = <
+					text = <"*System or structure examined(en)">
+					description = <"*Identification of the examined body system or anatomical structure.(en)">
+					comment = <"*Coding of the system or structure examined with a terminology is preferred, where possible.(en)">
+				>
+				["at0003"] = <
+					text = <"*Clinical description(en)">
+					description = <"*Narrative description of the overall findings observed during the physical examination.(en)">
+				>
+				["at0004"] = <
+					text = <"*Examination findings(en)">
+					description = <"*Structured details about the physical examination findings.(en)">
+				>
+				["at0005"] = <
+					text = <"*Multimedia representation(en)">
+					description = <"*Digital image, video or diagram representing the physical examination findings.(en)">
+				>
+				["at0006"] = <
+					text = <"*Clinical interpretation(en)">
+					description = <"*Single word, phrase or brief description that represents the clinical meaning and significance of the physical examination findings.(en)">
+					comment = <"*For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible.(en)">
+				>
+				["at0007"] = <
+					text = <"*Comment(en)">
+					description = <"*Additional narrative about the physical examination findings, not captured in other fields.(en)">
+				>
+				["at0008"] = <
+					text = <"*Examination not done(en)">
+					description = <"*Details to explicitly record that this examination was not performed.(en)">
+				>
+				["at0011"] = <
+					text = <"*Structured body site(en)">
+					description = <"*A structured description of the area of the body under examination.(en)">
+					comment = <"*If the body site has been fully identified in the 'System or structure examined' or the 'Body site' data element, this SLOT becomes redundant.(en)">
+				>
+				["at0012"] = <
+					text = <"*Body site(en)">
+					description = <"*Identification of the area of the body under examination. (en)">
+					comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+				>
+			>
+		>
+	>

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam-abdomen_adl2_id.v0.0.1-alpha.adls
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam-abdomen_adl2_id.v0.0.1-alpha.adls
@@ -1,0 +1,323 @@
+archetype (adl_version=2.0.6; rm_release=1.1.0; generated; uid=a965a5e8-12a6-471c-8a8e-98dfb8aa9f1f; build_uid=837261fa-d6a9-441c-b85b-3e1e33aae00d)
+    openEHR-EHR-CLUSTER.exam-abdomen.v0.0.1-alpha
+
+specialize
+    openEHR-EHR-CLUSTER.exam.v2
+
+language
+    original_language = <[ISO_639-1::en]>
+    translations = <
+        ["de"] = <
+            language = <[ISO_639-1::de]>
+            author = <
+                ["name"] = <"Nina Schewe, Natalia Strauch, Darin Leonhardt">
+                ["organisation"] = <"Medizinische Hochschule Hannover, PLRI für medizinische Informatik/ Medizinische Hochschule">
+                ["email"] = <"schewe.nina@mh-hannover.de, Strauch.Natalia@mh-hannover.de, leonhardt.darin@mh-hannover.de">
+            >
+        >
+        ["sv"] = <
+            language = <[ISO_639-1::sv]>
+            author = <
+                ["name"] = <"Erik Sundvall">
+                ["organisation"] = <"Region Östergötland + Linköping University">
+                ["email"] = <"erik.sundvall@regionostergotland.se">
+            >
+        >
+        ["nb"] = <
+            language = <[ISO_639-1::nb]>
+            author = <
+                ["name"] = <"Silje Ljosland Bakke">
+                ["organisation"] = <"Nasjonal IKT HF">
+            >
+        >
+        ["pt-br"] = <
+            language = <[ISO_639-1::pt-br]>
+            author = <
+                ["name"] = <"Adriana Kitajima">
+                ["organisation"] = <"Hospital Alemão Oswaldo Cruz - HAOC">
+                ["email"] = <"adrianakitajima@gmail.com">
+            >
+        >
+        ["el"] = <
+            language = <[ISO_639-1::el]>
+            author = <
+                ["name"] = <"Erasmia Partafylla">
+                ["organisation"] = <"Sigmasoft">
+                ["email"] = <"c.partafylla@sigmasoft.gr">
+            >
+        >
+        ["es"] = <
+            language = <[ISO_639-1::es]>
+            author = <
+                ["name"] = <"Julio de Sosa">
+                ["organisation"] = <"Servei Català de la Salut">
+                ["email"] = <"juliodesosa@catsalut.cat">
+            >
+        >
+    >
+
+description
+    original_author = <
+        ["name"] = <"Heather Leslie">
+        ["organisation"] = <"Atomica Informatics">
+        ["email"] = <"heather.leslie@atomicainformatics.com">
+        ["date"] = <"2015-06-22">
+    >
+    original_namespace = <"org.openehr">
+    original_publisher = <"openEHR Foundation">
+    other_contributors = <"Vebjørn Arntzen, Oslo University Hospital, Norway (openEHR Editor)", "Silje Ljosland Bakke, Nasjonal IKT HF, Norway (openEHR Editor)", "SB Bhattacharyya, Sudisa Consultancy Services, India", "Lisbeth Dahlhaug, Helse Midt - Norge IT, Norway", "Shahla Foozonkhah, Iran ministry of health and education, Iran", "Hildegard Franke, freshEHR Clinical Informatics Ltd., United Kingdom (openEHR Editor)", "Mikkel Gaup Grønmo, FSE, Helse Nord, Norway (Nasjonal IKT redaktør)", "Ingrid Heitmann, Oslo universitetssykehus HF, Norway", "Hilde Hollås, DIPS ASA, Norway", "Evelyn Hovenga, EJSH Consulting, Australia", "Lars Ivar Mehlum, Helse Bergen HF, Norway", "Sabine Leh, Haukeland University Hospital, Department of Pathology, Norway", "Heather Leslie, Atomica Informatics, Australia (openEHR Editor)", "Ian McNicoll, freshEHR Clinical Informatics, United Kingdom", "Lars Morgan Karlsen, DIPS ASA, Norway", "Bjørn Næss, DIPS ASA, Norway", "Andrej Orel, Marand d.o.o., Slovenia", "Vladimir Pizzo, Hospital Sírio Libanês, Brazil", "Jussara Rotzsch, UNB, Brazil", "Anoop Shah, University College London, United Kingdom", "Line Silsand, Universitetssykehuset i Nord-Norge, Norway", "Norwegian Review Summary, Nasjonal IKT HF, Norway", "Nyree Taylor, Ocean Informatics, Australia (openEHR Editor)", "Rowan Thomas, St. Vincent's Hospital Melbourne, Australia", "Jon Tysdahl, Furst medlab AS, Norway", "John Tore Valand, Helse Bergen, Norway (openEHR Editor)">
+    lifecycle_state = <"in_development">
+    custodian_namespace = <"org.openehr">
+    custodian_organisation = <"openEHR Foundation">
+    licence = <"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.">
+    ip_acknowledgements = <
+        ["1"] = <"This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyrighted material of the International Health Terminology Standards Development Organisation (IHTSDO). Where an implementation of this artefact makes use of SNOMED CT content, the implementer must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/get-snomedct or info@snomed.org.">
+    >
+    other_details = <
+        ["current_contact"] = <"Heather Leslie, Atomica Informatics, Australia<heather.leslie@atomicainformatics.com>">
+        ["MD5-CAM-1.0.1"] = <"355409551F411079900E4744B677B74E">
+    >
+    details = <
+        ["de"] = <
+            language = <[ISO_639-1::de]>
+            purpose = <"Aufzeichnung der bei der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachteten Befunde.">
+            use = <"Zur Aufzeichnung der beobachteten Befunde während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur.
+
+Dieser Archetyp wurde speziell für die Verwendung im SLOT „Untersuchungsdetails“ innerhalb des Archetyps OBSERVATION.exam oder im SLOT „Verfahrensdetails“ innerhalb des Archetyps ACTION.procedure entwickelt, kann aber auch innerhalb anderer Archetypen ENTRY oder CLUSTER verwendet werden, sofern dies klinisch sinnvoll ist. Spezialisierungen dieses Archetyps werden verwendet, um Untersuchungsergebnisse für bestimmte Körpersysteme, anatomische Strukturen oder genauere Körperstellen zu erfassen. Jede Spezialisierung behält die Grundstruktur dieses allgemeinen Archetyps als Basis bei und wird durch die Hinzufügung von Elementen erweitert, die für die Körperstelle spezifisch sind. Steht keine geeignete Spezialisierung zur Verfügung, ist dieser Archetyp zu verwenden und das untersuchte System oder die untersuchte Struktur mit dem Datenelement „System oder untersuchte Struktur“ und die Körperstelle mit dem Datenelement „Körperstelle“ oder dem SLOT „Strukturierte Körperstelle“ anzugeben.
+
+Die Interpretation der Befunde, z. B. „Keine Abnormität festgestellt“ oder „Mäßige Entzündung vorhanden“, kann mit dem Datenelement „Klinische Interpretation“ erfasst werden.
+
+Verwendung zur Bereitstellung eines Rahmens, in dem CLUSTER-Archetypen im SLOT „Untersuchungsbefund“ verschachtelt werden können, um zusätzliche strukturierte körperliche Untersuchungsbefunde zu erfassen.
+
+Der Archetyp CLUSTER.exclusion_exam kann in den SLOT „Nicht durchgeführte Untersuchung“ geschachtelt werden, um optional explizite Details über die nicht durchgeführte Untersuchung zu erfassen.
+
+Verwenden Sie das Datenelement „Klinische Beschreibung“, um die narrativen Beschreibungen klinischer Befunde innerhalb bestehender oder vorhandener klinischer Systeme in ein archetypisches Format einzubinden.">
+            misuse = <"Nicht zur Darstellung der klinischen Anamnese zu verwenden – verwenden Sie spezifische OBSERVATION- und CLUSTER-Archetypen. Zum Beispiel OBSERVATION.story und CLUSTER.symptom_sign.
+
+Nicht zur Darstellung der Ergebnisse einer bildgebenden Untersuchung verwenden – verwenden Sie für diesen Zweck die Archetypenfamilie CLUSTER.imaging_exam.">
+        >
+        ["sv"] = <
+            language = <[ISO_639-1::sv]>
+            purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+            keywords = <"fynd, undersökningsfynd, fysisk undersökning, u.a., utan anmärkning", ...>
+            use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+            misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+        >
+        ["nb"] = <
+            language = <[ISO_639-1::nb]>
+            purpose = <"For å registrere en fritekstbeskrivelse og klinisk tolkning av observerte funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+            use = <"Brukes til å registrere en fritekstbeskrivelse og klinisk tolkning av observerte funn ved fysisk undersøkelse av et spesifisert organsystem eller anatomisk struktur. Denne arketypen består kun av kjerneelementene av mønsteret for undersøkelser, og kan utvides ved hjelp av andre CLUSTER-arketyper eller brukes som grunnlag for undersøkelsesarketyper for spesifikke kroppssystemer eller anatomiske strukturer.
+
+Eksempler på detaljer som kan beskrives ved hjelp av dette CLUSTER er inspeksjon, palpasjon, auskultasjon, perkusjon og bevegelser i kroppssystemer eller anatomiske strukturer. Undersøkelsen kan støttes av enkle hjelpemidler som stetoskop, otoskop eller reflekshammer. Også funn ved mer avanserte undersøkelser kan registreres her, som ved endoskopi. I de tilfellene vil informasjon om hvilket hjelpemiddel eller utstyr brukt bli registrert i OBSERVATION.exam, elementet \"Detaljer om medisinsk utstyr\", i ACTION.procedure \"Prosedyredetaljer\" eller tilsvarende i egnet ENTRY- eller ACTION-arketype.
+
+Arketypen er laget spesifikt for å brukes i \"Undersøkelsesdetaljer\"-SLOTet i arketypen OBSERVATION.exam, men kan også brukes innen andre ENTRY- og CLUSTER-arketyper der det er klinisk passende.
+
+Denne arketypen kan benyttes for alle typer undersøkelser, alt fra enkle undersøkelser som undersøkelse av et hudområde, inspeksjon av ører og til artroskopi av et kne.
+
+Kan for eksempel nøstes i SLOTet \"Undersøkelsesdetaljer\" i arketypen OBSERVATION.exam (Norsk Funn ved fysisk undersøkelse) for å registrere ytterligere strukturerte funn ved fysiske undersøkelser.
+
+Arketypen CLUSTER.exclusion_exam kan nøstes i SLOTet \"Undersøkelse ikke utført\" der en har behov for å registrere informasjon om at en undersøkelse ikke ble utført.
+
+Brukes for å videreføre fritekstbeskrivelser av kliniske funn fra tidligere systemer inn i et arketypeformat, ved å bruke elementet \"Klinisk beskrivelse\".">
+            misuse = <"Skal ikke brukes til å ta opp frittstående klinisk observasjoner eller testresultater - bruk spesifikke OBSERVATION arketyper, for eksempel OBSERVATION.head_circumference eller OBSERVATION.glasgow_coma_scale.
+
+Skal ikke brukes til å ta opp anamnese - bruk da spesifikke OBSERVATION og CLUSTER arketyper. For eksempel OBSERVATION.story og CLUSTER.symptom_sign.">
+        >
+        ["pt-br"] = <
+            language = <[ISO_639-1::pt-br]>
+            purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+            use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+            misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+        >
+        ["el"] = <
+            language = <[ISO_639-1::el]>
+            purpose = <"Για την καταγραφή των ευρημάτων που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+            use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+            misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.(en)">
+        >
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"To record a narrative description and clinical interpretation of the findings observed during the physical examination of the abdomen.">
+            use = <"Use to record a narrative description and clinical interpretation of the findings observed during the physical examination of the abdomen.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element.">
+            misuse = <"Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.">
+            copyright = <"© openEHR Foundation">
+        >
+        ["es"] = <
+            language = <[ISO_639-1::es]>
+            purpose = <"Registrar los hallazgos observados durante la exploración física de un sistema corporal o una estructura anatómica.">
+            use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+            misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.(en)">
+        >
+    >
+
+definition
+    CLUSTER[id1.1] matches {    -- Examination of the abdomen
+        items matches {
+            ELEMENT[id2.1]    -- System or structure examined
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["de"] = <
+            ["id1.1"] = <
+                text = <"Ergebnisse der körperlichen Untersuchung">
+                description = <"Während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachtete Befunde.">
+            >
+            ["id2.1"] = <
+                text = <"Untersuchtes System oder untersuchte Struktur">
+                description = <"Identifizierung des untersuchten Körpersystems oder der anatomischen Struktur.">
+                comment = <"Wenn möglich wird die Kodierung des untersuchten Systems oder der untersuchten Struktur mit einer Terminologie bevorzugt.">
+            >
+            ["id5.1"] = <
+                text = <"Untersuchungsergebnisse">
+                description = <"Strukturierte Angaben zu den Ergebnissen der körperlichen Untersuchung.">
+            >
+        >
+        ["sv"] = <
+            ["id1.1"] = <
+                text = <"*Physical examination findings (en)">
+                description = <"Observerade fynd vid fysisk undersökning av system i kroppen, eller av anatomisk struktur">
+            >
+            ["id2.1"] = <
+                text = <"System eller struktur som undersökts">
+                description = <"Identifiering av systemet eller strukturen som undersökts.">
+                comment = <"Om möjligt, koda systemet eller strukturen med hjälp av ett terminologisystem.">
+            >
+            ["id5.1"] = <
+                text = <"Fynd vid undersökning">
+                description = <"Strukturerade detaljer om fynd vid den fysiska undersökningen.">
+            >
+        >
+        ["nb"] = <
+            ["id1.1"] = <
+                text = <"*Examination of the abdomen (en)">
+                description = <"Funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+            >
+            ["id2.1"] = <
+                text = <"Undersøkt organsystem eller struktur">
+                description = <"Identifisering av det undersøkte organsystemet eller anatomiske strukturen.">
+                comment = <"For eksempel den generiske termen \"Hud\" - som mest sannsynlig vil trenge en ytterligere spesifikasjon ved å benytte dataelementet \"Anatomisk lokalisasjon\", eller en fullstendig frase, som \"Hud på høyre kne\". Det er anbefalt å kode det undersøkte systemet eller strukturen med en terminologi, der det er mulig.">
+            >
+            ["id5.1"] = <
+                text = <"Spesifikke funn">
+                description = <"Ytterligere strukturerte detaljer om undersøkelsesfunnene.">
+            >
+        >
+        ["pt-br"] = <
+            ["id1.1"] = <
+                text = <"*Physical examination findings (en)">
+                description = <"Constatações observadas durante o exame físico de um sistema corporal ou estrutura anatômica.">
+            >
+            ["id2.1"] = <
+                text = <"Sistema ou estrutura examinada">
+                description = <"Identificação do sistema do corpo examinado ou da estrutura anatômica.">
+                comment = <"A codificação do sistema ou estrutura examinada com uma terminologia é preferível, sempre que possível.">
+            >
+            ["id5.1"] = <
+                text = <"Resultados do exame">
+                description = <"Detalhes estruturados sobre os resultados do exame físico.">
+            >
+        >
+        ["el"] = <
+            ["id1.1"] = <
+                text = <"*Physical examination findings (en)">
+                description = <"Ευρήματα που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+            >
+            ["id2.1"] = <
+                text = <"Εξεταζόμενο σύστημα ή δομή">
+                description = <"Ταυτοποίηση του εξεταζόμενου συστήματος σώματος ή ανατομικής δομής.">
+                comment = <"Προτιμάται η κωδικοποίηση του συστήματος ή της δομής που εξετάζεται με ορολογία, όπου είναι δυνατόν.">
+            >
+            ["id5.1"] = <
+                text = <"Ευρήματα εξέτασης">
+                description = <"Δομημένες λεπτομέρειες σχετικά με τα ευρήματα της φυσικής εξέτασης.">
+            >
+        >
+        ["en"] = <
+            ["id1.1"] = <
+                text = <"Examination of the abdomen">
+                description = <"Findings observed during the physical examination of the abdomen.">
+            >
+            ["id2.1"] = <
+                text = <"System or structure examined">
+                description = <"Identification of the examined body system or anatomical structure.">
+                comment = <"For example: the very generic term \"skin\", which will likely require additional qualification using one of the 'Body site' data elements, or the complete phrase \"skin of right knee\". Coding of the system or structure examined with a terminology is preferred, where possible.">
+            >
+            ["id5.1"] = <
+                text = <"Examination findings">
+                description = <"Structured details about the physical examination findings.">
+            >
+        >
+        ["es"] = <
+            ["id1.1"] = <
+                text = <"*Physical examination findings (en)">
+                description = <"*Findings observed during the physical examination of a body system or anatomical structure.(en)">
+            >
+            ["id2.1"] = <
+                text = <"*System or structure examined(en)">
+                description = <"*Identification of the examined body system or anatomical structure.(en)">
+                comment = <"*Coding of the system or structure examined with a terminology is preferred, where possible.(en)">
+            >
+            ["id5.1"] = <
+                text = <"*Examination findings(en)">
+                description = <"*Structured details about the physical examination findings.(en)">
+            >
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam_adl14.v2.adl
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam_adl14.v2.adl
@@ -1,0 +1,674 @@
+archetype (adl_version=1.4; uid=7bed0e4b-3603-4a0a-8f20-75b80d81be9b)
+	openEHR-EHR-CLUSTER.exam.v2
+
+concept
+	[at0000]	-- Physical examination findings
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			author = <
+				["name"] = <"Nina Schewe, Natalia Strauch, Darin Leonhardt">
+				["organisation"] = <"Medizinische Hochschule Hannover, PLRI für medizinische Informatik/ Medizinische Hochschule">
+				["email"] = <"schewe.nina@mh-hannover.de, Strauch.Natalia@mh-hannover.de, leonhardt.darin@mh-hannover.de">
+			>
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			author = <
+				["name"] = <"Erik Sundvall">
+				["organisation"] = <"Region Östergötland + Linköping University">
+				["email"] = <"erik.sundvall@regionostergotland.se">
+			>
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			author = <
+				["name"] = <"Silje Ljosland Bakke, Vebjørn Arntzen">
+				["organisation"] = <"Nasjonal IKT HF, Oslo University Hospital">
+				["email"] = <"varntzen@ous-hf.no">
+			>
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			author = <
+				["name"] = <"Adriana Kitajima">
+				["organisation"] = <"Hospital Alemão Oswaldo Cruz - HAOC">
+				["email"] = <"adrianakitajima@gmail.com">
+			>
+		>
+		["el"] = <
+			language = <[ISO_639-1::el]>
+			author = <
+				["name"] = <"Erasmia Partafylla">
+				["organisation"] = <"Sigmasoft">
+				["email"] = <"c.partafylla@sigmasoft.gr">
+			>
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			author = <
+				["name"] = <"Julio de Sosa, Clara Calleja Vega">
+				["organisation"] = <"Servei Català de la Salut, CatSalut. Servei Català de la Salut.">
+				["email"] = <"juliodesosa@catsalut.cat, ccalleja@catsalut.cat">
+			>
+		>
+		["ca"] = <
+			language = <[ISO_639-1::ca]>
+			author = <
+				["name"] = <"Laura Moral López">
+				["organisation"] = <"Sistema de Salut de Catalunya">
+				["email"] = <"lauramoral@catsalut.cat">
+			>
+			other_details = <
+				["other_contributors"] = <"Tradcrea">
+			>
+		>
+	>
+description
+	original_author = <
+		["name"] = <"Heather Leslie">
+		["organisation"] = <"Atomica Informatics">
+		["email"] = <"heather.leslie@atomicainformatics.com">
+		["date"] = <"2015-06-23">
+	>
+	details = <
+		["de"] = <
+			language = <[ISO_639-1::de]>
+			purpose = <"Aufzeichnung der bei der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachteten Befunde.">
+			use = <"Zur Aufzeichnung der beobachteten Befunde während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur.
+
+Dieser Archetyp wurde speziell für die Verwendung im SLOT „Untersuchungsdetails“ innerhalb des Archetyps OBSERVATION.exam oder im SLOT „Verfahrensdetails“ innerhalb des Archetyps ACTION.procedure entwickelt, kann aber auch innerhalb anderer Archetypen ENTRY oder CLUSTER verwendet werden, sofern dies klinisch sinnvoll ist. Spezialisierungen dieses Archetyps werden verwendet, um Untersuchungsergebnisse für bestimmte Körpersysteme, anatomische Strukturen oder genauere Körperstellen zu erfassen. Jede Spezialisierung behält die Grundstruktur dieses allgemeinen Archetyps als Basis bei und wird durch die Hinzufügung von Elementen erweitert, die für die Körperstelle spezifisch sind. Steht keine geeignete Spezialisierung zur Verfügung, ist dieser Archetyp zu verwenden und das untersuchte System oder die untersuchte Struktur mit dem Datenelement „System oder untersuchte Struktur“ und die Körperstelle mit dem Datenelement „Körperstelle“ oder dem SLOT „Strukturierte Körperstelle“ anzugeben.
+
+Die Interpretation der Befunde, z. B. „Keine Abnormität festgestellt“ oder „Mäßige Entzündung vorhanden“, kann mit dem Datenelement „Klinische Interpretation“ erfasst werden.
+
+Verwendung zur Bereitstellung eines Rahmens, in dem CLUSTER-Archetypen im SLOT „Untersuchungsbefund“ verschachtelt werden können, um zusätzliche strukturierte körperliche Untersuchungsbefunde zu erfassen.
+
+Der Archetyp CLUSTER.exclusion_exam kann in den SLOT „Nicht durchgeführte Untersuchung“ geschachtelt werden, um optional explizite Details über die nicht durchgeführte Untersuchung zu erfassen.
+
+Verwenden Sie das Datenelement „Klinische Beschreibung“, um die narrativen Beschreibungen klinischer Befunde innerhalb bestehender oder vorhandener klinischer Systeme in ein archetypisches Format einzubinden.">
+			misuse = <"Nicht zur Darstellung der klinischen Anamnese zu verwenden – verwenden Sie spezifische OBSERVATION- und CLUSTER-Archetypen. Zum Beispiel OBSERVATION.story und CLUSTER.symptom_sign.
+
+Nicht zur Darstellung der Ergebnisse einer bildgebenden Untersuchung verwenden – verwenden Sie für diesen Zweck die Archetypenfamilie CLUSTER.imaging_exam.">
+		>
+		["sv"] = <
+			language = <[ISO_639-1::sv]>
+			purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+			use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+			keywords = <"fynd, undersökningsfynd, fysisk undersökning, u.a., utan anmärkning", ...>
+			misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+		>
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			purpose = <"For å registrere observerte funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+			use = <"
+Bruk for å registrere observerte funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.
+
+Denne arketypen har vært designet spesifikt for å kunne brukes i SLOT'et \"Undersøkelsesdetaljer\" i arketypen OBSERVATION.exam (Funn ved fysisk undersøkelse) eller SLOT'et \"Prosedyredetaljer\" i arketypen ACTION.procedure (Prosedyre), men kan også bli brukt i andre ENTRY- eller CLUSTER-arketyper der det er klinisk passende. Spesialiseringer av denne arketypen for bestemte organsystem eller anatomiske strukturer kan brukes for å registrere undersøkelsesfunn for disse. Hver slik spesialisering vil bevare den underliggende strukturen til denne generiske arketypen som basis, og utvides med tilleggselementer som er spesifikk for den kroppsstrukturen spesialiseringen gjelder. Dersom det ikke finnes noen passende spesialisering, bruk denne arketypen og registrer organstrukturen eller den anatomiske strukturen i elementet \"Undersøkt organsystem eller struktur\" og lokalisering på kroppen i SLOT'et \"Anatomisk lokalisasjon\" eller \"Strukturert anatomisk lokalisasjon\".
+
+Tolkning av funn kan bli registrert i dataelementet \"Fortolkning\", for eksempel \"Uten anmerkning\" eller \"Moderat inflammasjon\".
+
+Kan også brukes som et rammeverk der man kan nøste CLUSTER-arketyper i SLOT'et \"Spesifikke funn\" for å registrere ytterligere strukturerte undersøkelsesfunn.
+
+Arketypen CLUSTER.exclusion_exam (Eksklusjon av en undersøkelse) kan nøstes inn i SLOT'et \"Undersøkelse ikke utført\" for å registrere begrunnelse eller detaljer om hvorfor undersøkelsen ikke ble utført.
+
+Brukes for å legge til fritekstlige beskrivelser av undersøkelsesfunn fra eksisterende eller historiske journalsystemer til arketypeformat ved å benytte dataelementet \"Klinisk beskrivelse\".">
+			misuse = <"Skal ikke brukes til å ta opp anamnese - bruk da spesifikke OBSERVATION og CLUSTER arketyper. For eksempel OBSERVATION.story og CLUSTER.symptom_sign.
+
+Skal ikke brukes for å registrere funn ved bildeundersøkelse - bruk arketype innen gruppen av CLUSTER.imaging_exam (Bildeundersøkelse) for dette.">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+			use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+			misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+		>
+		["el"] = <
+			language = <[ISO_639-1::el]>
+			purpose = <"Για την καταγραφή των ευρημάτων που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+			use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+			misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.(en)">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To record the findings observed during the physical examination of a body system or anatomical structure.">
+			use = <"Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element.">
+			misuse = <"Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.">
+			copyright = <"© openEHR Foundation">
+		>
+		["es"] = <
+			language = <[ISO_639-1::es]>
+			purpose = <"Registrar los hallazgos observados durante el examen físico de un sistema corporal o estructura anatómica.">
+			use = <"Se utiliza para registrar los hallazgos observados durante la exploración física de un sistema corporal o estructura anatómica.
+
+Este arquetipo se ha diseñado específicamente para su uso en el SLOT \"Detalle del examen\" dentro de OBSERVATION.exam o en el SLOT \"Detalle del procedimiento\" dentro de ACTION.procedure, pero también puede utilizarse dentro de otros arquetipos de ENTRY o CLUSTER, cuando sea clínicamente apropiado. Las especializaciones de este arquetipo se utilizarán para registrar los hallazgos de la exploración de sistemas corporales, estructuras anatómicas o zonas corporales más precisas identificadas. Cada especialización conservará la estructura subyacente de este arquetipo general como base y se ampliará añadiendo elementos específicos de la zona corporal. Si no hay una especialización adecuada disponible, utilice este arquetipo e identifique el sistema o la estructura que se examina utilizando el elemento de datos \"Sistema o estructura examinada\" y la ubicación en el cuerpo utilizando el elemento de datos \"Zona corporal\" o la ranura \"Zona corporal estructurada\".
+
+Interpretación de los hallazgos, por ejemplo, \"No se detecta ninguna anomalía\" o La presencia de inflamación moderada se puede registrar mediante el elemento de datos \"Interpretación clínica\".
+
+Se utiliza para proporcionar un marco en el que los arquetipos CLUSTER se pueden anidar en la ranura \"Hallazgos del examen\" para registrar hallazgos adicionales estructurados del examen físico.
+
+El arquetipo CLUSTER.exclusion_exam se puede anidar en la ranura \"Examen no realizado\" para registrar opcionalmente detalles explícitos sobre el examen no realizado.
+
+Se utiliza para incorporar las descripciones narrativas de los hallazgos clínicos en sistemas clínicos existentes o heredados en un formato arquetipado, mediante el elemento de datos \"Descripción clínica\".">
+			misuse = <"No debe utilizarse para registrar la historia clínica; utilice los arquetipos específicos OBSERVATION y CLUSTER. Por ejemplo, OBSERVATION.story y CLUSTER.symptom_sign.
+
+No debe utilizarse para registrar los resultados de un examen de imagen; utilice la familia de arquetipos CLUSTER.imaging_exam para este fin.">
+		>
+		["ca"] = <
+			language = <[ISO_639-1::ca]>
+			purpose = <"Registrar les troballes observades durant l'examen físic del cos o estructura anatòmica.">
+			use = <"S'utilitza per registrar les troballes observades durant l'examen físic del cos o estructura anatòmica.
+
+Aquest arquetip ha estat dissenyat específicament per a ser utilitzat en el SLOT 'Examination detail' dins de l'OBSERVATION.exam o del SLOT \"Procedure detail\" dins de l'arquetip ACTION.procedure, però també es pot utilitzar dins d'altres arquetips ENTRY o CLUSTER, quan sigui clínicament apropiat. Les especialitzacions d'aquest arquetip s'utilitzaran per registrar els resultats de l'examen per a sistemes corporals identificats, estructures anatòmiques o llocs corporals més precisos. Cada especialització preservarà com a base l'estructura subjacent d'aquest arquetip general i s'ampliarà mitjançant l'addició d'elements específics al cos. Si no hi ha una especialització adequada disponible, utilitzeu aquest arquetip i identifiqueu el sistema o estructura que s'està examinant utilitzant l'element de dades \"Sistema o estructura examinada\" i la ubicació en el cos utilitzant l'element de dades \"lloc del cos\" o la RANURA \"lloc del cos estructurat\".
+
+La interpretació de les troballes, per exemple 'No s'ha detectat cap anormalitat' o 'inflamació present moderada', es pot registrar utilitzant l'element de dades 'interpretació clínica'.
+
+S'utilitza per proporcionar un marc en el qual els arquetips de CLUSTER poden ser afegits en el SLOT \"Troballes de l'examen\" per registrar resultats d'un examen físic estructurats addicionals.
+
+L'arquetip CLUSTER.exclusion_exam es pot afegir dins del SLOT 'Examen no realitzat' per tal de registrar opcionalment detalls explícits sobre l'examen que no s'està realitzant.
+
+Incorporar les descripcions narratives de les troballes clíniques dins dels sistemes clínics existents o llegats en un format arquetipat, utilitzant l'element de dades de \"Descripció clínica\".">
+			misuse = <"No s'ha d'utilitzar per registrar la història clínica - utilitzar els arquetipis OBSERVATION i CLUSTER. Exemple: OBSERVATION.story i CLUSTER.symptom_sign.
+
+No s'ha d'utilitzar per registrar els resultats d'un examen d'imatge - utilitzar la família d'arquetips CLUSTER.imaging_exam per a aquest propòsit.">
+		>
+	>
+	lifecycle_state = <"published">
+	other_contributors = <"Vebjørn Arntzen, Oslo University Hospital, Norway (openEHR Editor)", "Silje Ljosland Bakke, Nasjonal IKT HF, Norway (openEHR Editor)", "SB Bhattacharyya, Sudisa Consultancy Services, India", "Lisbeth Dahlhaug, Helse Midt - Norge IT, Norway", "Shahla Foozonkhah, Iran ministry of health and education, Iran", "Hildegard Franke, freshEHR Clinical Informatics Ltd., United Kingdom (openEHR Editor)", "Mikkel Gaup Grønmo, FSE, Helse Nord, Norway (Nasjonal IKT redaktør)", "Ingrid Heitmann, Oslo universitetssykehus HF, Norway", "Hilde Hollås, DIPS ASA, Norway", "Evelyn Hovenga, EJSH Consulting, Australia", "Lars Ivar Mehlum, Helse Bergen HF, Norway", "Sabine Leh, Haukeland University Hospital, Department of Pathology, Norway", "Heather Leslie, Atomica Informatics, Australia (openEHR Editor)", "Ian McNicoll, freshEHR Clinical Informatics, United Kingdom", "Lars Morgan Karlsen, DIPS ASA, Norway", "Bjørn Næss, DIPS ASA, Norway", "Andrej Orel, Marand d.o.o., Slovenia", "Vladimir Pizzo, Hospital Sírio Libanês, Brazil", "Jussara Rotzsch, UNB, Brazil", "Anoop Shah, University College London, United Kingdom", "Line Silsand, Universitetssykehuset i Nord-Norge, Norway", "Norwegian Review Summary, Nasjonal IKT HF, Norway", "Nyree Taylor, Ocean Informatics, Australia (openEHR Editor)", "Rowan Thomas, St. Vincent's Hospital Melbourne, Australia", "Jon Tysdahl, Furst medlab AS, Norway", "John Tore Valand, Helse Bergen, Norway (openEHR Editor)">
+	other_details = <
+		["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.">
+		["custodian_organisation"] = <"openEHR Foundation">
+		["current_contact"] = <"Heather Leslie, Atomica Informatics, Australia<heather.leslie@atomicainformatics.com>">
+		["original_namespace"] = <"org.openehr">
+		["original_publisher"] = <"openEHR Foundation">
+		["custodian_namespace"] = <"org.openehr">
+		["MD5-CAM-1.0.1"] = <"419545A4ABAC8966511DFB6F7F5993EA">
+		["build_uid"] = <"06eaf774-4c3f-455d-ba3c-cdb5d81b4e0a">
+		["ip_acknowledgements"] = <"This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyrighted material of the International Health Terminology Standards Development Organisation (IHTSDO). Where an implementation of this artefact makes use of SNOMED CT content, the implementer must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/get-snomedct or info@snomed.org.">
+		["revision"] = <"2.1.3">
+	>
+
+definition
+	CLUSTER[at0000] matches {    -- Physical examination findings
+		items cardinality matches {1..*; unordered} matches {
+			ELEMENT[at0001] matches {    -- System or structure examined
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0012] occurrences matches {0..1} matches {    -- Body site
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			allow_archetype CLUSTER[at0011] occurrences matches {0..*} matches {    -- Structured body site
+				include
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.anatomical_location(-[a-zA-Z0-9_]+)*\.v1|openEHR-EHR-CLUSTER\.anatomical_location_circle(-[a-zA-Z0-9_]+)*\.v1|openEHR-EHR-CLUSTER\.anatomical_location_relative(-[a-zA-Z0-9_]+)*\.v2/}
+			}
+			ELEMENT[at0003] occurrences matches {0..1} matches {    -- Clinical description
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			allow_archetype CLUSTER[at0004] occurrences matches {0..*} matches {    -- Examination findings
+				include
+					archetype_id/value matches {/.*/}
+			}
+			allow_archetype CLUSTER[at0005] occurrences matches {0..*} matches {    -- Multimedia representation
+				include
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.media_file(-[a-zA-Z0-9_]+)*\.v1/}
+			}
+			ELEMENT[at0006] occurrences matches {0..*} matches {    -- Clinical interpretation
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			ELEMENT[at0007] occurrences matches {0..1} matches {    -- Comment
+				value matches {
+					DV_TEXT matches {*}
+				}
+			}
+			allow_archetype CLUSTER[at0008] occurrences matches {0..*} matches {    -- Examination not done
+				include
+					archetype_id/value matches {/openEHR-EHR-CLUSTER\.exclusion_exam(-[a-zA-Z0-9_]+)*\.v1/}
+			}
+		}
+	}
+
+
+ontology
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Physical examination findings">
+					description = <"Findings observed during the physical examination of a body system or anatomical structure.">
+				>
+				["at0001"] = <
+					text = <"System or structure examined">
+					description = <"Identification of the examined body system or anatomical structure.">
+					comment = <"Coding of the system or structure examined with a terminology is preferred, where possible.">
+				>
+				["at0003"] = <
+					text = <"Clinical description">
+					description = <"Narrative description of the overall findings observed during the physical examination.">
+				>
+				["at0004"] = <
+					text = <"Examination findings">
+					description = <"Structured details about the physical examination findings.">
+				>
+				["at0005"] = <
+					text = <"Multimedia representation">
+					description = <"Digital image, video or diagram representing the physical examination findings.">
+				>
+				["at0006"] = <
+					text = <"Clinical interpretation">
+					description = <"Single word, phrase or brief description that represents the clinical meaning and significance of the physical examination findings.">
+					comment = <"For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible.">
+				>
+				["at0007"] = <
+					text = <"Comment">
+					description = <"Additional narrative about the physical examination findings, not captured in other fields.">
+				>
+				["at0008"] = <
+					text = <"Examination not done">
+					description = <"Details to explicitly record that this examination was not performed.">
+				>
+				["at0011"] = <
+					text = <"Structured body site">
+					description = <"A structured description of the area of the body under examination.">
+					comment = <"If the body site has been fully identified in the 'System or structure examined' or the 'Body site' data element, this SLOT becomes redundant.">
+				>
+				["at0012"] = <
+					text = <"Body site">
+					description = <"Identification of the area of the body under examination.">
+					comment = <"For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant.">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["at0000"] = <
+					text = <"Funn ved fysisk undersøkelse">
+					description = <"Undersøkelsesfunn gjort ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+				>
+				["at0001"] = <
+					text = <"Undersøkt organsystem eller struktur">
+					description = <"Identifisering av det undersøkte organsystemet eller den anatomiske strukturen.">
+					comment = <"Det anbefales å kode organsystem eller den anatomiske strukturen med en terminologi dersom mulig.">
+				>
+				["at0003"] = <
+					text = <"Klinisk beskrivelse">
+					description = <"Fritekstbeskrivelse av de overordnede funnene ved den fysiske undersøkelsen.">
+				>
+				["at0004"] = <
+					text = <"Spesifikke funn">
+					description = <"Ytterligere strukturerte detaljer om undersøkelsesfunnene.">
+				>
+				["at0005"] = <
+					text = <"Multimediarepresentasjon">
+					description = <"Digitale bilder, video eller diagram som representerer undersøkelsesfunnene.">
+				>
+				["at0006"] = <
+					text = <"Fortolkning">
+					description = <"Enkelt ord, setning, frase eller kort beskrivelse som representerer den kliniske betydning og viktigheten av funnene ved den fysiske undersøkelsen.">
+					comment = <"For eksempel \"Uten anmerkning\" eller \"Moderat inflammasjon\". Det anbefales å kode \"Fortolkning\" med en terminologi dersom mulig.">
+				>
+				["at0007"] = <
+					text = <"Kommentar">
+					description = <"Ytterligere fritekst om funn ved undersøkelsen, som ikke dekkes av andre elementer.">
+				>
+				["at0008"] = <
+					text = <"Undersøkelse ikke utført">
+					description = <"Detaljer for å eksplisitt registrere at denne undersøkelsen ikke ble utført.">
+				>
+				["at0011"] = <
+					text = <"Strukturert anatomisk lokalisasjon">
+					description = <"Angivelse av en strukturert anatomisk lokalisering av det undersøkte organsystemet eller den anatomiske strukturen.">
+					comment = <"Hvis anatomisk lokalisasjon er entydig identifisert i elementet \"Undersøkt organsystem eller struktur\" er dette SLOT'et ikke nødvendig å benytte.">
+				>
+				["at0012"] = <
+					text = <"Anatomisk lokalisasjon">
+					description = <"Identifisering av et enkelt fysisk sted enten på eller i menneskekroppen.">
+					comment = <"For eksempel undersøkelse av et spesifikt område på huden. Dersom den anatomiske lokaliseringen allerede er identifisert i elementet \"Undersøkt organsystem eller struktur\" er dette dataelementet overflødig.">
+				>
+			>
+		>
+		["pt-br"] = <
+			items = <
+				["at0000"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Constatações observadas durante o exame físico de um sistema corporal ou estrutura anatômica.">
+				>
+				["at0001"] = <
+					text = <"Sistema ou estrutura examinada">
+					description = <"Identificação do sistema do corpo examinado ou da estrutura anatômica.">
+					comment = <"A codificação do sistema ou estrutura examinada com uma terminologia é preferível, sempre que possível.">
+				>
+				["at0003"] = <
+					text = <"Descrição clínica">
+					description = <"Descrição narrativa dos achados gerais observados durante o exame físico.">
+				>
+				["at0004"] = <
+					text = <"Resultados do exame">
+					description = <"Detalhes estruturados sobre os resultados do exame físico.">
+				>
+				["at0005"] = <
+					text = <"Representação multimídia">
+					description = <"Imagem digital, vídeo ou diagrama representando os achados do exame físico.">
+				>
+				["at0006"] = <
+					text = <"Interpretação clínica">
+					description = <"Palavra, frase ou breve descrição que represente o significado clínico e o significado dos resultados do exame físico.">
+					comment = <"*For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible. (en)">
+				>
+				["at0007"] = <
+					text = <"Comentário">
+					description = <"Narrativa adicional sobre os achados do exame físico, não capturados em outros campos.">
+				>
+				["at0008"] = <
+					text = <"Exame não realizado">
+					description = <"Detalhes para registrar explicitamente que esse exame não foi realizado.">
+				>
+				["at0011"] = <
+					text = <"Local do corpo estruturado">
+					description = <"Uma descrição estruturada da área do corpo em exame.">
+					comment = <"Se o local do corpo tiver sido totalmente identificado no elemento de dados 'Sistema ou estrutura examinada' ou 'Local do corpo', esse SLOT se tornará redundante.">
+				>
+				["at0012"] = <
+					text = <"Local do corpo">
+					description = <"*Identification of the area of the body under examination. (en)">
+					comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+				>
+			>
+		>
+		["de"] = <
+			items = <
+				["at0000"] = <
+					text = <"Ergebnisse der körperlichen Untersuchung">
+					description = <"Während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachtete Befunde.">
+				>
+				["at0001"] = <
+					text = <"Untersuchtes System oder untersuchte Struktur">
+					description = <"Identifizierung des untersuchten Körpersystems oder der anatomischen Struktur.">
+					comment = <"Wenn möglich wird die Kodierung des untersuchten Systems oder der untersuchten Struktur mit einer Terminologie bevorzugt.">
+				>
+				["at0003"] = <
+					text = <"Klinische Beschreibung">
+					description = <"Beschreibung der bei der körperlichen Untersuchung beobachteten Gesamtbefunde.">
+				>
+				["at0004"] = <
+					text = <"Untersuchungsergebnisse">
+					description = <"Strukturierte Angaben zu den Ergebnissen der körperlichen Untersuchung.">
+				>
+				["at0005"] = <
+					text = <"Multimediale Darstellung">
+					description = <"Digitales Bild, Video oder Diagramm, das die Ergebnisse der körperlichen Untersuchung darstellt.">
+				>
+				["at0006"] = <
+					text = <"Klinische Interpretation">
+					description = <"Ein einzelnes Wort, eine Phrase oder eine kurze Beschreibung, die die klinische Bedeutung und Wichtigkeit der Untersuchungsergebnisse darstellt.">
+					comment = <"Zum Beispiel: „Ohne Befund“ oder „Mäßige Entzündung vorhanden“. Wenn möglich, wird die Codierung der „Klinischen Interpretation“ mit einer Terminologie bevorzugt.">
+				>
+				["at0007"] = <
+					text = <"Kommentar">
+					description = <"Zusätzliche Beschreibung der Ergebnisse der körperlichen Untersuchung, die in anderen Bereichen nicht erfasst werden konnten.">
+				>
+				["at0008"] = <
+					text = <"Nicht durchgeführte Untersuchung">
+					description = <"Eine Aussage die ausdrücklich erfasst, dass die Untersuchung nicht durchgeführt wurde.">
+				>
+				["at0011"] = <
+					text = <"Strukturierte Körperstelle">
+					description = <"Eine strukturierte Beschreibung des zu untersuchenden Körperbereichs.">
+					comment = <"Wenn die Körperstelle im Datenelement \"Untersuchtes System oder untersuchte Struktur\" oder im Datenelement \"Körperstelle\" vollständig identifiziert wurde, wird die Verwendung dieses SLOT überflüssig.">
+				>
+				["at0012"] = <
+					text = <"Körperstelle">
+					description = <"Identifizierung des untersuchten Körperbereichs.">
+					comment = <"Zum Beispiel die Untersuchung einer bestimmten Hautpartie. Wenn die Körperstelle im Datenelement „Untersuchtes System oder Struktur“ vollständig identifiziert wurde, wird dieses Datenelement überflüssig.">
+				>
+			>
+		>
+		["sv"] = <
+			items = <
+				["at0000"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Observerade fynd vid fysisk undersökning av system i kroppen, eller av anatomisk struktur">
+				>
+				["at0001"] = <
+					text = <"System eller struktur som undersökts">
+					description = <"Identifiering av systemet eller strukturen som undersökts.">
+					comment = <"Om möjligt, koda systemet eller strukturen med hjälp av ett terminologisystem.">
+				>
+				["at0003"] = <
+					text = <"Klinisk beskrivning">
+					description = <"En övergripande beskrivning av fynden från den fysiska undersökningen. ">
+				>
+				["at0004"] = <
+					text = <"Fynd vid undersökning">
+					description = <"Strukturerade detaljer om fynd vid den fysiska undersökningen.">
+				>
+				["at0005"] = <
+					text = <"Multimedia-representation">
+					description = <"Digital bild, video eller diagram som återger fynd från undersökningen.">
+				>
+				["at0006"] = <
+					text = <"Klinisk tolkning">
+					description = <"Ord, fras eller kort beskrivning av fyndens kliniska betydelse.">
+					comment = <"*For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible. (en)">
+				>
+				["at0007"] = <
+					text = <"Kommentar">
+					description = <"Kommentarer avseende undersökningsfynd som inte beskrivs i övriga fält.">
+				>
+				["at0008"] = <
+					text = <"Undersökning ej genomförd">
+					description = <"Detaljerad beskrivning om att undersökningen inte genomfördes.">
+				>
+				["at0011"] = <
+					text = <"Strukturerad anatomisk plats">
+					description = <"Strukturerad beskrivning av den anatomiska platsen som undersökts.">
+					comment = <"Om den anatomiska platsen kan identifieras helt via dataelementet \"System eller struktur som undersökts\" så blir denna del redundant.">
+				>
+				["at0012"] = <
+					text = <"Anatomisk plats">
+					description = <"*Identification of the area of the body under examination. (en)">
+					comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+				>
+			>
+		>
+		["el"] = <
+			items = <
+				["at0000"] = <
+					text = <"*Physical examination findings (en)">
+					description = <"Ευρήματα που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+				>
+				["at0001"] = <
+					text = <"Εξεταζόμενο σύστημα ή δομή">
+					description = <"Ταυτοποίηση του εξεταζόμενου συστήματος σώματος ή ανατομικής δομής.">
+					comment = <"Προτιμάται η κωδικοποίηση του συστήματος ή της δομής που εξετάζεται με ορολογία, όπου είναι δυνατόν.">
+				>
+				["at0003"] = <
+					text = <"Κλινική Περιγραφή">
+					description = <"Αφηγηματική περιγραφή των συνολικών ευρημάτων που παρατηρήθηκαν κατά τη διάρκεια της φυσικής εξέτασης.">
+				>
+				["at0004"] = <
+					text = <"Ευρήματα εξέτασης">
+					description = <"Δομημένες λεπτομέρειες σχετικά με τα ευρήματα της φυσικής εξέτασης.">
+				>
+				["at0005"] = <
+					text = <"Αναπαράσταση πολυμέσων">
+					description = <"Ψηφιακή εικόνα, βίντεο ή διάγραμμα που αναπαριστά τα ευρήματα της φυσικής εξέτασης.">
+				>
+				["at0006"] = <
+					text = <"Κλινική αξιολόγηση">
+					description = <"Μία λέξη, φράση ή σύντομη περιγραφή που αντιπροσωπεύει την κλινική σημασία και σημασία των ευρημάτων της φυσικής εξέτασης.">
+					comment = <"Για παράδειγμα: «Δεν ανιχνεύθηκε ανωμαλία» ή «Υπάρχει μέτρια φλεγμονή». Προτιμάται η κωδικοποίηση της «κλινικής ερμηνείας» με ορολογία, όπου είναι δυνατόν.">
+				>
+				["at0007"] = <
+					text = <"Σχόλιο">
+					description = <"Πρόσθετη αφήγηση σχετικά με τα ευρήματα της φυσικής εξέτασης, που δεν αποτυπώνεται σε άλλους τομείς.">
+				>
+				["at0008"] = <
+					text = <"Λόγος διακοπής εξέτασης">
+					description = <"Λεπτομέρειες για να καταγραφεί ρητά ότι αυτή η εξέταση δεν διενεργήθηκε.">
+				>
+				["at0011"] = <
+					text = <"ω">
+					description = <"περιγραφή της περιοχής του υπό εξέταση σώματος.">
+					comment = <"*If the body site has been fully identified in the 'System or structure examined' or the 'Body site' data element, this SLOT becomes redundant.(en)">
+				>
+				["at0012"] = <
+					text = <"Περιοχή σώματος">
+					description = <"*Identification of the area of the body under examination. (en)">
+					comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+				>
+			>
+		>
+		["es"] = <
+			items = <
+				["at0000"] = <
+					text = <"Hallazgos de la exploración física">
+					description = <"Hallazgos observados durante la exploración física de un sistema corporal o estructura anatómica.">
+				>
+				["at0001"] = <
+					text = <"Sistema o estructura examinada">
+					description = <"Identificación del sistema corporal o estructura anatómica examinados.">
+					comment = <"Se prefiere, siempre que sea posible, codificar el sistema o la estructura examinada con una terminología.">
+				>
+				["at0003"] = <
+					text = <"Descripción clínica">
+					description = <"Descripción narrativa de los hallazgos generales observados durante la exploración física.">
+				>
+				["at0004"] = <
+					text = <"Hallazgos de la exploración">
+					description = <"Detalles estructurados sobre los hallazgos de la exploración física.">
+				>
+				["at0005"] = <
+					text = <"Representación multimedia">
+					description = <"Imagen digital, video o diagrama que representa los hallazgos de la exploración física.">
+				>
+				["at0006"] = <
+					text = <"Interpretación clínica">
+					description = <"Palabra, frase o descripción breve que representa el significado clínico y la importancia de los hallazgos de la exploración física.">
+					comment = <"Por ejemplo: \"No se detecta ninguna anomalía\" o \"Inflamación moderada\". Se prefiere codificar la \"Interpretación clínica\" con una terminología, siempre que sea posible.">
+				>
+				["at0007"] = <
+					text = <"Comentario">
+					description = <"Narración adicional sobre los hallazgos de la exploración física, no registrada en otros campos.">
+				>
+				["at0008"] = <
+					text = <"Examen no realizado">
+					description = <"Detalles para registrar explícitamente que esta exploración no se realizó.">
+				>
+				["at0011"] = <
+					text = <"Zona corporal estructurada">
+					description = <"Descripción estructurada de la zona del cuerpo examinada.">
+					comment = <"Si la zona corporal se ha identificado completamente en los elementos de datos «Sistema o estructura examinada» o «Zona corporal», esta ranura se vuelve redundante.">
+				>
+				["at0012"] = <
+					text = <"Zona corporal">
+					description = <"Identificación de la zona del cuerpo examinada.">
+					comment = <"Por ejemplo, el examen de una zona específica de la piel. Si la zona corporal se ha identificado completamente en los elementos de datos «Sistema o estructura examinada», este elemento se vuelve redundante.">
+				>
+			>
+		>
+		["ca"] = <
+			items = <
+				["at0000"] = <
+					text = <"Resultats de l'examen físic">
+					description = <"Troballes observades durant l'examen físic d'un sistema corporal o estructura anatòmica.">
+				>
+				["at0001"] = <
+					text = <"Sistema o estructura examinada">
+					description = <"Identificació del sistema corporal examinat o estructura anatòmica.">
+					comment = <"Preferiblement utilitzar la codificació del sistema o estructura examinada amb una terminologia, sempre que sigui possible.">
+				>
+				["at0003"] = <
+					text = <"Descripció clínica">
+					description = <"Descripció narrativa dels resultats globals observats durant l'examen físic.">
+				>
+				["at0004"] = <
+					text = <"Resultats de l'examen">
+					description = <"Detalls estructurats sobre els resultats de l'examen físic.">
+				>
+				["at0005"] = <
+					text = <"Representació multimèdia">
+					description = <"Imatge digital, vídeo o diagrama que representa els resultats de l'examen físic.">
+				>
+				["at0006"] = <
+					text = <"Interpretació clínica">
+					description = <"Paraula única, frase o breu descripció que representa el significat clínic i la significació de les troballes de l'examen físic.">
+					comment = <"Exemple: 'No s'ha detectat cap anormalitat' o 'inflamació present moderada'. Es prefereix la codificació de la \"interpretació clínica\" amb una terminologia, sempre que sigui possible.">
+				>
+				["at0007"] = <
+					text = <"Comentari">
+					description = <"Narrativa addicional sobre els resultats de l'examen físic, no capturada en altres camps.">
+				>
+				["at0008"] = <
+					text = <"Examen no realitzat">
+					description = <"Detalls per registrar explícitament que aquest examen no es va realitzar.">
+				>
+				["at0011"] = <
+					text = <"Part del cos estructurada">
+					description = <"Descripció estructurada de l'àrea del cos objecte d'examen.">
+					comment = <"Si el lloc del cos ha estat completament identificat en el \"Sistema o estructura examinada\" o l'element de dades del \"lloc cos\", aquest SLOT es torna redundant.">
+				>
+				["at0012"] = <
+					text = <"Part del cos">
+					description = <"Identificació de l'àrea de l'organisme objecte d'examen.">
+					comment = <"Exemple: l'examen d'una àrea específica de la pell. Si el lloc del cos ha estat completament identificat en l'element de dades \"Sistema o estructura examinada\", aquest element de dades esdevé redundant.">
+				>
+			>
+		>
+	>

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam_adl2_id.v2.1.3.adls
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-CLUSTER.exam_adl2_id.v2.1.3.adls
@@ -1,0 +1,656 @@
+archetype (adl_version=2.0.6; rm_release=1.1.0; generated; uid=7bed0e4b-3603-4a0a-8f20-75b80d81be9b; build_uid=06eaf774-4c3f-455d-ba3c-cdb5d81b4e0a)
+    openEHR-EHR-CLUSTER.exam.v2.1.3
+
+language
+    original_language = <[ISO_639-1::en]>
+    translations = <
+        ["de"] = <
+            language = <[ISO_639-1::de]>
+            author = <
+                ["name"] = <"Nina Schewe, Natalia Strauch, Darin Leonhardt">
+                ["organisation"] = <"Medizinische Hochschule Hannover, PLRI für medizinische Informatik/ Medizinische Hochschule">
+                ["email"] = <"schewe.nina@mh-hannover.de, Strauch.Natalia@mh-hannover.de, leonhardt.darin@mh-hannover.de">
+            >
+        >
+        ["sv"] = <
+            language = <[ISO_639-1::sv]>
+            author = <
+                ["name"] = <"Erik Sundvall">
+                ["organisation"] = <"Region Östergötland + Linköping University">
+                ["email"] = <"erik.sundvall@regionostergotland.se">
+            >
+        >
+        ["nb"] = <
+            language = <[ISO_639-1::nb]>
+            author = <
+                ["name"] = <"Silje Ljosland Bakke, Vebjørn Arntzen">
+                ["organisation"] = <"Nasjonal IKT HF, Oslo University Hospital">
+                ["email"] = <"varntzen@ous-hf.no">
+            >
+        >
+        ["pt-br"] = <
+            language = <[ISO_639-1::pt-br]>
+            author = <
+                ["name"] = <"Adriana Kitajima">
+                ["organisation"] = <"Hospital Alemão Oswaldo Cruz - HAOC">
+                ["email"] = <"adrianakitajima@gmail.com">
+            >
+        >
+        ["el"] = <
+            language = <[ISO_639-1::el]>
+            author = <
+                ["name"] = <"Erasmia Partafylla">
+                ["organisation"] = <"Sigmasoft">
+                ["email"] = <"c.partafylla@sigmasoft.gr">
+            >
+        >
+        ["es"] = <
+            language = <[ISO_639-1::es]>
+            author = <
+                ["name"] = <"Julio de Sosa, Clara Calleja Vega">
+                ["organisation"] = <"Servei Català de la Salut, CatSalut. Servei Català de la Salut.">
+                ["email"] = <"juliodesosa@catsalut.cat, ccalleja@catsalut.cat">
+            >
+        >
+        ["ca"] = <
+            language = <[ISO_639-1::ca]>
+            author = <
+                ["name"] = <"Laura Moral López">
+                ["organisation"] = <"Sistema de Salut de Catalunya">
+                ["email"] = <"lauramoral@catsalut.cat">
+            >
+            other_details = <
+                ["other_contributors"] = <"Tradcrea">
+            >
+        >
+    >
+
+description
+    original_author = <
+        ["name"] = <"Heather Leslie">
+        ["organisation"] = <"Atomica Informatics">
+        ["email"] = <"heather.leslie@atomicainformatics.com">
+        ["date"] = <"2015-06-23">
+    >
+    original_namespace = <"org.openehr">
+    original_publisher = <"openEHR Foundation">
+    other_contributors = <"Vebjørn Arntzen, Oslo University Hospital, Norway (openEHR Editor)", "Silje Ljosland Bakke, Nasjonal IKT HF, Norway (openEHR Editor)", "SB Bhattacharyya, Sudisa Consultancy Services, India", "Lisbeth Dahlhaug, Helse Midt - Norge IT, Norway", "Shahla Foozonkhah, Iran ministry of health and education, Iran", "Hildegard Franke, freshEHR Clinical Informatics Ltd., United Kingdom (openEHR Editor)", "Mikkel Gaup Grønmo, FSE, Helse Nord, Norway (Nasjonal IKT redaktør)", "Ingrid Heitmann, Oslo universitetssykehus HF, Norway", "Hilde Hollås, DIPS ASA, Norway", "Evelyn Hovenga, EJSH Consulting, Australia", "Lars Ivar Mehlum, Helse Bergen HF, Norway", "Sabine Leh, Haukeland University Hospital, Department of Pathology, Norway", "Heather Leslie, Atomica Informatics, Australia (openEHR Editor)", "Ian McNicoll, freshEHR Clinical Informatics, United Kingdom", "Lars Morgan Karlsen, DIPS ASA, Norway", "Bjørn Næss, DIPS ASA, Norway", "Andrej Orel, Marand d.o.o., Slovenia", "Vladimir Pizzo, Hospital Sírio Libanês, Brazil", "Jussara Rotzsch, UNB, Brazil", "Anoop Shah, University College London, United Kingdom", "Line Silsand, Universitetssykehuset i Nord-Norge, Norway", "Norwegian Review Summary, Nasjonal IKT HF, Norway", "Nyree Taylor, Ocean Informatics, Australia (openEHR Editor)", "Rowan Thomas, St. Vincent's Hospital Melbourne, Australia", "Jon Tysdahl, Furst medlab AS, Norway", "John Tore Valand, Helse Bergen, Norway (openEHR Editor)">
+    lifecycle_state = <"published">
+    custodian_namespace = <"org.openehr">
+    custodian_organisation = <"openEHR Foundation">
+    licence = <"This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.">
+    ip_acknowledgements = <
+        ["1"] = <"This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyrighted material of the International Health Terminology Standards Development Organisation (IHTSDO). Where an implementation of this artefact makes use of SNOMED CT content, the implementer must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/get-snomedct or info@snomed.org.">
+    >
+    other_details = <
+        ["current_contact"] = <"Heather Leslie, Atomica Informatics, Australia<heather.leslie@atomicainformatics.com>">
+        ["MD5-CAM-1.0.1"] = <"419545A4ABAC8966511DFB6F7F5993EA">
+    >
+    details = <
+        ["de"] = <
+            language = <[ISO_639-1::de]>
+            purpose = <"Aufzeichnung der bei der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachteten Befunde.">
+            use = <"Zur Aufzeichnung der beobachteten Befunde während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur.
+
+Dieser Archetyp wurde speziell für die Verwendung im SLOT „Untersuchungsdetails“ innerhalb des Archetyps OBSERVATION.exam oder im SLOT „Verfahrensdetails“ innerhalb des Archetyps ACTION.procedure entwickelt, kann aber auch innerhalb anderer Archetypen ENTRY oder CLUSTER verwendet werden, sofern dies klinisch sinnvoll ist. Spezialisierungen dieses Archetyps werden verwendet, um Untersuchungsergebnisse für bestimmte Körpersysteme, anatomische Strukturen oder genauere Körperstellen zu erfassen. Jede Spezialisierung behält die Grundstruktur dieses allgemeinen Archetyps als Basis bei und wird durch die Hinzufügung von Elementen erweitert, die für die Körperstelle spezifisch sind. Steht keine geeignete Spezialisierung zur Verfügung, ist dieser Archetyp zu verwenden und das untersuchte System oder die untersuchte Struktur mit dem Datenelement „System oder untersuchte Struktur“ und die Körperstelle mit dem Datenelement „Körperstelle“ oder dem SLOT „Strukturierte Körperstelle“ anzugeben.
+
+Die Interpretation der Befunde, z. B. „Keine Abnormität festgestellt“ oder „Mäßige Entzündung vorhanden“, kann mit dem Datenelement „Klinische Interpretation“ erfasst werden.
+
+Verwendung zur Bereitstellung eines Rahmens, in dem CLUSTER-Archetypen im SLOT „Untersuchungsbefund“ verschachtelt werden können, um zusätzliche strukturierte körperliche Untersuchungsbefunde zu erfassen.
+
+Der Archetyp CLUSTER.exclusion_exam kann in den SLOT „Nicht durchgeführte Untersuchung“ geschachtelt werden, um optional explizite Details über die nicht durchgeführte Untersuchung zu erfassen.
+
+Verwenden Sie das Datenelement „Klinische Beschreibung“, um die narrativen Beschreibungen klinischer Befunde innerhalb bestehender oder vorhandener klinischer Systeme in ein archetypisches Format einzubinden.">
+            misuse = <"Nicht zur Darstellung der klinischen Anamnese zu verwenden – verwenden Sie spezifische OBSERVATION- und CLUSTER-Archetypen. Zum Beispiel OBSERVATION.story und CLUSTER.symptom_sign.
+
+Nicht zur Darstellung der Ergebnisse einer bildgebenden Untersuchung verwenden – verwenden Sie für diesen Zweck die Archetypenfamilie CLUSTER.imaging_exam.">
+        >
+        ["sv"] = <
+            language = <[ISO_639-1::sv]>
+            purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+            keywords = <"fynd, undersökningsfynd, fysisk undersökning, u.a., utan anmärkning", ...>
+            use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+            misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+        >
+        ["nb"] = <
+            language = <[ISO_639-1::nb]>
+            purpose = <"For å registrere observerte funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+            use = <"
+Bruk for å registrere observerte funn ved fysisk undersøkelse av et organsystem eller anatomisk struktur.
+
+Denne arketypen har vært designet spesifikt for å kunne brukes i SLOT'et \"Undersøkelsesdetaljer\" i arketypen OBSERVATION.exam (Funn ved fysisk undersøkelse) eller SLOT'et \"Prosedyredetaljer\" i arketypen ACTION.procedure (Prosedyre), men kan også bli brukt i andre ENTRY- eller CLUSTER-arketyper der det er klinisk passende. Spesialiseringer av denne arketypen for bestemte organsystem eller anatomiske strukturer kan brukes for å registrere undersøkelsesfunn for disse. Hver slik spesialisering vil bevare den underliggende strukturen til denne generiske arketypen som basis, og utvides med tilleggselementer som er spesifikk for den kroppsstrukturen spesialiseringen gjelder. Dersom det ikke finnes noen passende spesialisering, bruk denne arketypen og registrer organstrukturen eller den anatomiske strukturen i elementet \"Undersøkt organsystem eller struktur\" og lokalisering på kroppen i SLOT'et \"Anatomisk lokalisasjon\" eller \"Strukturert anatomisk lokalisasjon\".
+
+Tolkning av funn kan bli registrert i dataelementet \"Fortolkning\", for eksempel \"Uten anmerkning\" eller \"Moderat inflammasjon\".
+
+Kan også brukes som et rammeverk der man kan nøste CLUSTER-arketyper i SLOT'et \"Spesifikke funn\" for å registrere ytterligere strukturerte undersøkelsesfunn.
+
+Arketypen CLUSTER.exclusion_exam (Eksklusjon av en undersøkelse) kan nøstes inn i SLOT'et \"Undersøkelse ikke utført\" for å registrere begrunnelse eller detaljer om hvorfor undersøkelsen ikke ble utført.
+
+Brukes for å legge til fritekstlige beskrivelser av undersøkelsesfunn fra eksisterende eller historiske journalsystemer til arketypeformat ved å benytte dataelementet \"Klinisk beskrivelse\".">
+            misuse = <"Skal ikke brukes til å ta opp anamnese - bruk da spesifikke OBSERVATION og CLUSTER arketyper. For eksempel OBSERVATION.story og CLUSTER.symptom_sign.
+
+Skal ikke brukes for å registrere funn ved bildeundersøkelse - bruk arketype innen gruppen av CLUSTER.imaging_exam (Bildeundersøkelse) for dette.">
+        >
+        ["pt-br"] = <
+            language = <[ISO_639-1::pt-br]>
+            purpose = <"*To record the findings observed during the physical examination of a body system or anatomical structure. (en)">
+            use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+            misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose. (en)">
+        >
+        ["el"] = <
+            language = <[ISO_639-1::el]>
+            purpose = <"Για την καταγραφή των ευρημάτων που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+            use = <"*Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element. (en)">
+            misuse = <"*Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.(en)">
+        >
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"To record the findings observed during the physical examination of a body system or anatomical structure.">
+            use = <"Use to record the observed findings during the physical examination of a body system or anatomical structure.
+
+This archetype has been specifically designed to be used in the 'Examination detail' SLOT within the OBSERVATION.exam or the \"Procedure detail\" SLOT within the ACTION.procedure archetype, but can also be used within other ENTRY or CLUSTER archetypes, where clinically appropriate. Specialisations of this archetype will be used to record examination findings for identified body systems, anatomical structures or more precise body sites. Each specialisation will preserve the underlying structure of this general archetype as its base and be extended by the addition of elements specific to the body site. If there is no appropriate specialisation available, use this archetype and identify the system or structure being examined using the 'System or structure examined' data element and the location on the body using the 'Body site' data element or the 'Structured body site' SLOT.
+
+Interpretation of the findings, for example 'No abnormality detected' or 'Moderate inflammation present', can be recorded using the 'Clinical interpretation' data element.
+
+Use to provide a framework in which CLUSTER archetypes can be nested in the 'Examination findings' SLOT to record additional structured physical examination findings.
+
+The CLUSTER.exclusion_exam archetype can be nested within the 'Examination not done' SLOT to optionally record explicit details about the examination not being performed.
+
+Use to incorporate the narrative descriptions of clinical findings within existing or legacy clinical systems into an archetyped format, using the 'Clinical Description' data element.">
+            misuse = <"Not to be used for recording the clinical history - use specific OBSERVATION and CLUSTER archetypes. For example OBSERVATION.story and CLUSTER.symptom_sign.
+
+Not to be used for recording the results of an imaging examination - use the CLUSTER.imaging_exam family of archetypes for this purpose.">
+            copyright = <"© openEHR Foundation">
+        >
+        ["es"] = <
+            language = <[ISO_639-1::es]>
+            purpose = <"Registrar los hallazgos observados durante el examen físico de un sistema corporal o estructura anatómica.">
+            use = <"Se utiliza para registrar los hallazgos observados durante la exploración física de un sistema corporal o estructura anatómica.
+
+Este arquetipo se ha diseñado específicamente para su uso en el SLOT \"Detalle del examen\" dentro de OBSERVATION.exam o en el SLOT \"Detalle del procedimiento\" dentro de ACTION.procedure, pero también puede utilizarse dentro de otros arquetipos de ENTRY o CLUSTER, cuando sea clínicamente apropiado. Las especializaciones de este arquetipo se utilizarán para registrar los hallazgos de la exploración de sistemas corporales, estructuras anatómicas o zonas corporales más precisas identificadas. Cada especialización conservará la estructura subyacente de este arquetipo general como base y se ampliará añadiendo elementos específicos de la zona corporal. Si no hay una especialización adecuada disponible, utilice este arquetipo e identifique el sistema o la estructura que se examina utilizando el elemento de datos \"Sistema o estructura examinada\" y la ubicación en el cuerpo utilizando el elemento de datos \"Zona corporal\" o la ranura \"Zona corporal estructurada\".
+
+Interpretación de los hallazgos, por ejemplo, \"No se detecta ninguna anomalía\" o La presencia de inflamación moderada se puede registrar mediante el elemento de datos \"Interpretación clínica\".
+
+Se utiliza para proporcionar un marco en el que los arquetipos CLUSTER se pueden anidar en la ranura \"Hallazgos del examen\" para registrar hallazgos adicionales estructurados del examen físico.
+
+El arquetipo CLUSTER.exclusion_exam se puede anidar en la ranura \"Examen no realizado\" para registrar opcionalmente detalles explícitos sobre el examen no realizado.
+
+Se utiliza para incorporar las descripciones narrativas de los hallazgos clínicos en sistemas clínicos existentes o heredados en un formato arquetipado, mediante el elemento de datos \"Descripción clínica\".">
+            misuse = <"No debe utilizarse para registrar la historia clínica; utilice los arquetipos específicos OBSERVATION y CLUSTER. Por ejemplo, OBSERVATION.story y CLUSTER.symptom_sign.
+
+No debe utilizarse para registrar los resultados de un examen de imagen; utilice la familia de arquetipos CLUSTER.imaging_exam para este fin.">
+        >
+        ["ca"] = <
+            language = <[ISO_639-1::ca]>
+            purpose = <"Registrar les troballes observades durant l'examen físic del cos o estructura anatòmica.">
+            use = <"S'utilitza per registrar les troballes observades durant l'examen físic del cos o estructura anatòmica.
+
+Aquest arquetip ha estat dissenyat específicament per a ser utilitzat en el SLOT 'Examination detail' dins de l'OBSERVATION.exam o del SLOT \"Procedure detail\" dins de l'arquetip ACTION.procedure, però també es pot utilitzar dins d'altres arquetips ENTRY o CLUSTER, quan sigui clínicament apropiat. Les especialitzacions d'aquest arquetip s'utilitzaran per registrar els resultats de l'examen per a sistemes corporals identificats, estructures anatòmiques o llocs corporals més precisos. Cada especialització preservarà com a base l'estructura subjacent d'aquest arquetip general i s'ampliarà mitjançant l'addició d'elements específics al cos. Si no hi ha una especialització adequada disponible, utilitzeu aquest arquetip i identifiqueu el sistema o estructura que s'està examinant utilitzant l'element de dades \"Sistema o estructura examinada\" i la ubicació en el cos utilitzant l'element de dades \"lloc del cos\" o la RANURA \"lloc del cos estructurat\".
+
+La interpretació de les troballes, per exemple 'No s'ha detectat cap anormalitat' o 'inflamació present moderada', es pot registrar utilitzant l'element de dades 'interpretació clínica'.
+
+S'utilitza per proporcionar un marc en el qual els arquetips de CLUSTER poden ser afegits en el SLOT \"Troballes de l'examen\" per registrar resultats d'un examen físic estructurats addicionals.
+
+L'arquetip CLUSTER.exclusion_exam es pot afegir dins del SLOT 'Examen no realitzat' per tal de registrar opcionalment detalls explícits sobre l'examen que no s'està realitzant.
+
+Incorporar les descripcions narratives de les troballes clíniques dins dels sistemes clínics existents o llegats en un format arquetipat, utilitzant l'element de dades de \"Descripció clínica\".">
+            misuse = <"No s'ha d'utilitzar per registrar la història clínica - utilitzar els arquetipis OBSERVATION i CLUSTER. Exemple: OBSERVATION.story i CLUSTER.symptom_sign.
+
+No s'ha d'utilitzar per registrar els resultats d'un examen d'imatge - utilitzar la família d'arquetips CLUSTER.imaging_exam per a aquest propòsit.">
+        >
+    >
+
+definition
+    CLUSTER[id1] matches {    -- Physical examination findings
+        items cardinality matches {1..*; unordered} matches {
+            ELEMENT[id2] occurrences matches {1} matches {    -- System or structure examined
+                value matches {
+                    DV_TEXT[id9000]
+                }
+            }
+            ELEMENT[id13] occurrences matches {0..1} matches {    -- Body site
+                value matches {
+                    DV_TEXT[id9001]
+                }
+            }
+            allow_archetype CLUSTER[id12] matches {    -- Structured body site
+                include
+                    archetype_id/value matches {/openEHR-EHR-CLUSTER\.anatomical_location(-[a-zA-Z0-9_]+)*\.v1\..*|openEHR-EHR-CLUSTER\.anatomical_location_circle(-[a-zA-Z0-9_]+)*\.v1\..*|openEHR-EHR-CLUSTER\.anatomical_location_relative(-[a-zA-Z0-9_]+)*\.v2\..*/}
+            }
+            ELEMENT[id4] occurrences matches {0..1} matches {    -- Clinical description
+                value matches {
+                    DV_TEXT[id9002]
+                }
+            }
+            allow_archetype CLUSTER[id5] matches {    -- Examination findings
+                include
+                    archetype_id/value matches {/.*/}
+            }
+            allow_archetype CLUSTER[id6] matches {    -- Multimedia representation
+                include
+                    archetype_id/value matches {/openEHR-EHR-CLUSTER\.media_file(-[a-zA-Z0-9_]+)*\.v1\..*/}
+            }
+            ELEMENT[id7] matches {    -- Clinical interpretation
+                value matches {
+                    DV_TEXT[id9003]
+                }
+            }
+            ELEMENT[id8] occurrences matches {0..1} matches {    -- Comment
+                value matches {
+                    DV_TEXT[id9004]
+                }
+            }
+            allow_archetype CLUSTER[id9] matches {    -- Examination not done
+                include
+                    archetype_id/value matches {/openEHR-EHR-CLUSTER\.exclusion_exam(-[a-zA-Z0-9_]+)*\.v1\..*/}
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["de"] = <
+            ["id1"] = <
+                text = <"Ergebnisse der körperlichen Untersuchung">
+                description = <"Während der körperlichen Untersuchung eines Körpersystems oder einer anatomischen Struktur beobachtete Befunde.">
+            >
+            ["id2"] = <
+                text = <"Untersuchtes System oder untersuchte Struktur">
+                description = <"Identifizierung des untersuchten Körpersystems oder der anatomischen Struktur.">
+                comment = <"Wenn möglich wird die Kodierung des untersuchten Systems oder der untersuchten Struktur mit einer Terminologie bevorzugt.">
+            >
+            ["id4"] = <
+                text = <"Klinische Beschreibung">
+                description = <"Beschreibung der bei der körperlichen Untersuchung beobachteten Gesamtbefunde.">
+            >
+            ["id5"] = <
+                text = <"Untersuchungsergebnisse">
+                description = <"Strukturierte Angaben zu den Ergebnissen der körperlichen Untersuchung.">
+            >
+            ["id6"] = <
+                text = <"Multimediale Darstellung">
+                description = <"Digitales Bild, Video oder Diagramm, das die Ergebnisse der körperlichen Untersuchung darstellt.">
+            >
+            ["id7"] = <
+                text = <"Klinische Interpretation">
+                description = <"Ein einzelnes Wort, eine Phrase oder eine kurze Beschreibung, die die klinische Bedeutung und Wichtigkeit der Untersuchungsergebnisse darstellt.">
+                comment = <"Zum Beispiel: „Ohne Befund“ oder „Mäßige Entzündung vorhanden“. Wenn möglich, wird die Codierung der „Klinischen Interpretation“ mit einer Terminologie bevorzugt.">
+            >
+            ["id8"] = <
+                text = <"Kommentar">
+                description = <"Zusätzliche Beschreibung der Ergebnisse der körperlichen Untersuchung, die in anderen Bereichen nicht erfasst werden konnten.">
+            >
+            ["id9"] = <
+                text = <"Nicht durchgeführte Untersuchung">
+                description = <"Eine Aussage die ausdrücklich erfasst, dass die Untersuchung nicht durchgeführt wurde.">
+            >
+            ["id12"] = <
+                text = <"Strukturierte Körperstelle">
+                description = <"Eine strukturierte Beschreibung des zu untersuchenden Körperbereichs.">
+                comment = <"Wenn die Körperstelle im Datenelement \"Untersuchtes System oder untersuchte Struktur\" oder im Datenelement \"Körperstelle\" vollständig identifiziert wurde, wird die Verwendung dieses SLOT überflüssig.">
+            >
+            ["id13"] = <
+                text = <"Körperstelle">
+                description = <"Identifizierung des untersuchten Körperbereichs.">
+                comment = <"Zum Beispiel die Untersuchung einer bestimmten Hautpartie. Wenn die Körperstelle im Datenelement „Untersuchtes System oder Struktur“ vollständig identifiziert wurde, wird dieses Datenelement überflüssig.">
+            >
+        >
+        ["sv"] = <
+            ["id1"] = <
+                text = <"*Physical examination findings (en)">
+                description = <"Observerade fynd vid fysisk undersökning av system i kroppen, eller av anatomisk struktur">
+            >
+            ["id2"] = <
+                text = <"System eller struktur som undersökts">
+                description = <"Identifiering av systemet eller strukturen som undersökts.">
+                comment = <"Om möjligt, koda systemet eller strukturen med hjälp av ett terminologisystem.">
+            >
+            ["id4"] = <
+                text = <"Klinisk beskrivning">
+                description = <"En övergripande beskrivning av fynden från den fysiska undersökningen. ">
+            >
+            ["id5"] = <
+                text = <"Fynd vid undersökning">
+                description = <"Strukturerade detaljer om fynd vid den fysiska undersökningen.">
+            >
+            ["id6"] = <
+                text = <"Multimedia-representation">
+                description = <"Digital bild, video eller diagram som återger fynd från undersökningen.">
+            >
+            ["id7"] = <
+                text = <"Klinisk tolkning">
+                description = <"Ord, fras eller kort beskrivning av fyndens kliniska betydelse.">
+                comment = <"*For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible. (en)">
+            >
+            ["id8"] = <
+                text = <"Kommentar">
+                description = <"Kommentarer avseende undersökningsfynd som inte beskrivs i övriga fält.">
+            >
+            ["id9"] = <
+                text = <"Undersökning ej genomförd">
+                description = <"Detaljerad beskrivning om att undersökningen inte genomfördes.">
+            >
+            ["id12"] = <
+                text = <"Strukturerad anatomisk plats">
+                description = <"Strukturerad beskrivning av den anatomiska platsen som undersökts.">
+                comment = <"Om den anatomiska platsen kan identifieras helt via dataelementet \"System eller struktur som undersökts\" så blir denna del redundant.">
+            >
+            ["id13"] = <
+                text = <"Anatomisk plats">
+                description = <"*Identification of the area of the body under examination. (en)">
+                comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+            >
+        >
+        ["nb"] = <
+            ["id1"] = <
+                text = <"Funn ved fysisk undersøkelse">
+                description = <"Undersøkelsesfunn gjort ved fysisk undersøkelse av et organsystem eller anatomisk struktur.">
+            >
+            ["id2"] = <
+                text = <"Undersøkt organsystem eller struktur">
+                description = <"Identifisering av det undersøkte organsystemet eller den anatomiske strukturen.">
+                comment = <"Det anbefales å kode organsystem eller den anatomiske strukturen med en terminologi dersom mulig.">
+            >
+            ["id4"] = <
+                text = <"Klinisk beskrivelse">
+                description = <"Fritekstbeskrivelse av de overordnede funnene ved den fysiske undersøkelsen.">
+            >
+            ["id5"] = <
+                text = <"Spesifikke funn">
+                description = <"Ytterligere strukturerte detaljer om undersøkelsesfunnene.">
+            >
+            ["id6"] = <
+                text = <"Multimediarepresentasjon">
+                description = <"Digitale bilder, video eller diagram som representerer undersøkelsesfunnene.">
+            >
+            ["id7"] = <
+                text = <"Fortolkning">
+                description = <"Enkelt ord, setning, frase eller kort beskrivelse som representerer den kliniske betydning og viktigheten av funnene ved den fysiske undersøkelsen.">
+                comment = <"For eksempel \"Uten anmerkning\" eller \"Moderat inflammasjon\". Det anbefales å kode \"Fortolkning\" med en terminologi dersom mulig.">
+            >
+            ["id8"] = <
+                text = <"Kommentar">
+                description = <"Ytterligere fritekst om funn ved undersøkelsen, som ikke dekkes av andre elementer.">
+            >
+            ["id9"] = <
+                text = <"Undersøkelse ikke utført">
+                description = <"Detaljer for å eksplisitt registrere at denne undersøkelsen ikke ble utført.">
+            >
+            ["id12"] = <
+                text = <"Strukturert anatomisk lokalisasjon">
+                description = <"Angivelse av en strukturert anatomisk lokalisering av det undersøkte organsystemet eller den anatomiske strukturen.">
+                comment = <"Hvis anatomisk lokalisasjon er entydig identifisert i elementet \"Undersøkt organsystem eller struktur\" er dette SLOT'et ikke nødvendig å benytte.">
+            >
+            ["id13"] = <
+                text = <"Anatomisk lokalisasjon">
+                description = <"Identifisering av et enkelt fysisk sted enten på eller i menneskekroppen.">
+                comment = <"For eksempel undersøkelse av et spesifikt område på huden. Dersom den anatomiske lokaliseringen allerede er identifisert i elementet \"Undersøkt organsystem eller struktur\" er dette dataelementet overflødig.">
+            >
+        >
+        ["pt-br"] = <
+            ["id1"] = <
+                text = <"*Physical examination findings (en)">
+                description = <"Constatações observadas durante o exame físico de um sistema corporal ou estrutura anatômica.">
+            >
+            ["id2"] = <
+                text = <"Sistema ou estrutura examinada">
+                description = <"Identificação do sistema do corpo examinado ou da estrutura anatômica.">
+                comment = <"A codificação do sistema ou estrutura examinada com uma terminologia é preferível, sempre que possível.">
+            >
+            ["id4"] = <
+                text = <"Descrição clínica">
+                description = <"Descrição narrativa dos achados gerais observados durante o exame físico.">
+            >
+            ["id5"] = <
+                text = <"Resultados do exame">
+                description = <"Detalhes estruturados sobre os resultados do exame físico.">
+            >
+            ["id6"] = <
+                text = <"Representação multimídia">
+                description = <"Imagem digital, vídeo ou diagrama representando os achados do exame físico.">
+            >
+            ["id7"] = <
+                text = <"Interpretação clínica">
+                description = <"Palavra, frase ou breve descrição que represente o significado clínico e o significado dos resultados do exame físico.">
+                comment = <"*For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible. (en)">
+            >
+            ["id8"] = <
+                text = <"Comentário">
+                description = <"Narrativa adicional sobre os achados do exame físico, não capturados em outros campos.">
+            >
+            ["id9"] = <
+                text = <"Exame não realizado">
+                description = <"Detalhes para registrar explicitamente que esse exame não foi realizado.">
+            >
+            ["id12"] = <
+                text = <"Local do corpo estruturado">
+                description = <"Uma descrição estruturada da área do corpo em exame.">
+                comment = <"Se o local do corpo tiver sido totalmente identificado no elemento de dados 'Sistema ou estrutura examinada' ou 'Local do corpo', esse SLOT se tornará redundante.">
+            >
+            ["id13"] = <
+                text = <"Local do corpo">
+                description = <"*Identification of the area of the body under examination. (en)">
+                comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+            >
+        >
+        ["el"] = <
+            ["id1"] = <
+                text = <"*Physical examination findings (en)">
+                description = <"Ευρήματα που παρατηρούνται κατά τη φυσική εξέταση ενός συστήματος σώματος ή ανατομικής δομής.">
+            >
+            ["id2"] = <
+                text = <"Εξεταζόμενο σύστημα ή δομή">
+                description = <"Ταυτοποίηση του εξεταζόμενου συστήματος σώματος ή ανατομικής δομής.">
+                comment = <"Προτιμάται η κωδικοποίηση του συστήματος ή της δομής που εξετάζεται με ορολογία, όπου είναι δυνατόν.">
+            >
+            ["id4"] = <
+                text = <"Κλινική Περιγραφή">
+                description = <"Αφηγηματική περιγραφή των συνολικών ευρημάτων που παρατηρήθηκαν κατά τη διάρκεια της φυσικής εξέτασης.">
+            >
+            ["id5"] = <
+                text = <"Ευρήματα εξέτασης">
+                description = <"Δομημένες λεπτομέρειες σχετικά με τα ευρήματα της φυσικής εξέτασης.">
+            >
+            ["id6"] = <
+                text = <"Αναπαράσταση πολυμέσων">
+                description = <"Ψηφιακή εικόνα, βίντεο ή διάγραμμα που αναπαριστά τα ευρήματα της φυσικής εξέτασης.">
+            >
+            ["id7"] = <
+                text = <"Κλινική αξιολόγηση">
+                description = <"Μία λέξη, φράση ή σύντομη περιγραφή που αντιπροσωπεύει την κλινική σημασία και σημασία των ευρημάτων της φυσικής εξέτασης.">
+                comment = <"Για παράδειγμα: «Δεν ανιχνεύθηκε ανωμαλία» ή «Υπάρχει μέτρια φλεγμονή». Προτιμάται η κωδικοποίηση της «κλινικής ερμηνείας» με ορολογία, όπου είναι δυνατόν.">
+            >
+            ["id8"] = <
+                text = <"Σχόλιο">
+                description = <"Πρόσθετη αφήγηση σχετικά με τα ευρήματα της φυσικής εξέτασης, που δεν αποτυπώνεται σε άλλους τομείς.">
+            >
+            ["id9"] = <
+                text = <"Λόγος διακοπής εξέτασης">
+                description = <"Λεπτομέρειες για να καταγραφεί ρητά ότι αυτή η εξέταση δεν διενεργήθηκε.">
+            >
+            ["id12"] = <
+                text = <"ω">
+                description = <"περιγραφή της περιοχής του υπό εξέταση σώματος.">
+                comment = <"*If the body site has been fully identified in the 'System or structure examined' or the 'Body site' data element, this SLOT becomes redundant.(en)">
+            >
+            ["id13"] = <
+                text = <"Περιοχή σώματος">
+                description = <"*Identification of the area of the body under examination. (en)">
+                comment = <"*For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant. (en)">
+            >
+        >
+        ["en"] = <
+            ["id1"] = <
+                text = <"Physical examination findings">
+                description = <"Findings observed during the physical examination of a body system or anatomical structure.">
+            >
+            ["id2"] = <
+                text = <"System or structure examined">
+                description = <"Identification of the examined body system or anatomical structure.">
+                comment = <"Coding of the system or structure examined with a terminology is preferred, where possible.">
+            >
+            ["id4"] = <
+                text = <"Clinical description">
+                description = <"Narrative description of the overall findings observed during the physical examination.">
+            >
+            ["id5"] = <
+                text = <"Examination findings">
+                description = <"Structured details about the physical examination findings.">
+            >
+            ["id6"] = <
+                text = <"Multimedia representation">
+                description = <"Digital image, video or diagram representing the physical examination findings.">
+            >
+            ["id7"] = <
+                text = <"Clinical interpretation">
+                description = <"Single word, phrase or brief description that represents the clinical meaning and significance of the physical examination findings.">
+                comment = <"For example: 'No abnormality detected' or 'Moderate inflammation present'. Coding of the 'Clinical interpretation' with a terminology is preferred, where possible.">
+            >
+            ["id8"] = <
+                text = <"Comment">
+                description = <"Additional narrative about the physical examination findings, not captured in other fields.">
+            >
+            ["id9"] = <
+                text = <"Examination not done">
+                description = <"Details to explicitly record that this examination was not performed.">
+            >
+            ["id12"] = <
+                text = <"Structured body site">
+                description = <"A structured description of the area of the body under examination.">
+                comment = <"If the body site has been fully identified in the 'System or structure examined' or the 'Body site' data element, this SLOT becomes redundant.">
+            >
+            ["id13"] = <
+                text = <"Body site">
+                description = <"Identification of the area of the body under examination.">
+                comment = <"For example examination of a specific area of skin. If the body site has been fully identified in the 'System or structure examined' data element, this data element becomes redundant.">
+            >
+        >
+        ["es"] = <
+            ["id1"] = <
+                text = <"Hallazgos de la exploración física">
+                description = <"Hallazgos observados durante la exploración física de un sistema corporal o estructura anatómica.">
+            >
+            ["id2"] = <
+                text = <"Sistema o estructura examinada">
+                description = <"Identificación del sistema corporal o estructura anatómica examinados.">
+                comment = <"Se prefiere, siempre que sea posible, codificar el sistema o la estructura examinada con una terminología.">
+            >
+            ["id4"] = <
+                text = <"Descripción clínica">
+                description = <"Descripción narrativa de los hallazgos generales observados durante la exploración física.">
+            >
+            ["id5"] = <
+                text = <"Hallazgos de la exploración">
+                description = <"Detalles estructurados sobre los hallazgos de la exploración física.">
+            >
+            ["id6"] = <
+                text = <"Representación multimedia">
+                description = <"Imagen digital, video o diagrama que representa los hallazgos de la exploración física.">
+            >
+            ["id7"] = <
+                text = <"Interpretación clínica">
+                description = <"Palabra, frase o descripción breve que representa el significado clínico y la importancia de los hallazgos de la exploración física.">
+                comment = <"Por ejemplo: \"No se detecta ninguna anomalía\" o \"Inflamación moderada\". Se prefiere codificar la \"Interpretación clínica\" con una terminología, siempre que sea posible.">
+            >
+            ["id8"] = <
+                text = <"Comentario">
+                description = <"Narración adicional sobre los hallazgos de la exploración física, no registrada en otros campos.">
+            >
+            ["id9"] = <
+                text = <"Examen no realizado">
+                description = <"Detalles para registrar explícitamente que esta exploración no se realizó.">
+            >
+            ["id12"] = <
+                text = <"Zona corporal estructurada">
+                description = <"Descripción estructurada de la zona del cuerpo examinada.">
+                comment = <"Si la zona corporal se ha identificado completamente en los elementos de datos «Sistema o estructura examinada» o «Zona corporal», esta ranura se vuelve redundante.">
+            >
+            ["id13"] = <
+                text = <"Zona corporal">
+                description = <"Identificación de la zona del cuerpo examinada.">
+                comment = <"Por ejemplo, el examen de una zona específica de la piel. Si la zona corporal se ha identificado completamente en los elementos de datos «Sistema o estructura examinada», este elemento se vuelve redundante.">
+            >
+        >
+        ["ca"] = <
+            ["id1"] = <
+                text = <"Resultats de l'examen físic">
+                description = <"Troballes observades durant l'examen físic d'un sistema corporal o estructura anatòmica.">
+            >
+            ["id2"] = <
+                text = <"Sistema o estructura examinada">
+                description = <"Identificació del sistema corporal examinat o estructura anatòmica.">
+                comment = <"Preferiblement utilitzar la codificació del sistema o estructura examinada amb una terminologia, sempre que sigui possible.">
+            >
+            ["id4"] = <
+                text = <"Descripció clínica">
+                description = <"Descripció narrativa dels resultats globals observats durant l'examen físic.">
+            >
+            ["id5"] = <
+                text = <"Resultats de l'examen">
+                description = <"Detalls estructurats sobre els resultats de l'examen físic.">
+            >
+            ["id6"] = <
+                text = <"Representació multimèdia">
+                description = <"Imatge digital, vídeo o diagrama que representa els resultats de l'examen físic.">
+            >
+            ["id7"] = <
+                text = <"Interpretació clínica">
+                description = <"Paraula única, frase o breu descripció que representa el significat clínic i la significació de les troballes de l'examen físic.">
+                comment = <"Exemple: 'No s'ha detectat cap anormalitat' o 'inflamació present moderada'. Es prefereix la codificació de la \"interpretació clínica\" amb una terminologia, sempre que sigui possible.">
+            >
+            ["id8"] = <
+                text = <"Comentari">
+                description = <"Narrativa addicional sobre els resultats de l'examen físic, no capturada en altres camps.">
+            >
+            ["id9"] = <
+                text = <"Examen no realitzat">
+                description = <"Detalls per registrar explícitament que aquest examen no es va realitzar.">
+            >
+            ["id12"] = <
+                text = <"Part del cos estructurada">
+                description = <"Descripció estructurada de l'àrea del cos objecte d'examen.">
+                comment = <"Si el lloc del cos ha estat completament identificat en el \"Sistema o estructura examinada\" o l'element de dades del \"lloc cos\", aquest SLOT es torna redundant.">
+            >
+            ["id13"] = <
+                text = <"Part del cos">
+                description = <"Identificació de l'àrea de l'organisme objecte d'examen.">
+                comment = <"Exemple: l'examen d'una àrea específica de la pell. Si el lloc del cos ha estat completament identificat en l'element de dades \"Sistema o estructura examinada\", aquest element de dades esdevé redundant.">
+            >
+        >
+    >

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-OBSERVATION.demo_adl14.v1.adl
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-OBSERVATION.demo_adl14.v1.adl
@@ -1,0 +1,1014 @@
+archetype (adl_version=1.4; uid=489ceb2a-8336-406c-9fa5-e01b44643a47)
+	openEHR-EHR-OBSERVATION.demo.v1
+
+concept
+	[at0000]	-- Demonstration
+language
+	original_language = <[ISO_639-1::en]>
+	translations = <
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			author = <
+				["name"] = <"Silje Ljosland Bakke">
+				["organisation"] = <"Bergen Hospital Trust">
+			>
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			author = <
+				["name"] = <"Jussara Rötzsch">
+				["organisation"] = <"openEHR Foundation">
+				["email"] = <"jussara.macedo@gmail.com">
+			>
+			accreditation = <"MD. MSc., Pschyatrist, Clinical Modeller, Coordinator of  Standards and Semantic Interoperability of Brazil e-Health Initiative ">
+		>
+	>
+description
+	original_author = <
+		["name"] = <"Heather Leslie">
+		["organisation"] = <"Atomica Informatics">
+		["email"] = <"heather.leslie@atomicainformatics.com">
+		["date"] = <"2008-12-23">
+	>
+	details = <
+		["nb"] = <
+			language = <[ISO_639-1::nb]>
+			purpose = <"For å gi en oversikt over visningen av de forskjellige datatypene som er tilgjengelige i en openEHR-arketype. Gir også oversikt over Data, State, Event og Protocol-modellene i forbindelse med HTML-visning og tilknyttet ADL.">
+			use = <"For å gi en visuell oversikt over datatyper og komponenter i arketyper til nåværende og fremtidige deltakere i vurdering av arketyper.">
+			keywords = <"demonstrasjon", "test", "prototype", "datatyper", "state", "status", "protocol", "protokoll", "event", "hendelse", "data">
+			misuse = <"Skal ikke brukes til reelle kliniske data.">
+			copyright = <"© openEHR Foundation">
+		>
+		["pt-br"] = <
+			language = <[ISO_639-1::pt-br]>
+			purpose = <"Para fornecer uma visão geral da exibição de cada um dos tipos de dados  disponíveis em um arquétipo openEHR, e dos modelos de Dados, Eventos e Protocolos dentro de um contexto de uma tela HTML e ADL associado.">
+			use = <"Para fornecer uma visualisação geral dos tipos de dados e componetes dos arquétipos para atuais e potenciais revisores de conteúdo clínico no Gestor de Conhecimento Clínico openEHR, o CKM.">
+			keywords = <"demonstração", "teste", "protótipo(s)", "tipo(s) de dado(s)", "estado", "protocolo(s)", "evento(s)", "dado(s)">
+			misuse = <"Não apropriado para carregar nenhum dado clínico real.">
+			copyright = <"© openEHR Foundation">
+		>
+		["en"] = <
+			language = <[ISO_639-1::en]>
+			purpose = <"To provide an overview of the display of each of the datatypes available in an openEHR archetype, and of the Data, State, Event and Protocol models within the context of a HTML display and associated ADL.">
+			use = <"To provide a visual overview of archetype data types and archetype components to potential and current clinical content reviewers in the openEHR Clinical Knowledge Manager.">
+			keywords = <"demonstration", "test", "prototype", "datatypes", "state", "protocol", "event", "data">
+			misuse = <"Not to carry any real clinical data.">
+			copyright = <"© openEHR Foundation">
+		>
+	>
+	lifecycle_state = <"published">
+	other_contributors = <"Individual A, Argentina", "Individual B, Belgium", "Individual C, Canada (Editor)">
+	other_details = <
+		["licence"] = <"This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.">
+		["custodian_organisation"] = <"openEHR Foundation">
+		["references"] = <"openEHR website:  http://www.openehr.org/home.html
+CKM:  http://www.openehr.org/knowledge/">
+		["current_contact"] = <"Heather Leslie, Atomica Informatics<heather.leslie@atomicainformatics.com>">
+		["original_namespace"] = <"org.openehr">
+		["original_publisher"] = <"openEHR Foundation">
+		["custodian_namespace"] = <"org.openehr">
+		["MD5-CAM-1.0.1"] = <"44E350A26FDDA0C9E6E98F4BD527CE70">
+		["build_uid"] = <"b115156b-c2a5-46ab-ad0c-d0d99c0f979d">
+		["ip_acknowledgements"] = <"This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyrighted material of the International Health Terminology Standards Development Organisation (IHTSDO). Where an implementation of this artefact makes use of SNOMED CT content, the implementer must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/get-snomedct or info@snomed.org.">
+		["revision"] = <"1.0.0">
+	>
+
+definition
+	OBSERVATION[at0000] matches {	-- Demonstration
+		data matches {
+			HISTORY[at0001] matches {	-- Event Series
+				events cardinality matches {1..*; unordered} matches {
+					EVENT[at0002] occurrences matches {0..1} matches {	-- Any Event
+						data matches {
+							ITEM_TREE[at0003] matches {	-- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0032] occurrences matches {0..1} matches {*}
+									CLUSTER[at0004] occurrences matches {0..*} matches {	-- Heading1
+										items cardinality matches {1..*; unordered} matches {
+											ELEMENT[at0005] occurrences matches {0..1} matches {	-- Free Text or Coded
+												value matches {
+													DV_TEXT matches {*}
+												}
+											}
+											ELEMENT[at0006] occurrences matches {0..*} matches {	-- Text That Uses Internal Codes
+												value matches {
+													DV_CODED_TEXT matches {
+														defining_code matches {
+															[local::
+															at0007, 	-- Lying
+															at0008, 	-- Reclining
+															at0009, 	-- Sitting
+															at0010]	-- Standing
+														}
+													}
+												}
+											}
+											ELEMENT[at0011] matches {	-- Text That is Sourced From an External Terminology
+												value matches {
+													DV_CODED_TEXT matches {
+														defining_code matches {[ac0001]}		-- SubsetA
+													}
+												}
+											}
+											ELEMENT[at0012] occurrences matches {0..1} matches {	-- Quantity
+												value matches {
+													C_DV_QUANTITY <
+														property = <[openehr::122]>
+														list = <
+															["1"] = <
+																units = <"cm">
+																magnitude = <|0.0..100.0|>
+																precision = <|1|>
+															>
+															["2"] = <
+																units = <"mm">
+															>
+															["3"] = <
+																units = <"[in_i]">
+															>
+															["4"] = <
+																units = <"[ft_i]">
+															>
+														>
+													>
+												}
+											}
+											ELEMENT[at0023] occurrences matches {0..1} matches {	-- Interval of Quantity
+												value matches {
+													DV_INTERVAL<DV_QUANTITY> matches {
+														upper matches {
+															C_DV_QUANTITY <
+																property = <[openehr::122]>
+																list = <
+																	["1"] = <
+																		units = <"cm">
+																	>
+																	["2"] = <
+																		units = <"m">
+																	>
+																	["3"] = <
+																		units = <"[in_i]">
+																	>
+																	["4"] = <
+																		units = <"[ft_i]">
+																	>
+																>
+															>
+														}
+														lower matches {
+															C_DV_QUANTITY <
+																property = <[openehr::122]>
+																list = <
+																	["1"] = <
+																		units = <"cm">
+																	>
+																	["2"] = <
+																		units = <"m">
+																	>
+																	["3"] = <
+																		units = <"[in_i]">
+																	>
+																	["4"] = <
+																		units = <"[ft_i]">
+																	>
+																>
+															>
+														}
+													}
+												}
+											}
+											ELEMENT[at0013] occurrences matches {0..1} matches {	-- Count
+												value matches {
+													DV_COUNT matches {
+														magnitude matches {|>=0|}
+													}
+												}
+											}
+											ELEMENT[at0022] occurrences matches {0..1} matches {	-- Interval of Integer
+												value matches {
+													DV_INTERVAL<DV_COUNT> matches {
+														upper matches {
+															DV_COUNT matches {*}
+														}
+														lower matches {
+															DV_COUNT matches {*}
+														}
+													}
+												}
+											}
+											ELEMENT[at0028] occurrences matches {0..1} matches {	-- Proportion
+												value matches {
+													DV_PROPORTION matches {
+														is_integral matches {True}
+														type matches {0, 2, 3, 4}
+													}
+												}
+											}
+											ELEMENT[at0014] occurrences matches {0..1} matches {	-- Date/Time
+												value matches {
+													DV_DATE_TIME matches {*}
+												}
+											}
+											ELEMENT[at0024] occurrences matches {0..1} matches {	-- Interval of Date
+												value matches {
+													DV_INTERVAL<DV_DATE_TIME> matches {
+														upper matches {
+															DV_DATE_TIME matches {*}
+														}
+														lower matches {
+															DV_DATE_TIME matches {*}
+														}
+													}
+												}
+											}
+											ELEMENT[at0021] occurrences matches {0..1} matches {	-- Duration
+												value matches {
+													DV_DURATION matches {*}
+												}
+											}
+											ELEMENT[at0015] occurrences matches {0..1} matches {	-- Ordinal
+												value matches {
+													0|[local::at0038], 	-- No pain
+													1|[local::at0039], 	-- Slight pain
+													2|[local::at0040], 	-- Mild pain
+													5|[local::at0041], 	-- Moderate pain
+													9|[local::at0042], 	-- Severe pain
+													10|[local::at0043]  	-- Most severe pain imaginable
+												}
+											}
+											ELEMENT[at0016] occurrences matches {0..1} matches {	-- Boolean
+												value matches {
+													DV_BOOLEAN matches {
+														value matches {True, False}
+													}
+												}
+												null_flavour existence matches {0..1} matches {
+													DV_CODED_TEXT matches {
+														defining_code matches {
+															[openehr::
+															271,
+															272,
+															273,
+															253]
+														}
+													}
+												}
+											}
+											ELEMENT[at0017] occurrences matches {0..1} matches {*}
+											ELEMENT[at0025] occurrences matches {0..1} matches {	-- Choice
+												value matches {
+													C_DV_QUANTITY <
+														property = <[openehr::124]>
+														list = <
+															["1"] = <
+																units = <"g">
+															>
+															["2"] = <
+																units = <"[foz_us]">
+															>
+														>
+													>
+													DV_CODED_TEXT matches {
+														defining_code matches {[ac0003]}		-- SubsetB
+													}
+												}
+											}
+											ELEMENT[at0026] occurrences matches {0..1} matches {	-- Multimedia
+												value matches {
+													DV_MULTIMEDIA matches {
+														media_type matches {
+															[openEHR::
+															387,
+															388,
+															389,
+															390,
+															391,
+															392,
+															393,
+															394,
+															395,
+															396,
+															397,
+															398,
+															399,
+															400,
+															409,
+															410,
+															411,
+															412,
+															413,
+															425,
+															426,
+															427,
+															428,
+															429,
+															415,
+															416,
+															417,
+															418,
+															419,
+															420,
+															421,
+															422,
+															423,
+															424,
+															401,
+															402,
+															404,
+															405,
+															406,
+															407,
+															414,
+															517,
+															518,
+															519,
+															637]
+														}
+													}
+												}
+											}
+											ELEMENT[at0027] occurrences matches {0..1} matches {	-- URI - resource identifier
+												value matches {
+													DV_URI matches {*}
+												}
+											}
+											ELEMENT[at0044] occurrences matches {0..1} matches {	-- Identifier
+												value matches {
+													DV_IDENTIFIER matches {*}
+												}
+											}
+										}
+									}
+									CLUSTER[at0018] occurrences matches {0..1} matches {	-- Heading 2
+										items cardinality matches {1..*; unordered} matches {
+											allow_archetype CLUSTER[at0019] occurrences matches {0..*} matches {	-- Slot To Contain Other Cluster Archetypes
+												include
+													archetype_id/value matches {/openEHR-EHR-CLUSTER\.anatomical_location\.v1|openEHR-EHR-CLUSTER\.device\.v1/}
+											}
+											allow_archetype ELEMENT[at0020] occurrences matches {0..*} matches {	-- Slot To Contain Other Element Archetypes
+												include
+													archetype_id/value matches {/openEHR-EHR-ELEMENT\.ctg_codes\.v1/}
+												exclude
+													archetype_id/value matches {/.*/}
+											}
+										}
+									}
+								}
+							}
+						}
+						state matches {
+							ITEM_TREE[at0030] matches {	-- Tree
+								items cardinality matches {0..*; unordered} matches {
+									ELEMENT[at0031] occurrences matches {0..1} matches {*}
+								}
+							}
+						}
+					}
+					POINT_EVENT[at0033] occurrences matches {0..1} matches {	-- Named Point In Time
+						data matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/data[at0003]	-- /data[Event Series]/events[Any Event]/data[Tree]
+						}
+						state matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/state[at0030]	-- /data[Event Series]/events[Any Event]/state[Tree]
+						}
+					}
+					INTERVAL_EVENT[at0034] occurrences matches {0..1} matches {	-- Named Interval
+						math_function matches {
+							DV_CODED_TEXT matches {
+								defining_code matches {[openehr::147]}
+							}
+						}
+						data matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/data[at0003]	-- /data[Event Series]/events[Any Event]/data[Tree]
+						}
+						state matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/state[at0030]	-- /data[Event Series]/events[Any Event]/state[Tree]
+						}
+					}
+					POINT_EVENT[at0035] occurrences matches {0..1} matches {	-- Offset Point In Time
+						offset matches {
+							DV_DURATION matches {
+								value matches {|PT5M|}
+							}
+						}
+						data matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/data[at0003]	-- /data[Event Series]/events[Any Event]/data[Tree]
+						}
+						state matches {
+							use_node ITEM_TREE /data[at0001]/events[at0002]/state[at0030]	-- /data[Event Series]/events[Any Event]/state[Tree]
+						}
+					}
+				}
+			}
+		}
+		protocol matches {
+			ITEM_TREE[at0036] matches {	-- Tree
+				items cardinality matches {0..*; unordered} matches {
+					ELEMENT[at0037] occurrences matches {0..1} matches {*}
+					allow_archetype CLUSTER[at0045] occurrences matches {0..*} matches {	-- Extension
+						include
+							archetype_id/value matches {/.*/}
+					}
+				}
+			}
+		}
+	}
+
+
+ontology
+	terminologies_available = <"SNOMED-CT", ...>
+	term_definitions = <
+		["en"] = <
+			items = <
+				["at0000"] = <
+					text = <"Demonstration">
+					description = <"Demonstration archetype with descriptions and explanations.">
+				>
+				["at0001"] = <
+					text = <"Event Series">
+					description = <"@ internal @">
+				>
+				["at0002"] = <
+					text = <"Any Event">
+					description = <"All archetypes of the OBSERVATION class contain a HISTORY or EVENT model which contains information about the timing of the observation and the 'width' of the information - either a point in time or an interval.  The default is 'Any event' and it is not specified if this is a Point in time or an Interval.">
+				>
+				["at0003"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0004"] = <
+					text = <"Heading1">
+					description = <"This is a symbol for a cluster which can have other elements 'nested' within it.">
+				>
+				["at0005"] = <
+					text = <"Free Text or Coded">
+					description = <"Text data type in which free text can be entered or coding can be incorporated either in the template or at run time.">
+				>
+				["at0006"] = <
+					text = <"Text That Uses Internal Codes">
+					description = <"Text data type which can use an internal vocabulary.  Each of these 'internal codes' can be bound to a terminology code.">
+				>
+				["at0007"] = <
+					text = <"Lying">
+					description = <"Patient is lying supine.">
+				>
+				["at0008"] = <
+					text = <"Reclining">
+					description = <"Patient is reclining, propped up on one medium pillow.">
+				>
+				["at0009"] = <
+					text = <"Sitting">
+					description = <"Patient is sitting on a chair.">
+				>
+				["at0010"] = <
+					text = <"Standing">
+					description = <"Patient is standing.">
+				>
+				["at0011"] = <
+					text = <"Text That is Sourced From an External Terminology">
+					description = <"Text data type utilising codes derived from an external terminology source eg a SNOMED-CT, LOINC or ICD subset.">
+				>
+				["at0012"] = <
+					text = <"Quantity">
+					description = <"A quantity data type used to record a measurement associated with its' appropriate units.  These are derived from ISO standards and the Reference model enables conversion between these units. The example shown here is length.">
+				>
+				["at0013"] = <
+					text = <"Count">
+					description = <"Count data types are composed of an integer with no units eg for recording the number of children - in this example the minimum is set at 0 and the maximum not specified.">
+				>
+				["at0014"] = <
+					text = <"Date/Time">
+					description = <"Date/Time datatype allows recording of a date and/or time, including partial dates such as year only or month and year only.  Allow all is the default - so all forms of date/time are permitted.">
+				>
+				["at0015"] = <
+					text = <"Ordinal">
+					description = <"Ordinal datatypes pair a number and text - in this way scores can be calculated in software, or progression can be assessed eg if used in a pain score.">
+				>
+				["at0016"] = <
+					text = <"Boolean">
+					description = <"Boolean datatype that allows for true or false answers.">
+				>
+				["at0017"] = <
+					text = <"Any">
+					description = <"The datatype for this 'any' element can be specified or constrained in a template or at run-time, but is not explicitly modelled in the archetype.">
+				>
+				["at0018"] = <
+					text = <"Heading 2">
+					description = <"This is a symbol for a cluster which can have other elements 'nested' within it.">
+				>
+				["at0019"] = <
+					text = <"Slot To Contain Other Cluster Archetypes">
+					description = <"List of CLUSTER archetypes allowed to be included or excluded within this OBSERVATION archetype.">
+				>
+				["at0020"] = <
+					text = <"Slot To Contain Other Element Archetypes">
+					description = <"List of ELEMENT archetypes allowed to be included or excluded within this OBSERVATION archetype.">
+				>
+				["at0021"] = <
+					text = <"Duration">
+					description = <"Duration datatype allows recording of the duration of clinical concepts.  'Allow all time units' is the default, although specific time units can be explicitly modelled.  Maximum and minum values can be set for each time unit.">
+				>
+				["at0022"] = <
+					text = <"Interval of Integer">
+					description = <"Interval of integer datatype allows for recording of a range of counts eg 1-2 tablets prescribed.  Maximum and minimum values can be set for the lower count and the upper count.">
+				>
+				["at0023"] = <
+					text = <"Interval of Quantity">
+					description = <"Interval of quantity datatypes allow for the recording of a range of measurements in association with appropriate units eg 1-2cm (prescribed amount of cream for a rash).">
+				>
+				["at0024"] = <
+					text = <"Interval of Date">
+					description = <"Interval of integer datatype allows for recording of a range of dates eg between September 1, 2008 and September 8, 2008.">
+				>
+				["at0025"] = <
+					text = <"Choice">
+					description = <"Choice datatype allows for a number of types of element to be specified simultaneously and which can constrained or selected within a template or at run-time.  In this example, a text datatype set to Free text or Coded and another that is constrained to Terminology record data about the same data element.">
+				>
+				["at0026"] = <
+					text = <"Multimedia">
+					description = <"Multimedia datatypes allow for the recording of many types of multimedia files to be captured.  All available types have been explicitly selected in this example.">
+				>
+				["at0027"] = <
+					text = <"URI - resource identifier">
+					description = <"URI datatypes allow for recording of relationships from this data to data recorded elsewhere.  These links can be within the same EHR, or external eg to a  URL.">
+				>
+				["at0028"] = <
+					text = <"Proportion">
+					description = <"Proportion datatypes allow for ratios, percent, fractions and proportions to be modelled.">
+				>
+				["at0030"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0031"] = <
+					text = <"State - Definition">
+					description = <"All archetypes of the OBSERVATION class can  contain a STATE model which contains information about the subject of data at the time the information was collected, and this information is required for safe clinical interpretation of the core information. An example is the position of the patient at the time of measuring a blood pressure.  Datatypes are identical to those explained in the Data model, above.">
+				>
+				["at0032"] = <
+					text = <"Data - Definition">
+					description = <"All archetypes of the OBSERVATION class contain a DATA model  which contains the core information e.g. the systolic and diastolic pressures when measuring a blood pressure.">
+				>
+				["at0033"] = <
+					text = <"Named Point In Time">
+					description = <"An event that is both named (eg Birth) and constrained as a Point in time event records the data elements in relation to a specified point in time eg Weight at Birth.">
+				>
+				["at0034"] = <
+					text = <"Named Interval">
+					description = <"An event that is both named and constrained as an Interval event records the data elements in relation to a period of time eg Weight Loss over time.  The interval can be fixed or left unspecified.  In addition there are mathematical functions that can be specified to capture concepts such as change, decrease, increase, maximum, minimum, mean etc.">
+				>
+				["at0035"] = <
+					text = <"Offset Point In Time">
+					description = <"Offset Point in time records data at a point in time with a fixed offset of 5 minutes from another specified event eg recording a 2 minute Apgar reading at 2 minutes offset from Birth.">
+				>
+				["at0036"] = <
+					text = <"Tree">
+					description = <"@ internal @">
+				>
+				["at0037"] = <
+					text = <"Protocol - Definition">
+					description = <"All archetypes of the OBSERVATION class can contain a PROTOCOL model which records information on how the information was gathered or measured, and any other information that is not required for safe clinical interpretation of the core Data. Datatypes are identical to those explained in the Data model, above.">
+				>
+				["at0038"] = <
+					text = <"No pain">
+					description = <"No pain at all.">
+				>
+				["at0039"] = <
+					text = <"Slight pain">
+					description = <"Pain level rated as 1 out of a possible maximum score of 10.">
+				>
+				["at0040"] = <
+					text = <"Mild pain">
+					description = <"Pain level rated as 2 out of a possible maximum score of 10.">
+				>
+				["at0041"] = <
+					text = <"Moderate pain">
+					description = <"Pain level rated as 5 out of a possible maximum score of 10.">
+				>
+				["at0042"] = <
+					text = <"Severe pain">
+					description = <"Pain level rated as 9 out of a possible maximum score of 10.">
+				>
+				["at0043"] = <
+					text = <"Most severe pain imaginable">
+					description = <"Pain level rated as 10 out of a possible maximum score of 10.">
+				>
+				["at0044"] = <
+					text = <"Identifier">
+					description = <"Identifier datatypes enable recording of formal data identifiers.">
+				>
+				["at0045"] = <
+					text = <"Extension">
+					description = <"Additional information required to capture local context or to align with other reference models/formalisms.">
+					comment = <"For example: Local hospital departmental infomation or additional metadata to align with FHIR or CIMI equivalents.">
+				>
+			>
+		>
+		["pt-br"] = <
+			items = <
+				["at0000"] = <
+					text = <"Demonstração">
+					description = <"Arquétipo de Demonstração com descrições e explicações. ">
+				>
+				["at0001"] = <
+					text = <"*Event Series(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"Qualquer evento">
+					description = <"Todos os arquétipos da classe de OBSERVAÇÃO contêm um modelo de HISTÓRIA ou de EVENTO que contém informação sobre o período da observação com a duração  da informação-  seja um ponto no  tempo ou um intervalo temporal. O padrão predeterminado é ' Qualquer evento' e não é especificado, se é um Ponto no tempo ou um Intervalo.">
+				>
+				["at0003"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"Cabeçalho1">
+					description = <"Este é um símbolo para um 'cluster' que pode ter outros elementos 'aninhados' dentro dele.">
+				>
+				["at0005"] = <
+					text = <"Texto livre ou Codificado">
+					description = <"Tipo de dado Texto no qual se pode entrar ou  texto livre ou códigos podem ser incoprporados seja  no template ou no tempo de execução.">
+				>
+				["at0006"] = <
+					text = <"Texto Que Usa Códigos Internos">
+					description = <"Tipo de dados  Texto que pode usar um vocabulário interno. Cada um desses ' códigos internos' pode ser vnculado a um código de uma terminologia.">
+				>
+				["at0007"] = <
+					text = <"Deitado">
+					description = <"Paciente Deitado em posição supina ou decúbito dorsal.">
+				>
+				["at0008"] = <
+					text = <"Reclinado">
+					description = <"Paciente Reclinado, apoiado em um travesseiro médio.">
+				>
+				["at0009"] = <
+					text = <"Sentado">
+					description = <"Paciente está Sentado em uma cadeira.">
+				>
+				["at0010"] = <
+					text = <"Em pé">
+					description = <"Paciente está em Pé.">
+				>
+				["at0011"] = <
+					text = <"Texto Cuja Origem é uma Terminologia Externa ">
+					description = <"Tipo de dado Texto utilizando códigos originários de uma terminologia externa como, por exemplo, um subset do SNOMED CT, do LOINC ou da CID 10. ">
+				>
+				["at0012"] = <
+					text = <"Quantidade">
+					description = <"Um tipo de dado de Quantidade usado para registrar uma medida associada com suas uniddades apropriadas. Essas unidades são derivadas de norams ISO e o modelo de  Referência possibilita a conversão entre elas. O exemplo demonstrado aqui é o comprimento.">
+				>
+				["at0013"] = <
+					text = <"Contagem ">
+					description = <"Tipos de dados de Contagem são compostos de um número inteiro sem casas decimais (integer), por exemplo, para registar o número de filhos- nesse exemplo o mínimo é colocado como 0 e o máximo não é especificado.">
+				>
+				["at0014"] = <
+					text = <"Data/Horário">
+					description = <"Tipos de dado Data/Horário permite o registro de uma data e /ou um horário, incluindo  datas parciais como somente o mês ou o ano. Permite tudo como padrão de modo que todas as formas de data/horário são permitidas.">
+				>
+				["at0015"] = <
+					text = <"Ordinal">
+					description = <"Tipos de dados Ordinal pareiam um número e texto- deste modo  pode ser calculada uma pontuação pela  aplicação a progressão ser avaliada, como por exemplo se está se utilizando de uma escala de avaliação de dor.">
+				>
+				["at0016"] = <
+					text = <"Booleano">
+					description = <"Tipo de dado  Booleano que permite repostas do tipo falso ou verdadeiro.">
+				>
+				["at0017"] = <
+					text = <"Qualquer">
+					description = <"Este tipo de dado para esse elemento 'Qualquer' pode ser especificado ou 'restrito' num modelo ou no tempo de execução, mas não é especificamente modelado no arquétipo.">
+				>
+				["at0018"] = <
+					text = <"Cabelaçalho2">
+					description = <"Esse é o símbolo de um 'cluster' que pode ter outros elementos 'aninhados' dentro dele.">
+				>
+				["at0019"] = <
+					text = <"Slot Para Conter Outros Arquétipos Clusters">
+					description = <"Lista de arquétipos  CLUSTER permitidos de serem incluídos ou excluídos dentro deste arquétipo de  OBSERVAÇÃO.">
+				>
+				["at0020"] = <
+					text = <"Slot Para Conter Outroa Arququétipos de Elementos">
+					description = <"Lista de arquétipos de ELEMENTOS permitidos de serem incluíos ou excluídos dentro deste arquétipo de OBSERVAÇÃO.">
+				>
+				["at0021"] = <
+					text = <"Duração">
+					description = <"Tipo de dado Duração permite registrar a duração dos conceitos clínicos. O padrão predeterminado é 'Permitir  todas unidades de tempo', embora unidades específicas de tempo possam ser explicitamente modeladas.   Valores máximos e mínimos podem ser configurados para cada unidade de tempo.">
+				>
+				["at0022"] = <
+					text = <"Intervalo de Integer">
+					description = <"Tipo de dados de Intervalo de Integer permite o registro de uma faixa de contagem em intervalos, por exemplo, a cada 1 a 2 comprimidos prescritos. Os valores máximo e mínimo podem ser configurados para a contagem inferior ou para a superior.">
+				>
+				["at0023"] = <
+					text = <"Intervalo de Quantidade">
+					description = <"Tipos de dados de Intervalo de Quantidade permitem registrar uma gama de mediddas  associadas com unidades apropriadas, por exemplo, 1-2cm  (quantidade de creme prescrito para um uma erupção cutânea).">
+				>
+				["at0024"] = <
+					text = <"Intervalo de Data">
+					description = <"Tipo de dado de Intervalo de Integer permite o registro de uma faixa de datas como, por exemplo, entre 1 de Setembro de 2008 e 8 de Setembro de 2008.">
+				>
+				["at0025"] = <
+					text = <"Escolha">
+					description = <"Tipo de dado Escolha permite que um número de tipos de elementos sejam simultaneamente especificados, os quais podem ser restringidos num template ou no tempo de execução. Neste exemplo, um tipo de dado Texto é configurado para Texto livre ou Codificado e outro que é configurado restritamente para  registrar códigos de uma determinada terminologia para o mesmo elemento de dado.">
+				>
+				["at0026"] = <
+					text = <"Multimídia">
+					description = <"Tipos de dado Multimídia permitem o registro de vários tipos de arquivos multimídia. Todos os tipos disponíveis foram explicitamente selecionados neste exemplo.">
+				>
+				["at0027"] = <
+					text = <"URI - Identificador de Recursos ">
+					description = <"Tipos de dados URI permitem registrar os relacionamentos entre  estes dados e os dados registrados em outros lugares. Esses enlaces (links) podem estar  no mesmo RES ou serem externos, por exemplo, pertencer a  num endereço  na internet, uma URL.">
+				>
+				["at0028"] = <
+					text = <"Porporção">
+					description = <"Tipos de dados de Proporção permitem modelar taxas, porcentagens, frações e proporções.">
+				>
+				["at0030"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0031"] = <
+					text = <"Estado - Definição">
+					description = <"Todos os arquétipos da classe de OBSERVAÇÃO podem conter um modelo de ESTADO, que contém a informação sobre o sujeito a informação na hora que o dado foi colhido, e essa informação é requisito para uma interpretação segura das informações básicas. Um exemplo disso é a posição que o paciente se encontrava quando sua pressão arterial foi medida. Os tipos de dados são idênticos aos que foram explicados no modelo de DADOS acima.">
+				>
+				["at0032"] = <
+					text = <"Dados - Definição ">
+					description = <"Todos os arquétipos da classe de OBSERVAÇÃO contêm um modelo de DADOS que contém as informações básicas, por exemplo, as pressões sistólica e diastólica, quando está se medindo a pressão sanguínea.">
+				>
+				["at0033"] = <
+					text = <"Ponto no tempo Nomeado">
+					description = <"Um evento que é ao mesmo tempo nomeado (p. ex. Nascimento) e restrito como evento em um  Ponto no tempo, registra os elementos de dados relacionados a um ponto específico no tempo, como por exemplo, Peso no Nascimento.">
+				>
+				["at0034"] = <
+					text = <"Intervalo Nomeado">
+					description = <"Um evento que é ao mesmo tempo nomeado e restrito como um evento Intervalo, registra os mesmos elementos de dados relacionados ao período de tempo, por exemplo, Perda de peso durante o determinado período. O intervalo pode ser fixado, ou deixado inespecificado. Além disso,  pode-se especificar funções matemáticas para capturar conceitos como mudança, diminuição aumento, máximo, mínimo, média,etc.">
+				>
+				["at0035"] = <
+					text = <"Deslocamento do Ponto no tempo">
+					description = <"Deslocamento  do Ponto no Tempo registra o deslocamento fixo de 5 minutos de outro evento especificado, por exemplo, registrando a leitura de um escore de Apgar de 2 minutos aos 2 minutos após o parto.">
+				>
+				["at0036"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0037"] = <
+					text = <"Protocolo-Definição">
+					description = <"Todos os arquétipos da classe de OBSERVAÇÃO podem conter um modelo de PROTOCOLO, o qual registra informação sobre como a informação foi colhida ou medida e quaisquer outras informações que não sejam necessárias para a interpretação clínica  segura das informações básicas. Os tipos de dados são idênticos àqueles explicados no modelo e DADOS acima.">
+				>
+				["at0038"] = <
+					text = <"Sem dor">
+					description = <"Nenhuma dor.">
+				>
+				["at0039"] = <
+					text = <"Dor leve">
+					description = <"Dor classificada como nível 1 numa escala máxima de 10.">
+				>
+				["at0040"] = <
+					text = <"Dor branda">
+					description = <"Dor classificada como nível 2 numa escala máxima de 10.">
+				>
+				["at0041"] = <
+					text = <"Dor Moderada">
+					description = <"Dor classificada  como nível 5 numa escala máxima de 10.">
+				>
+				["at0042"] = <
+					text = <"Dor severa">
+					description = <"Dor classificada nível 9 numa escala de 10.">
+				>
+				["at0043"] = <
+					text = <"Pior dor possível">
+					description = <"Dor classificada como nível 10 numa escala de 10.">
+				>
+				["at0044"] = <
+					text = <"Identificador">
+					description = <"Tipos de dados Identificadores possibilitam registrar identificadores formais de dados.">
+				>
+				["at0045"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local context or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: Local hospital departmental infomation or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["at0000"] = <
+					text = <"Demonstrasjon">
+					description = <"Demonstrasjonsarketype med beskrivelser og forklaringer.">
+				>
+				["at0001"] = <
+					text = <"*Event Series(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0002"] = <
+					text = <"Tidfestet hendelse">
+					description = <"Alle arketyper av OBSERVATION-klassen inneholder en HISTORY eller EVENT-modell som inneholder informasjon om tidfesting av observasjonen og \"bredden\" av informasjonen, enten et tidspunkt eller et intervall. Standardverdi er \"Tidfestet hendelse\", og det er ikke spesifisert om dette er et tidspunkt eller et intervall.">
+				>
+				["at0003"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0004"] = <
+					text = <"Overskrift1">
+					description = <"Dette er et symbol for et \"cluster\" som kan inneholde andre elementer.">
+				>
+				["at0005"] = <
+					text = <"Fri eller kodet tekst">
+					description = <"Tekstdatatype som kan inneholde fritekst eller kodet tekst. Kodingen kan legges inn enten i template eller i applikasjonen.">
+				>
+				["at0006"] = <
+					text = <"Tekst med interne koder">
+					description = <"Tekstdatatype som bruker et internt vokabular. Hver av disse \"interne kodene\" kan bindes til en terminologikode.">
+				>
+				["at0007"] = <
+					text = <"Liggende">
+					description = <"Pasienten ligger på ryggen.">
+				>
+				["at0008"] = <
+					text = <"Tilbakelent">
+					description = <"Pasienten ligger tilbakelent, støttet av en mellomstor pute.">
+				>
+				["at0009"] = <
+					text = <"Sittende">
+					description = <"Pasienten sitter i en stol.">
+				>
+				["at0010"] = <
+					text = <"Stående">
+					description = <"Pasienten står oppreist.">
+				>
+				["at0011"] = <
+					text = <"Tekst hentet fra en ekstern terminologi">
+					description = <"Tekstdata som bruker koder fra en ekstern terminologikilde, f.eks. SNOMED CT, LOINC eller ICD.">
+				>
+				["at0012"] = <
+					text = <"Kvantitet">
+					description = <"En kvantitetsdatatype som brukes til å registrere målinger tilknyttet passende enheter. Disse hentes fra ISO-standarder, og referansemodellen tillater konvertering mellom enhetene. Eksempelet vist er her lengde.">
+				>
+				["at0013"] = <
+					text = <"Antall">
+					description = <"Antall-datatypen består av et heltall uten enheter, f.eks. for å registrere antall barn. I dette eksempelet er minimum satt til 0 og maksimum er uspesifisert.">
+				>
+				["at0014"] = <
+					text = <"Dato/tid">
+					description = <"Dato/tidsdatatypen brukes til å registrere en dato og/eller tid, inklusiv deldatoer som f.eks. kun år eller kun måned og år. Standardverdi er at alle former er tillatt.">
+				>
+				["at0015"] = <
+					text = <"Ordinal">
+					description = <"Ordinaldatatyper setter sammen et tall og en tekststreng. Dette gjør det mulig å regne ut scoringer, eller vurdere progresjon dersom den brukes f.eks. i en smerteskala.">
+				>
+				["at0016"] = <
+					text = <"Boolsk verdi">
+					description = <"Boolsk verdi-datatypen brukes for å registrere verdier som sann/usann.">
+				>
+				["at0017"] = <
+					text = <"Hvilken som helst">
+					description = <"Datatypen \"hvilken som helst\" kan spesifiseres eller begrenses i template eller i applikasjonen, men modelleres ikke eksplisitt i arketypen.">
+				>
+				["at0018"] = <
+					text = <"Overskrift 2">
+					description = <"Dette er et symbol for et \"cluster\" med andre elementer inni seg.">
+				>
+				["at0019"] = <
+					text = <"Utvidelsesspor som kan inneholde andre Cluster-arketyper">
+					description = <"Listen over CLUSTER-arketyper som kan inkluderes eller ekskluderes i denne OBSERVATION-arketypen.">
+				>
+				["at0020"] = <
+					text = <"Utvidelsesspor som kan inneholde andre Element-arketyper">
+					description = <"Liste over ELEMENT-arketyper som kan inkluderes eller ekskluderes i denne OBSERVATION-arketypen.">
+				>
+				["at0021"] = <
+					text = <"Varighet">
+					description = <"Varighet-datatypen brukes til å registrere varigheten til kliniske konsepter. \"Tillat alle tidsenheter\" er standardverdi, selv om spesifikke tidsenheter kan modelleres eksplisitt. Maksimums- og minimumsverdier kan settes for hver tidsenhet.">
+				>
+				["at0022"] = <
+					text = <"Antallsintervall">
+					description = <"Antallsintervall-datatypen brukes for å registrere et intervall av antall, f.eks. 1-2 tabletter foreskrevet. Maksimums- og minimumsverdier kan settes for laveste og høyeste antall.">
+				>
+				["at0023"] = <
+					text = <"Kvantitetsintervall">
+					description = <"Kvantitetsintervaller tillater registreing av et intervall av målinger tilknyttet aktuelle enheter, f.eks. 1-2cm (foreskrevet mengde krem mot et utslett).">
+				>
+				["at0024"] = <
+					text = <"Datointervall">
+					description = <"Datointervall-datatypen brukes til å registrere et intervall av datoer, f.eks. mellom 1. september 2008 og 8. september 2008.">
+				>
+				["at0025"] = <
+					text = <"Valg">
+					description = <"Valg-datatypen tillater at man gir flere valgmuligheter for hvilken datatype et element kan tilhøre. Dette kan velges eller begrenses i template eller i applikasjonen. I dette eksempelet er valget mellom en tekstdatatype satt til fri eller kodet tekst, eller en som er begrenset til å bruke kodeverdier fra en terminologi.">
+				>
+				["at0026"] = <
+					text = <"Multimedia">
+					description = <"Multimedia-datatyper brukes for å registrere en av flere mulige typer multimediafiler. I dette eksempelet er alle mulige typer eksplisitt valgte.">
+				>
+				["at0027"] = <
+					text = <"URI-ressursidentifikator">
+					description = <"URI-datatyper tillater registrering av sammenhenger mellom disse dataene og data som er registrert andre steder. Lenkene kan være innenfor samme system, eller eksterne f.eks. en URL.">
+				>
+				["at0028"] = <
+					text = <"Forhold">
+					description = <"Forholdsdatatyper brukes til proporsjoner, prosent og brøker.">
+				>
+				["at0030"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0031"] = <
+					text = <"State-definision">
+					description = <"Alle arketyper av OBSERVATION-klassen kan inneholde en STATE-modell som inneholder informasjon om subjektet for datainnsamlingen på tidspunktet informasjonen ble innhentet, og denne informasjonen er nødvendig for trygg klinisk tolkning av kjerneinformasjonen. Et eksempel er stillingen pasienten befinner seg i under en blodtrykksmåling. Mulige datatyper er de samme som i DATA-modellen.">
+				>
+				["at0032"] = <
+					text = <"Data - definisjon">
+					description = <"Alle arketyper i OBSERVATION-klassen inneholder en DATA-modell som inneholder kjerneinformasjonen, f.eks. systolisk og diastolisk trykk for en blodtrykksmåling.">
+				>
+				["at0033"] = <
+					text = <"Navngitt tidspunkt">
+					description = <"En hendelse som er både navngitt (f.eks. fødsel) og begrenset til et tidspunkt, og brukes til å registrere dataelementer i sammenheng med et spesifikt tidspunkt, f.eks. fødselsvekt.">
+				>
+				["at0034"] = <
+					text = <"Navngitt intervall">
+					description = <"En hendelse som er både navngitt og begrenset til et intervall, og brukes til å registrere dataelementer i forbindelse med et tidsintervall, f.eks. vekttap over tid. Intervallet kan være fastsatt eller uspesifisert. I tillegg kan det spesifiseres matematiske funksjoner for å håndtere konsepter som endring, minking, økning, maksimum, minimum, gjennomsnitt, etc.">
+				>
+				["at0035"] = <
+					text = <"Forskjøvet tidspunkt">
+					description = <"Forskjøvet tidspunkt brukes til å registrere data på et tidspunkt med en fastsatt forskyvning fra en annen spesifisert hendelse, f.eks. 2-minutters Apgar-score ved 2 minutter forskyvning fra fødselen.">
+				>
+				["at0036"] = <
+					text = <"*Tree(en)">
+					description = <"*@ internal @(en)">
+				>
+				["at0037"] = <
+					text = <"Protocol-definisjon">
+					description = <"Alle arketyper av OBSERVATION-klassen kan inneholde en PROTOCOL-modell som registrerer informasjon om hvordan informasjonen ble samlet eller målt, og eventuell annen informasjon som ikke er nødvendig for trygg klinisk tolkning av kjernedataene. Datatypene er de samme som for DATA-modellen.">
+				>
+				["at0038"] = <
+					text = <"Ingen smerte">
+					description = <"Overhodet ingen smerte.">
+				>
+				["at0039"] = <
+					text = <"Svak smerte">
+					description = <"Smertenivå vurdert som 1 av maksimalt 10.">
+				>
+				["at0040"] = <
+					text = <"Mild smerte">
+					description = <"Smertenivå vurdert som 2 av maksimalt 10.">
+				>
+				["at0041"] = <
+					text = <"Moderat smerte">
+					description = <"Smertenivå vurdert som 5 av maksimalt 10.">
+				>
+				["at0042"] = <
+					text = <"Sterk smerte">
+					description = <"Smertenivå vurdert som 9 av maksimalt 10.">
+				>
+				["at0043"] = <
+					text = <"Sterkeste mulige smerte">
+					description = <"Smertenivå vurdert som 10 av maksimalt 10.">
+				>
+				["at0044"] = <
+					text = <"Identifikator">
+					description = <"Identifikator-datatyper tillater registrering av formelle dataidentifikatorer.">
+				>
+				["at0045"] = <
+					text = <"*Extension(en)">
+					description = <"*Additional information required to capture local context or to align with other reference models/formalisms.(en)">
+					comment = <"*For example: Local hospital departmental infomation or additional metadata to align with FHIR or CIMI equivalents.(en)">
+				>
+			>
+		>
+	>
+	constraint_definitions = <
+		["en"] = <
+			items = <
+				["ac0001"] = <
+					text = <"SubsetA">
+					description = <"Terminology subset derived from XXX">
+				>
+				["ac0003"] = <
+					text = <"SubsetB">
+					description = <"XYZ codes from Terminology 123">
+				>
+			>
+		>
+		["pt-br"] = <
+			items = <
+				["ac0001"] = <
+					text = <"SubconjuntoA">
+					description = <"Subconjunto de terminologia originário de XXX">
+				>
+				["ac0003"] = <
+					text = <"SubconjuntoB">
+					description = <"Códigos XYZ da Terminologia 123">
+				>
+			>
+		>
+		["nb"] = <
+			items = <
+				["ac0001"] = <
+					text = <"Subsett A">
+					description = <"Terminologi-subsett fra XXX">
+				>
+				["ac0003"] = <
+					text = <"Subsett B">
+					description = <"XYZ koder fra Terminologi 123">
+				>
+			>
+		>
+	>

--- a/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-OBSERVATION.demo_adl2_id.v1.0.0.adls
+++ b/tools/src/test/resources/com/nedap/archie/adl14/openEHR-EHR-OBSERVATION.demo_adl2_id.v1.0.0.adls
@@ -1,0 +1,1608 @@
+archetype (adl_version=2.0.6; rm_release=1.1.0; generated; uid=489ceb2a-8336-406c-9fa5-e01b44643a47; build_uid=b115156b-c2a5-46ab-ad0c-d0d99c0f979d)
+    openEHR-EHR-OBSERVATION.demo.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+    translations = <
+        ["nb"] = <
+            language = <[ISO_639-1::nb]>
+            author = <
+                ["name"] = <"Silje Ljosland Bakke">
+                ["organisation"] = <"Bergen Hospital Trust">
+            >
+        >
+        ["pt-br"] = <
+            language = <[ISO_639-1::pt-br]>
+            author = <
+                ["name"] = <"Jussara Rötzsch">
+                ["organisation"] = <"openEHR Foundation">
+                ["email"] = <"jussara.macedo@gmail.com">
+            >
+            accreditation = <"MD. MSc., Pschyatrist, Clinical Modeller, Coordinator of  Standards and Semantic Interoperability of Brazil e-Health Initiative ">
+        >
+    >
+
+description
+    original_author = <
+        ["name"] = <"Heather Leslie">
+        ["organisation"] = <"Atomica Informatics">
+        ["email"] = <"heather.leslie@atomicainformatics.com">
+        ["date"] = <"2008-12-23">
+    >
+    original_namespace = <"org.openehr">
+    original_publisher = <"openEHR Foundation">
+    other_contributors = <"Individual A, Argentina", "Individual B, Belgium", "Individual C, Canada (Editor)">
+    lifecycle_state = <"published">
+    custodian_namespace = <"org.openehr">
+    custodian_organisation = <"openEHR Foundation">
+    licence = <"This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.">
+    ip_acknowledgements = <
+        ["1"] = <"This artefact includes content from SNOMED Clinical Terms® (SNOMED CT®) which is copyrighted material of the International Health Terminology Standards Development Organisation (IHTSDO). Where an implementation of this artefact makes use of SNOMED CT content, the implementer must have the appropriate SNOMED CT Affiliate license - for more information contact http://www.snomed.org/snomed-ct/get-snomedct or info@snomed.org.">
+    >
+    references = <
+        ["1"] = <"openEHR website:  http://www.openehr.org/home.html">
+        ["2"] = <"CKM:  http://www.openehr.org/knowledge/">
+    >
+    other_details = <
+        ["current_contact"] = <"Heather Leslie, Atomica Informatics<heather.leslie@atomicainformatics.com>">
+        ["MD5-CAM-1.0.1"] = <"44E350A26FDDA0C9E6E98F4BD527CE70">
+    >
+    details = <
+        ["nb"] = <
+            language = <[ISO_639-1::nb]>
+            purpose = <"For å gi en oversikt over visningen av de forskjellige datatypene som er tilgjengelige i en openEHR-arketype. Gir også oversikt over Data, State, Event og Protocol-modellene i forbindelse med HTML-visning og tilknyttet ADL.">
+            keywords = <"demonstrasjon", "test", "prototype", "datatyper", "state", "status", "protocol", "protokoll", "event", "hendelse", "data">
+            use = <"For å gi en visuell oversikt over datatyper og komponenter i arketyper til nåværende og fremtidige deltakere i vurdering av arketyper.">
+            misuse = <"Skal ikke brukes til reelle kliniske data.">
+            copyright = <"© openEHR Foundation">
+        >
+        ["pt-br"] = <
+            language = <[ISO_639-1::pt-br]>
+            purpose = <"Para fornecer uma visão geral da exibição de cada um dos tipos de dados  disponíveis em um arquétipo openEHR, e dos modelos de Dados, Eventos e Protocolos dentro de um contexto de uma tela HTML e ADL associado.">
+            keywords = <"demonstração", "teste", "protótipo(s)", "tipo(s) de dado(s)", "estado", "protocolo(s)", "evento(s)", "dado(s)">
+            use = <"Para fornecer uma visualisação geral dos tipos de dados e componetes dos arquétipos para atuais e potenciais revisores de conteúdo clínico no Gestor de Conhecimento Clínico openEHR, o CKM.">
+            misuse = <"Não apropriado para carregar nenhum dado clínico real.">
+            copyright = <"© openEHR Foundation">
+        >
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"To provide an overview of the display of each of the datatypes available in an openEHR archetype, and of the Data, State, Event and Protocol models within the context of a HTML display and associated ADL.">
+            keywords = <"demonstration", "test", "prototype", "datatypes", "state", "protocol", "event", "data">
+            use = <"To provide a visual overview of archetype data types and archetype components to potential and current clinical content reviewers in the openEHR Clinical Knowledge Manager.">
+            misuse = <"Not to carry any real clinical data.">
+            copyright = <"© openEHR Foundation">
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- Demonstration
+        data matches {
+            HISTORY[id2] matches {
+                events cardinality matches {1..*; unordered} matches {
+                    EVENT[id3] occurrences matches {0..1} matches {    -- Any Event
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items cardinality matches {0..*; unordered} matches {
+                                    ELEMENT[id33] occurrences matches {0..1}    -- Data - Definition
+                                    CLUSTER[id5] matches {    -- Heading1
+                                        items cardinality matches {1..*; unordered} matches {
+                                            ELEMENT[id6] occurrences matches {0..1} matches {    -- Free Text or Coded
+                                                value matches {
+                                                    DV_TEXT[id9056]
+                                                }
+                                            }
+                                            ELEMENT[id7] matches {    -- Text That Uses Internal Codes
+                                                value matches {
+                                                    DV_CODED_TEXT[id9057] matches {
+                                                        defining_code matches {[ac9000]}    -- Text That Uses Internal Codes (synthesised)
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id12] occurrences matches {1} matches {    -- Text That is Sourced From an External Terminology
+                                                value matches {
+                                                    DV_CODED_TEXT[id9058] matches {
+                                                        defining_code matches {[ac2]}    -- SubsetA
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id13] occurrences matches {0..1} matches {    -- Quantity
+                                                value matches {
+                                                    DV_QUANTITY[id9059] matches {
+                                                        property matches {[at9001]}    -- Length
+                                                        [magnitude, units, precision] matches {
+                                                            [{|0.0..100.0|}, {"cm"}, {1}],
+                                                            [{|>=0.0|}, {"mm"}, {|>=0|}],
+                                                            [{|>=0.0|}, {"[in_i]"}, {|>=0|}],
+                                                            [{|>=0.0|}, {"[ft_i]"}, {|>=0|}]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id24] occurrences matches {0..1} matches {    -- Interval of Quantity
+                                                value matches {
+                                                    DV_INTERVAL<DV_QUANTITY>[id9060] matches {
+                                                        upper matches {
+                                                            DV_QUANTITY[id9061] matches {
+                                                                property matches {[at9001]}    -- Length
+                                                                [units] matches {
+                                                                    [{"cm"}],
+                                                                    [{"m"}],
+                                                                    [{"[in_i]"}],
+                                                                    [{"[ft_i]"}]
+                                                                }
+                                                            }
+                                                        }
+                                                        lower matches {
+                                                            DV_QUANTITY[id9062] matches {
+                                                                property matches {[at9001]}    -- Length
+                                                                [units] matches {
+                                                                    [{"cm"}],
+                                                                    [{"m"}],
+                                                                    [{"[in_i]"}],
+                                                                    [{"[ft_i]"}]
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id14] occurrences matches {0..1} matches {    -- Count
+                                                value matches {
+                                                    DV_COUNT[id9063] matches {
+                                                        magnitude matches {|>=0|}
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id23] occurrences matches {0..1} matches {    -- Interval of Integer
+                                                value matches {
+                                                    DV_INTERVAL<DV_COUNT>[id9064] matches {
+                                                        upper matches {
+                                                            DV_COUNT[id9065]
+                                                        }
+                                                        lower matches {
+                                                            DV_COUNT[id9066]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id29] occurrences matches {0..1} matches {    -- Proportion
+                                                value matches {
+                                                    DV_PROPORTION[id9067] matches {
+                                                        is_integral matches {True}
+                                                        type matches {0, 2, 3, 4}
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id15] occurrences matches {0..1} matches {    -- Date/Time
+                                                value matches {
+                                                    DV_DATE_TIME[id9068]
+                                                }
+                                            }
+                                            ELEMENT[id25] occurrences matches {0..1} matches {    -- Interval of Date
+                                                value matches {
+                                                    DV_INTERVAL<DV_DATE_TIME>[id9069] matches {
+                                                        upper matches {
+                                                            DV_DATE_TIME[id9070]
+                                                        }
+                                                        lower matches {
+                                                            DV_DATE_TIME[id9071]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id22] occurrences matches {0..1} matches {    -- Duration
+                                                value matches {
+                                                    DV_DURATION[id9072]
+                                                }
+                                            }
+                                            ELEMENT[id16] occurrences matches {0..1} matches {    -- Ordinal
+                                                value matches {
+                                                    DV_ORDINAL[id9073] matches {
+                                                        [value, symbol] matches {
+                                                            [{0}, {[at39]}],    -- No pain
+                                                            [{1}, {[at40]}],    -- Slight pain
+                                                            [{2}, {[at41]}],    -- Mild pain
+                                                            [{5}, {[at42]}],    -- Moderate pain
+                                                            [{9}, {[at43]}],    -- Severe pain
+                                                            [{10}, {[at44]}]    -- Most severe pain imaginable
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id17] occurrences matches {0..1} matches {    -- Boolean
+                                                value matches {
+                                                    DV_BOOLEAN[id9074] matches {
+                                                        value matches {True, False}
+                                                    }
+                                                }
+                                                null_flavour matches {
+                                                    DV_CODED_TEXT[id9075] matches {
+                                                        defining_code matches {[ac9007]}    -- Boolean (synthesised)
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id18] occurrences matches {0..1}    -- Any
+                                            ELEMENT[id26] occurrences matches {0..1} matches {    -- Choice
+                                                value matches {
+                                                    DV_QUANTITY[id9076] matches {
+                                                        property matches {[at9008]}    -- Mass
+                                                        [units] matches {
+                                                            [{"g"}],
+                                                            [{"[foz_us]"}]
+                                                        }
+                                                    }
+                                                    DV_CODED_TEXT[id9077] matches {
+                                                        defining_code matches {[ac4]}    -- SubsetB
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id27] occurrences matches {0..1} matches {    -- Multimedia
+                                                value matches {
+                                                    DV_MULTIMEDIA[id9078] matches {
+                                                        media_type matches {[ac9054]}    -- Multimedia (synthesised)
+                                                    }
+                                                }
+                                            }
+                                            ELEMENT[id28] occurrences matches {0..1} matches {    -- URI - resource identifier
+                                                value matches {
+                                                    DV_URI[id9079]
+                                                }
+                                            }
+                                            ELEMENT[id45] occurrences matches {0..1} matches {    -- Identifier
+                                                value matches {
+                                                    DV_IDENTIFIER[id9080]
+                                                }
+                                            }
+                                        }
+                                    }
+                                    CLUSTER[id19] occurrences matches {0..1} matches {    -- Heading 2
+                                        items cardinality matches {1..*; unordered} matches {
+                                            allow_archetype CLUSTER[id20] matches {    -- Slot To Contain Other Cluster Archetypes
+                                                include
+                                                    archetype_id/value matches {/openEHR-EHR-CLUSTER\.anatomical_location\.v1\..*|openEHR-EHR-CLUSTER\.device\.v1\..*/}
+                                            }
+                                            allow_archetype ELEMENT[id21] matches {    -- Slot To Contain Other Element Archetypes
+                                                include
+                                                    archetype_id/value matches {/openEHR-EHR-ELEMENT\.ctg_codes\.v1\..*/}
+                                                exclude
+                                                    archetype_id/value matches {/.*/}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        state matches {
+                            ITEM_TREE[id31] matches {
+                                items cardinality matches {0..*; unordered} matches {
+                                    ELEMENT[id32] occurrences matches {0..1}    -- State - Definition
+                                }
+                            }
+                        }
+                    }
+                    POINT_EVENT[id34] occurrences matches {0..1} matches {    -- Named Point In Time
+                        data matches {
+                            use_node ITEM_TREE[id9081] /data[id2]/events[id3]/data[id4]
+                        }
+                        state matches {
+                            use_node ITEM_TREE[id9082] /data[id2]/events[id3]/state[id31]
+                        }
+                    }
+                    INTERVAL_EVENT[id35] occurrences matches {0..1} matches {    -- Named Interval
+                        math_function matches {
+                            DV_CODED_TEXT[id9083] matches {
+                                defining_code matches {[at9055]}    -- change
+                            }
+                        }
+                        data matches {
+                            use_node ITEM_TREE[id9084] /data[id2]/events[id3]/data[id4]
+                        }
+                        state matches {
+                            use_node ITEM_TREE[id9085] /data[id2]/events[id3]/state[id31]
+                        }
+                    }
+                    POINT_EVENT[id36] occurrences matches {0..1} matches {    -- Offset Point In Time
+                        offset matches {
+                            DV_DURATION[id9086] matches {
+                                value matches {PT5M; PT5M}
+                            }
+                        }
+                        data matches {
+                            use_node ITEM_TREE[id9087] /data[id2]/events[id3]/data[id4]
+                        }
+                        state matches {
+                            use_node ITEM_TREE[id9088] /data[id2]/events[id3]/state[id31]
+                        }
+                    }
+                }
+            }
+        }
+        protocol matches {
+            ITEM_TREE[id37] matches {
+                items cardinality matches {0..*; unordered} matches {
+                    ELEMENT[id38] occurrences matches {0..1}    -- Protocol - Definition
+                    allow_archetype CLUSTER[id46] matches {    -- Extension
+                        include
+                            archetype_id/value matches {/.*/}
+                    }
+                }
+            }
+        }
+    }
+
+terminology
+    term_definitions = <
+        ["nb"] = <
+            ["id1"] = <
+                text = <"Demonstrasjon">
+                description = <"Demonstrasjonsarketype med beskrivelser og forklaringer.">
+            >
+            ["id3"] = <
+                text = <"Tidfestet hendelse">
+                description = <"Alle arketyper av OBSERVATION-klassen inneholder en HISTORY eller EVENT-modell som inneholder informasjon om tidfesting av observasjonen og \"bredden\" av informasjonen, enten et tidspunkt eller et intervall. Standardverdi er \"Tidfestet hendelse\", og det er ikke spesifisert om dette er et tidspunkt eller et intervall.">
+            >
+            ["id5"] = <
+                text = <"Overskrift1">
+                description = <"Dette er et symbol for et \"cluster\" som kan inneholde andre elementer.">
+            >
+            ["id6"] = <
+                text = <"Fri eller kodet tekst">
+                description = <"Tekstdatatype som kan inneholde fritekst eller kodet tekst. Kodingen kan legges inn enten i template eller i applikasjonen.">
+            >
+            ["id7"] = <
+                text = <"Tekst med interne koder">
+                description = <"Tekstdatatype som bruker et internt vokabular. Hver av disse \"interne kodene\" kan bindes til en terminologikode.">
+            >
+            ["at8"] = <
+                text = <"Liggende">
+                description = <"Pasienten ligger på ryggen.">
+            >
+            ["at9"] = <
+                text = <"Tilbakelent">
+                description = <"Pasienten ligger tilbakelent, støttet av en mellomstor pute.">
+            >
+            ["at10"] = <
+                text = <"Sittende">
+                description = <"Pasienten sitter i en stol.">
+            >
+            ["at11"] = <
+                text = <"Stående">
+                description = <"Pasienten står oppreist.">
+            >
+            ["id12"] = <
+                text = <"Tekst hentet fra en ekstern terminologi">
+                description = <"Tekstdata som bruker koder fra en ekstern terminologikilde, f.eks. SNOMED CT, LOINC eller ICD.">
+            >
+            ["id13"] = <
+                text = <"Kvantitet">
+                description = <"En kvantitetsdatatype som brukes til å registrere målinger tilknyttet passende enheter. Disse hentes fra ISO-standarder, og referansemodellen tillater konvertering mellom enhetene. Eksempelet vist er her lengde.">
+            >
+            ["id14"] = <
+                text = <"Antall">
+                description = <"Antall-datatypen består av et heltall uten enheter, f.eks. for å registrere antall barn. I dette eksempelet er minimum satt til 0 og maksimum er uspesifisert.">
+            >
+            ["id15"] = <
+                text = <"Dato/tid">
+                description = <"Dato/tidsdatatypen brukes til å registrere en dato og/eller tid, inklusiv deldatoer som f.eks. kun år eller kun måned og år. Standardverdi er at alle former er tillatt.">
+            >
+            ["id16"] = <
+                text = <"Ordinal">
+                description = <"Ordinaldatatyper setter sammen et tall og en tekststreng. Dette gjør det mulig å regne ut scoringer, eller vurdere progresjon dersom den brukes f.eks. i en smerteskala.">
+            >
+            ["id17"] = <
+                text = <"Boolsk verdi">
+                description = <"Boolsk verdi-datatypen brukes for å registrere verdier som sann/usann.">
+            >
+            ["id18"] = <
+                text = <"Hvilken som helst">
+                description = <"Datatypen \"hvilken som helst\" kan spesifiseres eller begrenses i template eller i applikasjonen, men modelleres ikke eksplisitt i arketypen.">
+            >
+            ["id19"] = <
+                text = <"Overskrift 2">
+                description = <"Dette er et symbol for et \"cluster\" med andre elementer inni seg.">
+            >
+            ["id20"] = <
+                text = <"Utvidelsesspor som kan inneholde andre Cluster-arketyper">
+                description = <"Listen over CLUSTER-arketyper som kan inkluderes eller ekskluderes i denne OBSERVATION-arketypen.">
+            >
+            ["id21"] = <
+                text = <"Utvidelsesspor som kan inneholde andre Element-arketyper">
+                description = <"Liste over ELEMENT-arketyper som kan inkluderes eller ekskluderes i denne OBSERVATION-arketypen.">
+            >
+            ["id22"] = <
+                text = <"Varighet">
+                description = <"Varighet-datatypen brukes til å registrere varigheten til kliniske konsepter. \"Tillat alle tidsenheter\" er standardverdi, selv om spesifikke tidsenheter kan modelleres eksplisitt. Maksimums- og minimumsverdier kan settes for hver tidsenhet.">
+            >
+            ["id23"] = <
+                text = <"Antallsintervall">
+                description = <"Antallsintervall-datatypen brukes for å registrere et intervall av antall, f.eks. 1-2 tabletter foreskrevet. Maksimums- og minimumsverdier kan settes for laveste og høyeste antall.">
+            >
+            ["id24"] = <
+                text = <"Kvantitetsintervall">
+                description = <"Kvantitetsintervaller tillater registreing av et intervall av målinger tilknyttet aktuelle enheter, f.eks. 1-2cm (foreskrevet mengde krem mot et utslett).">
+            >
+            ["id25"] = <
+                text = <"Datointervall">
+                description = <"Datointervall-datatypen brukes til å registrere et intervall av datoer, f.eks. mellom 1. september 2008 og 8. september 2008.">
+            >
+            ["id26"] = <
+                text = <"Valg">
+                description = <"Valg-datatypen tillater at man gir flere valgmuligheter for hvilken datatype et element kan tilhøre. Dette kan velges eller begrenses i template eller i applikasjonen. I dette eksempelet er valget mellom en tekstdatatype satt til fri eller kodet tekst, eller en som er begrenset til å bruke kodeverdier fra en terminologi.">
+            >
+            ["id27"] = <
+                text = <"Multimedia">
+                description = <"Multimedia-datatyper brukes for å registrere en av flere mulige typer multimediafiler. I dette eksempelet er alle mulige typer eksplisitt valgte.">
+            >
+            ["id28"] = <
+                text = <"URI-ressursidentifikator">
+                description = <"URI-datatyper tillater registrering av sammenhenger mellom disse dataene og data som er registrert andre steder. Lenkene kan være innenfor samme system, eller eksterne f.eks. en URL.">
+            >
+            ["id29"] = <
+                text = <"Forhold">
+                description = <"Forholdsdatatyper brukes til proporsjoner, prosent og brøker.">
+            >
+            ["id32"] = <
+                text = <"State-definision">
+                description = <"Alle arketyper av OBSERVATION-klassen kan inneholde en STATE-modell som inneholder informasjon om subjektet for datainnsamlingen på tidspunktet informasjonen ble innhentet, og denne informasjonen er nødvendig for trygg klinisk tolkning av kjerneinformasjonen. Et eksempel er stillingen pasienten befinner seg i under en blodtrykksmåling. Mulige datatyper er de samme som i DATA-modellen.">
+            >
+            ["id33"] = <
+                text = <"Data - definisjon">
+                description = <"Alle arketyper i OBSERVATION-klassen inneholder en DATA-modell som inneholder kjerneinformasjonen, f.eks. systolisk og diastolisk trykk for en blodtrykksmåling.">
+            >
+            ["id34"] = <
+                text = <"Navngitt tidspunkt">
+                description = <"En hendelse som er både navngitt (f.eks. fødsel) og begrenset til et tidspunkt, og brukes til å registrere dataelementer i sammenheng med et spesifikt tidspunkt, f.eks. fødselsvekt.">
+            >
+            ["id35"] = <
+                text = <"Navngitt intervall">
+                description = <"En hendelse som er både navngitt og begrenset til et intervall, og brukes til å registrere dataelementer i forbindelse med et tidsintervall, f.eks. vekttap over tid. Intervallet kan være fastsatt eller uspesifisert. I tillegg kan det spesifiseres matematiske funksjoner for å håndtere konsepter som endring, minking, økning, maksimum, minimum, gjennomsnitt, etc.">
+            >
+            ["id36"] = <
+                text = <"Forskjøvet tidspunkt">
+                description = <"Forskjøvet tidspunkt brukes til å registrere data på et tidspunkt med en fastsatt forskyvning fra en annen spesifisert hendelse, f.eks. 2-minutters Apgar-score ved 2 minutter forskyvning fra fødselen.">
+            >
+            ["id38"] = <
+                text = <"Protocol-definisjon">
+                description = <"Alle arketyper av OBSERVATION-klassen kan inneholde en PROTOCOL-modell som registrerer informasjon om hvordan informasjonen ble samlet eller målt, og eventuell annen informasjon som ikke er nødvendig for trygg klinisk tolkning av kjernedataene. Datatypene er de samme som for DATA-modellen.">
+            >
+            ["at39"] = <
+                text = <"Ingen smerte">
+                description = <"Overhodet ingen smerte.">
+            >
+            ["at40"] = <
+                text = <"Svak smerte">
+                description = <"Smertenivå vurdert som 1 av maksimalt 10.">
+            >
+            ["at41"] = <
+                text = <"Mild smerte">
+                description = <"Smertenivå vurdert som 2 av maksimalt 10.">
+            >
+            ["at42"] = <
+                text = <"Moderat smerte">
+                description = <"Smertenivå vurdert som 5 av maksimalt 10.">
+            >
+            ["at43"] = <
+                text = <"Sterk smerte">
+                description = <"Smertenivå vurdert som 9 av maksimalt 10.">
+            >
+            ["at44"] = <
+                text = <"Sterkeste mulige smerte">
+                description = <"Smertenivå vurdert som 10 av maksimalt 10.">
+            >
+            ["id45"] = <
+                text = <"Identifikator">
+                description = <"Identifikator-datatyper tillater registrering av formelle dataidentifikatorer.">
+            >
+            ["id46"] = <
+                text = <"*Extension(en)">
+                description = <"*Additional information required to capture local context or to align with other reference models/formalisms.(en)">
+                comment = <"*For example: Local hospital departmental infomation or additional metadata to align with FHIR or CIMI equivalents.(en)">
+            >
+            ["ac2"] = <
+                text = <"Subsett A">
+                description = <"Terminologi-subsett fra XXX">
+            >
+            ["ac4"] = <
+                text = <"Subsett B">
+                description = <"XYZ koder fra Terminologi 123">
+            >
+            ["ac9000"] = <
+                text = <"Tekst med interne koder (synthesised)">
+                description = <"Tekstdatatype som bruker et internt vokabular. Hver av disse \"interne kodene\" kan bindes til en terminologikode. (synthesised)">
+            >
+            ["at9001"] = <
+                text = <"* Length (en)">
+                description = <"* Length (en)">
+            >
+            ["ac9002"] = <
+                text = <"Ordinal (synthesised)">
+                description = <"Ordinaldatatyper setter sammen et tall og en tekststreng. Dette gjør det mulig å regne ut scoringer, eller vurdere progresjon dersom den brukes f.eks. i en smerteskala. (synthesised)">
+            >
+            ["at9003"] = <
+                text = <"* no information (en)">
+                description = <"* no information (en)">
+            >
+            ["at9004"] = <
+                text = <"* masked (en)">
+                description = <"* masked (en)">
+            >
+            ["at9005"] = <
+                text = <"* not applicable (en)">
+                description = <"* not applicable (en)">
+            >
+            ["at9006"] = <
+                text = <"* unknown (en)">
+                description = <"* unknown (en)">
+            >
+            ["ac9007"] = <
+                text = <"Boolsk verdi (synthesised)">
+                description = <"Boolsk verdi-datatypen brukes for å registrere verdier som sann/usann. (synthesised)">
+            >
+            ["at9008"] = <
+                text = <"* Mass (en)">
+                description = <"* Mass (en)">
+            >
+            ["at9009"] = <
+                text = <"Term binding for [openEHR::387], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::387], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9010"] = <
+                text = <"Term binding for [openEHR::388], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::388], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9011"] = <
+                text = <"Term binding for [openEHR::389], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::389], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9012"] = <
+                text = <"Term binding for [openEHR::390], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::390], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9013"] = <
+                text = <"Term binding for [openEHR::391], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::391], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9014"] = <
+                text = <"Term binding for [openEHR::392], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::392], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9015"] = <
+                text = <"Term binding for [openEHR::393], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::393], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9016"] = <
+                text = <"Term binding for [openEHR::394], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::394], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9017"] = <
+                text = <"Term binding for [openEHR::395], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::395], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9018"] = <
+                text = <"Term binding for [openEHR::396], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::396], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9019"] = <
+                text = <"Term binding for [openEHR::397], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::397], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9020"] = <
+                text = <"Term binding for [openEHR::398], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::398], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9021"] = <
+                text = <"Term binding for [openEHR::399], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::399], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9022"] = <
+                text = <"Term binding for [openEHR::400], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::400], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9023"] = <
+                text = <"Term binding for [openEHR::409], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::409], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9024"] = <
+                text = <"Term binding for [openEHR::410], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::410], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9025"] = <
+                text = <"Term binding for [openEHR::411], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::411], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9026"] = <
+                text = <"Term binding for [openEHR::412], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::412], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9027"] = <
+                text = <"Term binding for [openEHR::413], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::413], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9028"] = <
+                text = <"Term binding for [openEHR::425], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::425], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9029"] = <
+                text = <"Term binding for [openEHR::426], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::426], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9030"] = <
+                text = <"Term binding for [openEHR::427], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::427], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9031"] = <
+                text = <"Term binding for [openEHR::428], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::428], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9032"] = <
+                text = <"Term binding for [openEHR::429], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::429], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9033"] = <
+                text = <"Term binding for [openEHR::415], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::415], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9034"] = <
+                text = <"Term binding for [openEHR::416], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::416], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9035"] = <
+                text = <"Term binding for [openEHR::417], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::417], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9036"] = <
+                text = <"Term binding for [openEHR::418], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::418], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9037"] = <
+                text = <"Term binding for [openEHR::419], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::419], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9038"] = <
+                text = <"Term binding for [openEHR::420], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::420], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9039"] = <
+                text = <"Term binding for [openEHR::421], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::421], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9040"] = <
+                text = <"Term binding for [openEHR::422], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::422], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9041"] = <
+                text = <"Term binding for [openEHR::423], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::423], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9042"] = <
+                text = <"Term binding for [openEHR::424], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::424], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9043"] = <
+                text = <"Term binding for [openEHR::401], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::401], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9044"] = <
+                text = <"Term binding for [openEHR::402], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::402], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9045"] = <
+                text = <"Term binding for [openEHR::404], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::404], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9046"] = <
+                text = <"Term binding for [openEHR::405], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::405], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9047"] = <
+                text = <"Term binding for [openEHR::406], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::406], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9048"] = <
+                text = <"Term binding for [openEHR::407], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::407], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9049"] = <
+                text = <"Term binding for [openEHR::414], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::414], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9050"] = <
+                text = <"Term binding for [openEHR::517], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::517], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9051"] = <
+                text = <"Term binding for [openEHR::518], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::518], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9052"] = <
+                text = <"Term binding for [openEHR::519], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::519], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9053"] = <
+                text = <"Term binding for [openEHR::637], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::637], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["ac9054"] = <
+                text = <"Multimedia (synthesised)">
+                description = <"Multimedia-datatyper brukes for å registrere en av flere mulige typer multimediafiler. I dette eksempelet er alle mulige typer eksplisitt valgte. (synthesised)">
+            >
+            ["at9055"] = <
+                text = <"* change (en)">
+                description = <"* change (en)">
+            >
+        >
+        ["pt-br"] = <
+            ["id1"] = <
+                text = <"Demonstração">
+                description = <"Arquétipo de Demonstração com descrições e explicações. ">
+            >
+            ["id3"] = <
+                text = <"Qualquer evento">
+                description = <"Todos os arquétipos da classe de OBSERVAÇÃO contêm um modelo de HISTÓRIA ou de EVENTO que contém informação sobre o período da observação com a duração  da informação-  seja um ponto no  tempo ou um intervalo temporal. O padrão predeterminado é ' Qualquer evento' e não é especificado, se é um Ponto no tempo ou um Intervalo.">
+            >
+            ["id5"] = <
+                text = <"Cabeçalho1">
+                description = <"Este é um símbolo para um 'cluster' que pode ter outros elementos 'aninhados' dentro dele.">
+            >
+            ["id6"] = <
+                text = <"Texto livre ou Codificado">
+                description = <"Tipo de dado Texto no qual se pode entrar ou  texto livre ou códigos podem ser incoprporados seja  no template ou no tempo de execução.">
+            >
+            ["id7"] = <
+                text = <"Texto Que Usa Códigos Internos">
+                description = <"Tipo de dados  Texto que pode usar um vocabulário interno. Cada um desses ' códigos internos' pode ser vnculado a um código de uma terminologia.">
+            >
+            ["at8"] = <
+                text = <"Deitado">
+                description = <"Paciente Deitado em posição supina ou decúbito dorsal.">
+            >
+            ["at9"] = <
+                text = <"Reclinado">
+                description = <"Paciente Reclinado, apoiado em um travesseiro médio.">
+            >
+            ["at10"] = <
+                text = <"Sentado">
+                description = <"Paciente está Sentado em uma cadeira.">
+            >
+            ["at11"] = <
+                text = <"Em pé">
+                description = <"Paciente está em Pé.">
+            >
+            ["id12"] = <
+                text = <"Texto Cuja Origem é uma Terminologia Externa ">
+                description = <"Tipo de dado Texto utilizando códigos originários de uma terminologia externa como, por exemplo, um subset do SNOMED CT, do LOINC ou da CID 10. ">
+            >
+            ["id13"] = <
+                text = <"Quantidade">
+                description = <"Um tipo de dado de Quantidade usado para registrar uma medida associada com suas uniddades apropriadas. Essas unidades são derivadas de norams ISO e o modelo de  Referência possibilita a conversão entre elas. O exemplo demonstrado aqui é o comprimento.">
+            >
+            ["id14"] = <
+                text = <"Contagem ">
+                description = <"Tipos de dados de Contagem são compostos de um número inteiro sem casas decimais (integer), por exemplo, para registar o número de filhos- nesse exemplo o mínimo é colocado como 0 e o máximo não é especificado.">
+            >
+            ["id15"] = <
+                text = <"Data/Horário">
+                description = <"Tipos de dado Data/Horário permite o registro de uma data e /ou um horário, incluindo  datas parciais como somente o mês ou o ano. Permite tudo como padrão de modo que todas as formas de data/horário são permitidas.">
+            >
+            ["id16"] = <
+                text = <"Ordinal">
+                description = <"Tipos de dados Ordinal pareiam um número e texto- deste modo  pode ser calculada uma pontuação pela  aplicação a progressão ser avaliada, como por exemplo se está se utilizando de uma escala de avaliação de dor.">
+            >
+            ["id17"] = <
+                text = <"Booleano">
+                description = <"Tipo de dado  Booleano que permite repostas do tipo falso ou verdadeiro.">
+            >
+            ["id18"] = <
+                text = <"Qualquer">
+                description = <"Este tipo de dado para esse elemento 'Qualquer' pode ser especificado ou 'restrito' num modelo ou no tempo de execução, mas não é especificamente modelado no arquétipo.">
+            >
+            ["id19"] = <
+                text = <"Cabelaçalho2">
+                description = <"Esse é o símbolo de um 'cluster' que pode ter outros elementos 'aninhados' dentro dele.">
+            >
+            ["id20"] = <
+                text = <"Slot Para Conter Outros Arquétipos Clusters">
+                description = <"Lista de arquétipos  CLUSTER permitidos de serem incluídos ou excluídos dentro deste arquétipo de  OBSERVAÇÃO.">
+            >
+            ["id21"] = <
+                text = <"Slot Para Conter Outroa Arququétipos de Elementos">
+                description = <"Lista de arquétipos de ELEMENTOS permitidos de serem incluíos ou excluídos dentro deste arquétipo de OBSERVAÇÃO.">
+            >
+            ["id22"] = <
+                text = <"Duração">
+                description = <"Tipo de dado Duração permite registrar a duração dos conceitos clínicos. O padrão predeterminado é 'Permitir  todas unidades de tempo', embora unidades específicas de tempo possam ser explicitamente modeladas.   Valores máximos e mínimos podem ser configurados para cada unidade de tempo.">
+            >
+            ["id23"] = <
+                text = <"Intervalo de Integer">
+                description = <"Tipo de dados de Intervalo de Integer permite o registro de uma faixa de contagem em intervalos, por exemplo, a cada 1 a 2 comprimidos prescritos. Os valores máximo e mínimo podem ser configurados para a contagem inferior ou para a superior.">
+            >
+            ["id24"] = <
+                text = <"Intervalo de Quantidade">
+                description = <"Tipos de dados de Intervalo de Quantidade permitem registrar uma gama de mediddas  associadas com unidades apropriadas, por exemplo, 1-2cm  (quantidade de creme prescrito para um uma erupção cutânea).">
+            >
+            ["id25"] = <
+                text = <"Intervalo de Data">
+                description = <"Tipo de dado de Intervalo de Integer permite o registro de uma faixa de datas como, por exemplo, entre 1 de Setembro de 2008 e 8 de Setembro de 2008.">
+            >
+            ["id26"] = <
+                text = <"Escolha">
+                description = <"Tipo de dado Escolha permite que um número de tipos de elementos sejam simultaneamente especificados, os quais podem ser restringidos num template ou no tempo de execução. Neste exemplo, um tipo de dado Texto é configurado para Texto livre ou Codificado e outro que é configurado restritamente para  registrar códigos de uma determinada terminologia para o mesmo elemento de dado.">
+            >
+            ["id27"] = <
+                text = <"Multimídia">
+                description = <"Tipos de dado Multimídia permitem o registro de vários tipos de arquivos multimídia. Todos os tipos disponíveis foram explicitamente selecionados neste exemplo.">
+            >
+            ["id28"] = <
+                text = <"URI - Identificador de Recursos ">
+                description = <"Tipos de dados URI permitem registrar os relacionamentos entre  estes dados e os dados registrados em outros lugares. Esses enlaces (links) podem estar  no mesmo RES ou serem externos, por exemplo, pertencer a  num endereço  na internet, uma URL.">
+            >
+            ["id29"] = <
+                text = <"Porporção">
+                description = <"Tipos de dados de Proporção permitem modelar taxas, porcentagens, frações e proporções.">
+            >
+            ["id32"] = <
+                text = <"Estado - Definição">
+                description = <"Todos os arquétipos da classe de OBSERVAÇÃO podem conter um modelo de ESTADO, que contém a informação sobre o sujeito a informação na hora que o dado foi colhido, e essa informação é requisito para uma interpretação segura das informações básicas. Um exemplo disso é a posição que o paciente se encontrava quando sua pressão arterial foi medida. Os tipos de dados são idênticos aos que foram explicados no modelo de DADOS acima.">
+            >
+            ["id33"] = <
+                text = <"Dados - Definição ">
+                description = <"Todos os arquétipos da classe de OBSERVAÇÃO contêm um modelo de DADOS que contém as informações básicas, por exemplo, as pressões sistólica e diastólica, quando está se medindo a pressão sanguínea.">
+            >
+            ["id34"] = <
+                text = <"Ponto no tempo Nomeado">
+                description = <"Um evento que é ao mesmo tempo nomeado (p. ex. Nascimento) e restrito como evento em um  Ponto no tempo, registra os elementos de dados relacionados a um ponto específico no tempo, como por exemplo, Peso no Nascimento.">
+            >
+            ["id35"] = <
+                text = <"Intervalo Nomeado">
+                description = <"Um evento que é ao mesmo tempo nomeado e restrito como um evento Intervalo, registra os mesmos elementos de dados relacionados ao período de tempo, por exemplo, Perda de peso durante o determinado período. O intervalo pode ser fixado, ou deixado inespecificado. Além disso,  pode-se especificar funções matemáticas para capturar conceitos como mudança, diminuição aumento, máximo, mínimo, média,etc.">
+            >
+            ["id36"] = <
+                text = <"Deslocamento do Ponto no tempo">
+                description = <"Deslocamento  do Ponto no Tempo registra o deslocamento fixo de 5 minutos de outro evento especificado, por exemplo, registrando a leitura de um escore de Apgar de 2 minutos aos 2 minutos após o parto.">
+            >
+            ["id38"] = <
+                text = <"Protocolo-Definição">
+                description = <"Todos os arquétipos da classe de OBSERVAÇÃO podem conter um modelo de PROTOCOLO, o qual registra informação sobre como a informação foi colhida ou medida e quaisquer outras informações que não sejam necessárias para a interpretação clínica  segura das informações básicas. Os tipos de dados são idênticos àqueles explicados no modelo e DADOS acima.">
+            >
+            ["at39"] = <
+                text = <"Sem dor">
+                description = <"Nenhuma dor.">
+            >
+            ["at40"] = <
+                text = <"Dor leve">
+                description = <"Dor classificada como nível 1 numa escala máxima de 10.">
+            >
+            ["at41"] = <
+                text = <"Dor branda">
+                description = <"Dor classificada como nível 2 numa escala máxima de 10.">
+            >
+            ["at42"] = <
+                text = <"Dor Moderada">
+                description = <"Dor classificada  como nível 5 numa escala máxima de 10.">
+            >
+            ["at43"] = <
+                text = <"Dor severa">
+                description = <"Dor classificada nível 9 numa escala de 10.">
+            >
+            ["at44"] = <
+                text = <"Pior dor possível">
+                description = <"Dor classificada como nível 10 numa escala de 10.">
+            >
+            ["id45"] = <
+                text = <"Identificador">
+                description = <"Tipos de dados Identificadores possibilitam registrar identificadores formais de dados.">
+            >
+            ["id46"] = <
+                text = <"*Extension(en)">
+                description = <"*Additional information required to capture local context or to align with other reference models/formalisms.(en)">
+                comment = <"*For example: Local hospital departmental infomation or additional metadata to align with FHIR or CIMI equivalents.(en)">
+            >
+            ["ac2"] = <
+                text = <"SubconjuntoA">
+                description = <"Subconjunto de terminologia originário de XXX">
+            >
+            ["ac4"] = <
+                text = <"SubconjuntoB">
+                description = <"Códigos XYZ da Terminologia 123">
+            >
+            ["ac9000"] = <
+                text = <"Texto Que Usa Códigos Internos (synthesised)">
+                description = <"Tipo de dados  Texto que pode usar um vocabulário interno. Cada um desses ' códigos internos' pode ser vnculado a um código de uma terminologia. (synthesised)">
+            >
+            ["at9001"] = <
+                text = <"* Length (en)">
+                description = <"* Length (en)">
+            >
+            ["ac9002"] = <
+                text = <"Ordinal (synthesised)">
+                description = <"Tipos de dados Ordinal pareiam um número e texto- deste modo  pode ser calculada uma pontuação pela  aplicação a progressão ser avaliada, como por exemplo se está se utilizando de uma escala de avaliação de dor. (synthesised)">
+            >
+            ["at9003"] = <
+                text = <"* no information (en)">
+                description = <"* no information (en)">
+            >
+            ["at9004"] = <
+                text = <"* masked (en)">
+                description = <"* masked (en)">
+            >
+            ["at9005"] = <
+                text = <"* not applicable (en)">
+                description = <"* not applicable (en)">
+            >
+            ["at9006"] = <
+                text = <"* unknown (en)">
+                description = <"* unknown (en)">
+            >
+            ["ac9007"] = <
+                text = <"Booleano (synthesised)">
+                description = <"Tipo de dado  Booleano que permite repostas do tipo falso ou verdadeiro. (synthesised)">
+            >
+            ["at9008"] = <
+                text = <"* Mass (en)">
+                description = <"* Mass (en)">
+            >
+            ["at9009"] = <
+                text = <"Term binding for [openEHR::387], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::387], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9010"] = <
+                text = <"Term binding for [openEHR::388], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::388], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9011"] = <
+                text = <"Term binding for [openEHR::389], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::389], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9012"] = <
+                text = <"Term binding for [openEHR::390], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::390], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9013"] = <
+                text = <"Term binding for [openEHR::391], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::391], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9014"] = <
+                text = <"Term binding for [openEHR::392], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::392], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9015"] = <
+                text = <"Term binding for [openEHR::393], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::393], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9016"] = <
+                text = <"Term binding for [openEHR::394], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::394], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9017"] = <
+                text = <"Term binding for [openEHR::395], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::395], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9018"] = <
+                text = <"Term binding for [openEHR::396], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::396], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9019"] = <
+                text = <"Term binding for [openEHR::397], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::397], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9020"] = <
+                text = <"Term binding for [openEHR::398], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::398], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9021"] = <
+                text = <"Term binding for [openEHR::399], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::399], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9022"] = <
+                text = <"Term binding for [openEHR::400], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::400], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9023"] = <
+                text = <"Term binding for [openEHR::409], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::409], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9024"] = <
+                text = <"Term binding for [openEHR::410], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::410], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9025"] = <
+                text = <"Term binding for [openEHR::411], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::411], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9026"] = <
+                text = <"Term binding for [openEHR::412], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::412], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9027"] = <
+                text = <"Term binding for [openEHR::413], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::413], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9028"] = <
+                text = <"Term binding for [openEHR::425], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::425], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9029"] = <
+                text = <"Term binding for [openEHR::426], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::426], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9030"] = <
+                text = <"Term binding for [openEHR::427], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::427], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9031"] = <
+                text = <"Term binding for [openEHR::428], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::428], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9032"] = <
+                text = <"Term binding for [openEHR::429], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::429], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9033"] = <
+                text = <"Term binding for [openEHR::415], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::415], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9034"] = <
+                text = <"Term binding for [openEHR::416], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::416], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9035"] = <
+                text = <"Term binding for [openEHR::417], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::417], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9036"] = <
+                text = <"Term binding for [openEHR::418], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::418], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9037"] = <
+                text = <"Term binding for [openEHR::419], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::419], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9038"] = <
+                text = <"Term binding for [openEHR::420], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::420], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9039"] = <
+                text = <"Term binding for [openEHR::421], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::421], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9040"] = <
+                text = <"Term binding for [openEHR::422], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::422], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9041"] = <
+                text = <"Term binding for [openEHR::423], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::423], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9042"] = <
+                text = <"Term binding for [openEHR::424], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::424], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9043"] = <
+                text = <"Term binding for [openEHR::401], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::401], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9044"] = <
+                text = <"Term binding for [openEHR::402], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::402], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9045"] = <
+                text = <"Term binding for [openEHR::404], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::404], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9046"] = <
+                text = <"Term binding for [openEHR::405], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::405], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9047"] = <
+                text = <"Term binding for [openEHR::406], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::406], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9048"] = <
+                text = <"Term binding for [openEHR::407], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::407], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9049"] = <
+                text = <"Term binding for [openEHR::414], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::414], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9050"] = <
+                text = <"Term binding for [openEHR::517], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::517], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9051"] = <
+                text = <"Term binding for [openEHR::518], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::518], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9052"] = <
+                text = <"Term binding for [openEHR::519], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::519], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9053"] = <
+                text = <"Term binding for [openEHR::637], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::637], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["ac9054"] = <
+                text = <"Multimídia (synthesised)">
+                description = <"Tipos de dado Multimídia permitem o registro de vários tipos de arquivos multimídia. Todos os tipos disponíveis foram explicitamente selecionados neste exemplo. (synthesised)">
+            >
+            ["at9055"] = <
+                text = <"* change (en)">
+                description = <"* change (en)">
+            >
+        >
+        ["en"] = <
+            ["id1"] = <
+                text = <"Demonstration">
+                description = <"Demonstration archetype with descriptions and explanations.">
+            >
+            ["id3"] = <
+                text = <"Any Event">
+                description = <"All archetypes of the OBSERVATION class contain a HISTORY or EVENT model which contains information about the timing of the observation and the 'width' of the information - either a point in time or an interval.  The default is 'Any event' and it is not specified if this is a Point in time or an Interval.">
+            >
+            ["id5"] = <
+                text = <"Heading1">
+                description = <"This is a symbol for a cluster which can have other elements 'nested' within it.">
+            >
+            ["id6"] = <
+                text = <"Free Text or Coded">
+                description = <"Text data type in which free text can be entered or coding can be incorporated either in the template or at run time.">
+            >
+            ["id7"] = <
+                text = <"Text That Uses Internal Codes">
+                description = <"Text data type which can use an internal vocabulary.  Each of these 'internal codes' can be bound to a terminology code.">
+            >
+            ["at8"] = <
+                text = <"Lying">
+                description = <"Patient is lying supine.">
+            >
+            ["at9"] = <
+                text = <"Reclining">
+                description = <"Patient is reclining, propped up on one medium pillow.">
+            >
+            ["at10"] = <
+                text = <"Sitting">
+                description = <"Patient is sitting on a chair.">
+            >
+            ["at11"] = <
+                text = <"Standing">
+                description = <"Patient is standing.">
+            >
+            ["id12"] = <
+                text = <"Text That is Sourced From an External Terminology">
+                description = <"Text data type utilising codes derived from an external terminology source eg a SNOMED-CT, LOINC or ICD subset.">
+            >
+            ["id13"] = <
+                text = <"Quantity">
+                description = <"A quantity data type used to record a measurement associated with its' appropriate units.  These are derived from ISO standards and the Reference model enables conversion between these units. The example shown here is length.">
+            >
+            ["id14"] = <
+                text = <"Count">
+                description = <"Count data types are composed of an integer with no units eg for recording the number of children - in this example the minimum is set at 0 and the maximum not specified.">
+            >
+            ["id15"] = <
+                text = <"Date/Time">
+                description = <"Date/Time datatype allows recording of a date and/or time, including partial dates such as year only or month and year only.  Allow all is the default - so all forms of date/time are permitted.">
+            >
+            ["id16"] = <
+                text = <"Ordinal">
+                description = <"Ordinal datatypes pair a number and text - in this way scores can be calculated in software, or progression can be assessed eg if used in a pain score.">
+            >
+            ["id17"] = <
+                text = <"Boolean">
+                description = <"Boolean datatype that allows for true or false answers.">
+            >
+            ["id18"] = <
+                text = <"Any">
+                description = <"The datatype for this 'any' element can be specified or constrained in a template or at run-time, but is not explicitly modelled in the archetype.">
+            >
+            ["id19"] = <
+                text = <"Heading 2">
+                description = <"This is a symbol for a cluster which can have other elements 'nested' within it.">
+            >
+            ["id20"] = <
+                text = <"Slot To Contain Other Cluster Archetypes">
+                description = <"List of CLUSTER archetypes allowed to be included or excluded within this OBSERVATION archetype.">
+            >
+            ["id21"] = <
+                text = <"Slot To Contain Other Element Archetypes">
+                description = <"List of ELEMENT archetypes allowed to be included or excluded within this OBSERVATION archetype.">
+            >
+            ["id22"] = <
+                text = <"Duration">
+                description = <"Duration datatype allows recording of the duration of clinical concepts.  'Allow all time units' is the default, although specific time units can be explicitly modelled.  Maximum and minum values can be set for each time unit.">
+            >
+            ["id23"] = <
+                text = <"Interval of Integer">
+                description = <"Interval of integer datatype allows for recording of a range of counts eg 1-2 tablets prescribed.  Maximum and minimum values can be set for the lower count and the upper count.">
+            >
+            ["id24"] = <
+                text = <"Interval of Quantity">
+                description = <"Interval of quantity datatypes allow for the recording of a range of measurements in association with appropriate units eg 1-2cm (prescribed amount of cream for a rash).">
+            >
+            ["id25"] = <
+                text = <"Interval of Date">
+                description = <"Interval of integer datatype allows for recording of a range of dates eg between September 1, 2008 and September 8, 2008.">
+            >
+            ["id26"] = <
+                text = <"Choice">
+                description = <"Choice datatype allows for a number of types of element to be specified simultaneously and which can constrained or selected within a template or at run-time.  In this example, a text datatype set to Free text or Coded and another that is constrained to Terminology record data about the same data element.">
+            >
+            ["id27"] = <
+                text = <"Multimedia">
+                description = <"Multimedia datatypes allow for the recording of many types of multimedia files to be captured.  All available types have been explicitly selected in this example.">
+            >
+            ["id28"] = <
+                text = <"URI - resource identifier">
+                description = <"URI datatypes allow for recording of relationships from this data to data recorded elsewhere.  These links can be within the same EHR, or external eg to a  URL.">
+            >
+            ["id29"] = <
+                text = <"Proportion">
+                description = <"Proportion datatypes allow for ratios, percent, fractions and proportions to be modelled.">
+            >
+            ["id32"] = <
+                text = <"State - Definition">
+                description = <"All archetypes of the OBSERVATION class can  contain a STATE model which contains information about the subject of data at the time the information was collected, and this information is required for safe clinical interpretation of the core information. An example is the position of the patient at the time of measuring a blood pressure.  Datatypes are identical to those explained in the Data model, above.">
+            >
+            ["id33"] = <
+                text = <"Data - Definition">
+                description = <"All archetypes of the OBSERVATION class contain a DATA model  which contains the core information e.g. the systolic and diastolic pressures when measuring a blood pressure.">
+            >
+            ["id34"] = <
+                text = <"Named Point In Time">
+                description = <"An event that is both named (eg Birth) and constrained as a Point in time event records the data elements in relation to a specified point in time eg Weight at Birth.">
+            >
+            ["id35"] = <
+                text = <"Named Interval">
+                description = <"An event that is both named and constrained as an Interval event records the data elements in relation to a period of time eg Weight Loss over time.  The interval can be fixed or left unspecified.  In addition there are mathematical functions that can be specified to capture concepts such as change, decrease, increase, maximum, minimum, mean etc.">
+            >
+            ["id36"] = <
+                text = <"Offset Point In Time">
+                description = <"Offset Point in time records data at a point in time with a fixed offset of 5 minutes from another specified event eg recording a 2 minute Apgar reading at 2 minutes offset from Birth.">
+            >
+            ["id38"] = <
+                text = <"Protocol - Definition">
+                description = <"All archetypes of the OBSERVATION class can contain a PROTOCOL model which records information on how the information was gathered or measured, and any other information that is not required for safe clinical interpretation of the core Data. Datatypes are identical to those explained in the Data model, above.">
+            >
+            ["at39"] = <
+                text = <"No pain">
+                description = <"No pain at all.">
+            >
+            ["at40"] = <
+                text = <"Slight pain">
+                description = <"Pain level rated as 1 out of a possible maximum score of 10.">
+            >
+            ["at41"] = <
+                text = <"Mild pain">
+                description = <"Pain level rated as 2 out of a possible maximum score of 10.">
+            >
+            ["at42"] = <
+                text = <"Moderate pain">
+                description = <"Pain level rated as 5 out of a possible maximum score of 10.">
+            >
+            ["at43"] = <
+                text = <"Severe pain">
+                description = <"Pain level rated as 9 out of a possible maximum score of 10.">
+            >
+            ["at44"] = <
+                text = <"Most severe pain imaginable">
+                description = <"Pain level rated as 10 out of a possible maximum score of 10.">
+            >
+            ["id45"] = <
+                text = <"Identifier">
+                description = <"Identifier datatypes enable recording of formal data identifiers.">
+            >
+            ["id46"] = <
+                text = <"Extension">
+                description = <"Additional information required to capture local context or to align with other reference models/formalisms.">
+                comment = <"For example: Local hospital departmental infomation or additional metadata to align with FHIR or CIMI equivalents.">
+            >
+            ["ac2"] = <
+                text = <"SubsetA">
+                description = <"Terminology subset derived from XXX">
+            >
+            ["ac4"] = <
+                text = <"SubsetB">
+                description = <"XYZ codes from Terminology 123">
+            >
+            ["ac9000"] = <
+                text = <"Text That Uses Internal Codes (synthesised)">
+                description = <"Text data type which can use an internal vocabulary.  Each of these 'internal codes' can be bound to a terminology code. (synthesised)">
+            >
+            ["at9001"] = <
+                text = <"Length">
+                description = <"Length">
+            >
+            ["ac9002"] = <
+                text = <"Ordinal (synthesised)">
+                description = <"Ordinal datatypes pair a number and text - in this way scores can be calculated in software, or progression can be assessed eg if used in a pain score. (synthesised)">
+            >
+            ["at9003"] = <
+                text = <"no information">
+                description = <"no information">
+            >
+            ["at9004"] = <
+                text = <"masked">
+                description = <"masked">
+            >
+            ["at9005"] = <
+                text = <"not applicable">
+                description = <"not applicable">
+            >
+            ["at9006"] = <
+                text = <"unknown">
+                description = <"unknown">
+            >
+            ["ac9007"] = <
+                text = <"Boolean (synthesised)">
+                description = <"Boolean datatype that allows for true or false answers. (synthesised)">
+            >
+            ["at9008"] = <
+                text = <"Mass">
+                description = <"Mass">
+            >
+            ["at9009"] = <
+                text = <"Term binding for [openEHR::387], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::387], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9010"] = <
+                text = <"Term binding for [openEHR::388], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::388], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9011"] = <
+                text = <"Term binding for [openEHR::389], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::389], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9012"] = <
+                text = <"Term binding for [openEHR::390], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::390], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9013"] = <
+                text = <"Term binding for [openEHR::391], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::391], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9014"] = <
+                text = <"Term binding for [openEHR::392], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::392], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9015"] = <
+                text = <"Term binding for [openEHR::393], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::393], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9016"] = <
+                text = <"Term binding for [openEHR::394], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::394], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9017"] = <
+                text = <"Term binding for [openEHR::395], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::395], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9018"] = <
+                text = <"Term binding for [openEHR::396], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::396], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9019"] = <
+                text = <"Term binding for [openEHR::397], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::397], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9020"] = <
+                text = <"Term binding for [openEHR::398], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::398], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9021"] = <
+                text = <"Term binding for [openEHR::399], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::399], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9022"] = <
+                text = <"Term binding for [openEHR::400], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::400], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9023"] = <
+                text = <"Term binding for [openEHR::409], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::409], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9024"] = <
+                text = <"Term binding for [openEHR::410], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::410], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9025"] = <
+                text = <"Term binding for [openEHR::411], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::411], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9026"] = <
+                text = <"Term binding for [openEHR::412], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::412], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9027"] = <
+                text = <"Term binding for [openEHR::413], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::413], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9028"] = <
+                text = <"Term binding for [openEHR::425], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::425], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9029"] = <
+                text = <"Term binding for [openEHR::426], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::426], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9030"] = <
+                text = <"Term binding for [openEHR::427], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::427], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9031"] = <
+                text = <"Term binding for [openEHR::428], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::428], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9032"] = <
+                text = <"Term binding for [openEHR::429], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::429], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9033"] = <
+                text = <"Term binding for [openEHR::415], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::415], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9034"] = <
+                text = <"Term binding for [openEHR::416], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::416], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9035"] = <
+                text = <"Term binding for [openEHR::417], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::417], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9036"] = <
+                text = <"Term binding for [openEHR::418], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::418], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9037"] = <
+                text = <"Term binding for [openEHR::419], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::419], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9038"] = <
+                text = <"Term binding for [openEHR::420], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::420], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9039"] = <
+                text = <"Term binding for [openEHR::421], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::421], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9040"] = <
+                text = <"Term binding for [openEHR::422], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::422], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9041"] = <
+                text = <"Term binding for [openEHR::423], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::423], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9042"] = <
+                text = <"Term binding for [openEHR::424], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::424], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9043"] = <
+                text = <"Term binding for [openEHR::401], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::401], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9044"] = <
+                text = <"Term binding for [openEHR::402], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::402], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9045"] = <
+                text = <"Term binding for [openEHR::404], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::404], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9046"] = <
+                text = <"Term binding for [openEHR::405], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::405], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9047"] = <
+                text = <"Term binding for [openEHR::406], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::406], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9048"] = <
+                text = <"Term binding for [openEHR::407], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::407], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9049"] = <
+                text = <"Term binding for [openEHR::414], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::414], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9050"] = <
+                text = <"Term binding for [openEHR::517], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::517], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9051"] = <
+                text = <"Term binding for [openEHR::518], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::518], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9052"] = <
+                text = <"Term binding for [openEHR::519], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::519], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["at9053"] = <
+                text = <"Term binding for [openEHR::637], translation not known in ADL 1.4 -> ADL 2 converter">
+                description = <"Term binding for [openEHR::637], translation not known in ADL 1.4 -> ADL 2 converter">
+            >
+            ["ac9054"] = <
+                text = <"Multimedia (synthesised)">
+                description = <"Multimedia datatypes allow for the recording of many types of multimedia files to be captured.  All available types have been explicitly selected in this example. (synthesised)">
+            >
+            ["at9055"] = <
+                text = <"change">
+                description = <"change">
+            >
+        >
+    >
+    term_bindings = <
+        ["openehr"] = <
+            ["at9001"] = <http://openehr.org/id/122>
+            ["at9003"] = <http://openehr.org/id/271>
+            ["at9004"] = <http://openehr.org/id/272>
+            ["at9005"] = <http://openehr.org/id/273>
+            ["at9006"] = <http://openehr.org/id/253>
+            ["at9008"] = <http://openehr.org/id/124>
+            ["at9055"] = <http://openehr.org/id/147>
+        >
+        ["openEHR"] = <
+            ["at9009"] = <http://openEHR.org/id/387>
+            ["at9010"] = <http://openEHR.org/id/388>
+            ["at9011"] = <http://openEHR.org/id/389>
+            ["at9012"] = <http://openEHR.org/id/390>
+            ["at9013"] = <http://openEHR.org/id/391>
+            ["at9014"] = <http://openEHR.org/id/392>
+            ["at9015"] = <http://openEHR.org/id/393>
+            ["at9016"] = <http://openEHR.org/id/394>
+            ["at9017"] = <http://openEHR.org/id/395>
+            ["at9018"] = <http://openEHR.org/id/396>
+            ["at9019"] = <http://openEHR.org/id/397>
+            ["at9020"] = <http://openEHR.org/id/398>
+            ["at9021"] = <http://openEHR.org/id/399>
+            ["at9022"] = <http://openEHR.org/id/400>
+            ["at9023"] = <http://openEHR.org/id/409>
+            ["at9024"] = <http://openEHR.org/id/410>
+            ["at9025"] = <http://openEHR.org/id/411>
+            ["at9026"] = <http://openEHR.org/id/412>
+            ["at9027"] = <http://openEHR.org/id/413>
+            ["at9028"] = <http://openEHR.org/id/425>
+            ["at9029"] = <http://openEHR.org/id/426>
+            ["at9030"] = <http://openEHR.org/id/427>
+            ["at9031"] = <http://openEHR.org/id/428>
+            ["at9032"] = <http://openEHR.org/id/429>
+            ["at9033"] = <http://openEHR.org/id/415>
+            ["at9034"] = <http://openEHR.org/id/416>
+            ["at9035"] = <http://openEHR.org/id/417>
+            ["at9036"] = <http://openEHR.org/id/418>
+            ["at9037"] = <http://openEHR.org/id/419>
+            ["at9038"] = <http://openEHR.org/id/420>
+            ["at9039"] = <http://openEHR.org/id/421>
+            ["at9040"] = <http://openEHR.org/id/422>
+            ["at9041"] = <http://openEHR.org/id/423>
+            ["at9042"] = <http://openEHR.org/id/424>
+            ["at9043"] = <http://openEHR.org/id/401>
+            ["at9044"] = <http://openEHR.org/id/402>
+            ["at9045"] = <http://openEHR.org/id/404>
+            ["at9046"] = <http://openEHR.org/id/405>
+            ["at9047"] = <http://openEHR.org/id/406>
+            ["at9048"] = <http://openEHR.org/id/407>
+            ["at9049"] = <http://openEHR.org/id/414>
+            ["at9050"] = <http://openEHR.org/id/517>
+            ["at9051"] = <http://openEHR.org/id/518>
+            ["at9052"] = <http://openEHR.org/id/519>
+            ["at9053"] = <http://openEHR.org/id/637>
+        >
+    >
+    value_sets = <
+        ["ac9007"] = <
+            id = <"ac9007">
+            members = <"at9003", "at9004", "at9005", "at9006">
+        >
+        ["ac9002"] = <
+            id = <"ac9002">
+            members = <"at39", "at40", "at41", "at42", "at43", "at44">
+        >
+        ["ac9000"] = <
+            id = <"ac9000">
+            members = <"at8", "at9", "at10", "at11">
+        >
+        ["ac9054"] = <
+            id = <"ac9054">
+            members = <"at9009", "at9010", "at9011", "at9012", "at9013", "at9014", "at9015", "at9016", "at9017", "at9018", "at9019", "at9020", "at9021", "at9022", "at9023", "at9024", "at9025", "at9026", "at9027", "at9028", "at9029", "at9030", "at9031", "at9032", "at9033", "at9034", "at9035", "at9036", "at9037", "at9038", "at9039", "at9040", "at9041", "at9042", "at9043", "at9044", "at9045", "at9046", "at9047", "at9048", "at9049", "at9050", "at9051", "at9052", "at9053">
+        >
+    >


### PR DESCRIPTION
Add generic tests for parsing ADL1.4 archetypes, converting them to ADL2 archetypes, serializing them and checking them against the ADL2 files provided.