### PR TITLE
Fix RMPathQuery to not ignore node ID name, if index was given

### DIFF
--- a/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
+++ b/path-queries/src/main/java/com/nedap/archie/query/RMPathQuery.java
@@ -237,8 +237,12 @@ public class RMPathQuery {
             int i = 1;
             for(Object object:collection) {
                 if(number == i) {
-                    //TODO: check for other constraints as well
-                    return Lists.newArrayList(new RMObjectWithPath(object, path + buildPathConstraint(i, lookup.getArchetypeNodeIdFromRMObject(object))));
+                    String archetypeNodeId = lookup.getArchetypeNodeIdFromRMObject(object);
+                    //a pure index (no node id) matches any object; otherwise the indexed object must also satisfy the node constraint
+                    if(segment.getNodeId() == null || matchesSegment(lookup, segment, object, archetypeNodeId)) {
+                        return Lists.newArrayList(new RMObjectWithPath(object, path + buildPathConstraint(i, archetypeNodeId)));
+                    }
+                    return new ArrayList<>();
                 }
                 i++;
             }
@@ -247,33 +251,32 @@ public class RMPathQuery {
         int i = 1;
         for(Object object:collection) {
             String archetypeNodeId = lookup.getArchetypeNodeIdFromRMObject(object);
-
-            if (segment.hasIdCode()) {
-                if (matchSpecialisedNodes) {
-                    if (AOMUtils.codesConformant(archetypeNodeId, segment.getNodeId())) {
-                        result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, archetypeNodeId)));
-                    }
-                } else {
-                    if (segment.getNodeId().equals(archetypeNodeId)) {
-                        result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, archetypeNodeId)));
-                    }
-                }
-
-            } else if (segment.hasArchetypeRef()) {
-                //operational templates in RM Objects have their archetype node ID set to an archetype ref. That
-                //we support. Other things not so much
-                if (segment.getNodeId().equals(archetypeNodeId)) {
-                    result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, archetypeNodeId)));
-                }
-            } else {
-                if(equalsName(lookup.getNameFromRMObject(object), segment.getNodeId())) {
-                    logger.warn("Deprecation: Matching on object name is deprecated and will be removed. Use node id instead.");
-                    result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, archetypeNodeId)));
-                }
+            if (matchesSegment(lookup, segment, object, archetypeNodeId)) {
+                result.add(new RMObjectWithPath(object, path + buildPathConstraint(i, archetypeNodeId)));
             }
             i++;
         }
         return result;
+    }
+
+    private boolean matchesSegment(ModelInfoLookup lookup, PathSegment segment, Object object, String archetypeNodeId) {
+        if (segment.hasIdCode()) {
+            if (matchSpecialisedNodes) {
+                return AOMUtils.codesConformant(archetypeNodeId, segment.getNodeId());
+            } else {
+                return segment.getNodeId().equals(archetypeNodeId);
+            }
+        } else if (segment.hasArchetypeRef()) {
+            //operational templates in RM Objects have their archetype node ID set to an archetype ref. That
+            //we support. Other things not so much
+            return segment.getNodeId().equals(archetypeNodeId);
+        } else {
+            if (equalsName(lookup.getNameFromRMObject(object), segment.getNodeId())) {
+                logger.warn("Deprecation: Matching on object name is deprecated and will be removed. Use node id instead.");
+                return true;
+            }
+            return false;
+        }
     }
 
     private Object findRMObject(ModelInfoLookup lookup, PathSegment segment, Collection<?> collection) {

--- a/tools/src/test/java/com/nedap/archie/adlparser/RMPathQueryTest.java
+++ b/tools/src/test/java/com/nedap/archie/adlparser/RMPathQueryTest.java
@@ -10,6 +10,7 @@ import com.nedap.archie.query.RMObjectWithPath;
 import com.nedap.archie.query.RMPathQuery;
 import com.nedap.archie.rm.archetyped.Pathable;
 import com.nedap.archie.rm.composition.Composition;
+import com.nedap.archie.rm.datastructures.Cluster;
 import com.nedap.archie.rm.datastructures.Element;
 import com.nedap.archie.rm.datastructures.ItemTree;
 import com.nedap.archie.rm.datavalues.DvText;
@@ -168,4 +169,36 @@ public class RMPathQueryTest {
         assertEquals("/context/other_context[id2]/items[id3]/items[id6.0.1]", ((Element) listId6.get(1).getObject()).getPath());
     }
 
+    /**
+     * Test setup from {@link #multipleItems()}
+     */
+    @Test
+    public void multipleItemsQueryWithIndexDoesNotIgnoreOtherConstraints() {
+        root = (Pathable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        Composition composition = (Composition) root;
+
+        {
+            //add another cluster to the RM Object, with the same archetype id (very possible!)
+            Composition composition2 = (Composition) testUtil.constructEmptyRMObject(archetype.getDefinition());
+            ItemTree otherContext = (ItemTree) composition.getContext().getOtherContext();
+            composition2.getContext().getOtherContext().getItems().get(0).setName(new DvText("archie is great"));
+            otherContext.getItems().addAll(composition2.getContext().getOtherContext().getItems());
+        }
+
+        ModelInfoLookup modelInfoLookup = ArchieRMInfoLookup.getInstance();
+
+        // invalid name, expected empty
+        List<RMObjectWithPath> list = new RMPathQuery("/context[id11]/other_context[id2]/items[idInvalid, 1]").findList(modelInfoLookup, composition);
+        assertEquals(0, list.size());
+
+        // invalid name + out of bounds index, expected empty
+        List<RMObjectWithPath> list2 = new RMPathQuery("/context[id11]/other_context[id2]/items[idInvalid, 3]").findList(modelInfoLookup, composition);
+        assertEquals(0, list2.size());
+
+        // valid name + index, expect specific object
+        List<RMObjectWithPath> list3 = new RMPathQuery("/context[id11]/other_context[id2]/items[id3, 2]").findList(modelInfoLookup, composition);
+        assertEquals(1, list3.size());
+        Cluster cluster = (Cluster) list3.get(0).getObject();
+        assertEquals("archie is great", cluster.getNameAsString());
+    }
 }


### PR DESCRIPTION
Hello,

I had a problem where an invalid `RMPathQuery` path with index like

```java
composition.itemsAtPath("/content[openEHR-EHR-OBSERVATION.invaild.v1, 1]")
```

resulted in just the indexed match. See the test for details.

This MR is a proposal to fix this, if this behavior is indeed not as intended (as the TODO suggests).

Thanks and best,
Jake