### PR TITLE
Fix Codecov PGP key import in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,6 +18,7 @@ blocks:
             - ./gradlew clean build
             - ./gradlew jacocoRootReport
             - pip install codecov-cli
+            - export PATH="$(python3 -m site --user-base)/bin:$PATH"
             - codecovcli --verbose upload-process --disable-search -t "$ARCHIE_CODECOV_TOKEN" -n "java17-$SEMAPHORE_WORKFLOW_ID" -f ./build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
       prologue:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,8 +17,14 @@ blocks:
             - sem-version java 17
             - ./gradlew clean build
             - ./gradlew jacocoRootReport
-            - pip install codecov-cli
-            - codecovcli --verbose upload-process --disable-search -t "$ARCHIE_CODECOV_TOKEN" -n "java17-$SEMAPHORE_WORKFLOW_ID" -f ./build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
+            - curl -fsS https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            - curl -Os https://uploader.codecov.io/latest/linux/codecov
+            - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            - gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            - shasum -a 256 -c codecov.SHA256SUM
+            - chmod +x codecov
+            - ./codecov -f ./build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml -t "$ARCHIE_CODECOV_TOKEN"
       prologue:
         commands:
           - checkout

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,14 +17,8 @@ blocks:
             - sem-version java 17
             - ./gradlew clean build
             - ./gradlew jacocoRootReport
-            - curl -fsS https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
-            - curl -Os https://uploader.codecov.io/latest/linux/codecov
-            - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-            - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            - gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-            - shasum -a 256 -c codecov.SHA256SUM
-            - chmod +x codecov
-            - ./codecov -f ./build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml -t "$ARCHIE_CODECOV_TOKEN"
+            - pip install codecov-cli
+            - codecovcli --verbose upload-process --disable-search -t "$ARCHIE_CODECOV_TOKEN" -n "java17-$SEMAPHORE_WORKFLOW_ID" -f ./build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
       prologue:
         commands:
           - checkout

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -18,7 +18,6 @@ blocks:
             - ./gradlew clean build
             - ./gradlew jacocoRootReport
             - pip install codecov-cli
-            - export PATH="$(python3 -m site --user-base)/bin:$PATH"
             - codecovcli --verbose upload-process --disable-search -t "$ARCHIE_CODECOV_TOKEN" -n "java17-$SEMAPHORE_WORKFLOW_ID" -f ./build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
       prologue:
         commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ blocks:
             - sem-version java 17
             - ./gradlew clean build
             - ./gradlew jacocoRootReport
-            - curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+            - curl -fsS https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
             - curl -Os https://uploader.codecov.io/latest/linux/codecov
             - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             - curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig


### PR DESCRIPTION
The Java 17 CI build was failing at the Codecov uploader integrity-check                                                                                                                                                                                                                                                  
  step. The PGP key was fetched from `keybase.io/codecovsecurity/pgp_keys.asc`,                                                                                                                                                                                                                                             
  which now returns HTTP 404 ("SELF-SIGNED PUBLIC KEY NOT FOUND", a 32-byte                                                                                                                                                                                                                                                 
  body). Because `curl` piped that error body into `gpg`, the build failed                                                                                                                                                                                                                                                  
  with `gpg: no valid OpenPGP data found`.                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                            
  Codecov has moved the key to the `codecovsecops` keybase account. This                                                                                                                                                                                                                                                    
  updates the URL accordingly and adds `curl -fsS` so a future broken URL                                                                                                                                                                                                                                                   
  fails fast at the curl step rather than confusingly inside gpg.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  Source: https://docs.codecov.com/docs/codecov-uploader                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  Sources:                                                                                                                                                                                                                                                                                                                  
  - Codecov uploader documentation                                                                                                                                                                                                                                                                                          
  - keybase.io/codecovsecops/pgp_keys.asc