### PR TITLE
Add EvaluationResult.pathsConstrainedToRegularExpr 

### DIFF
--- a/aom/src/main/java/com/nedap/archie/aom/primitives/CString.java
+++ b/aom/src/main/java/com/nedap/archie/aom/primitives/CString.java
@@ -91,12 +91,21 @@ public class CString extends CPrimitiveObject<List<String>, String> {
     }
 
     private boolean matchesRegexp(String value, String constraint) {
-        return value.matches(constraint.substring(1).substring(0, constraint.length()-2));
+        return value.matches(stripRegexDelimiters(constraint));
     }
 
     public static boolean isRegexConstraint(String constraint) {
         return (constraint.startsWith("/") && constraint.endsWith("/")) ||
                 (constraint.startsWith("^") && constraint.endsWith("^"));
+    }
+
+    /**
+     * Strip the leading and trailing regex delimiter characters ('/…/' or '^…^') from a regex constraint,
+     * returning the bare regular expression. Only valid when {@link #isRegexConstraint(String)} is true
+     * (i.e. both delimiters are present).
+     */
+    public static String stripRegexDelimiters(String constraint) {
+        return constraint.substring(1).substring(0, constraint.length() - 2);
     }
 
     @Override

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
@@ -44,7 +44,10 @@ public class AssertionResult {
      */
     private Map<String, String> pathsConstrainedToValueSets = new LinkedHashMap<>();
 
-
+    /**
+     * Paths where a string value must now be constrained to a regular expression. Use for example to validate free text
+     * input against a pattern. The value is the regular expression with its delimiters ('/…/' or '^…^') stripped.
+     */
     private Map<String, String> pathsConstrainedToRegularExpression = new LinkedHashMap<>();
 
     public String getTag() {

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/AssertionResult.java
@@ -44,6 +44,9 @@ public class AssertionResult {
      */
     private Map<String, String> pathsConstrainedToValueSets = new LinkedHashMap<>();
 
+
+    private Map<String, String> pathsConstrainedToRegularExpression = new LinkedHashMap<>();
+
     public String getTag() {
         return tag;
     }
@@ -104,6 +107,14 @@ public class AssertionResult {
         this.pathsConstrainedToValueSets = pathsConstrainedToValueSets;
     }
 
+    public Map<String, String> getPathsConstrainedToRegularExpression() {
+        return pathsConstrainedToRegularExpression;
+    }
+
+    public void setPathsConstrainedToRegularExpression(Map<String, String> pathsConstrainedToRegularExpression) {
+        this.pathsConstrainedToRegularExpression = pathsConstrainedToRegularExpression;
+    }
+
     public void setPathsThatMustNotExist(List<String> pathsThatMustNotExist) {
         this.pathsThatMustNotExist = pathsThatMustNotExist;
     }
@@ -147,5 +158,9 @@ public class AssertionResult {
 
     public void constrainPathToValueSet(String path, String valueSetId) {
         pathsConstrainedToValueSets.put(path, valueSetId);
+    }
+
+    public void constrainPathToRegularExpression(String path, String regex) {
+        pathsConstrainedToRegularExpression.put(path, regex);
     }
 }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/EvaluationResult.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/EvaluationResult.java
@@ -58,4 +58,12 @@ public class EvaluationResult {
         }
         return result;
     }
+
+    public Map<String, String> getPathsConstrainedToRegularExpression() {
+        Map<String, String> result = new LinkedHashMap<>();
+        for (AssertionResult assertionResult : assertionResults) {
+            result.putAll(assertionResult.getPathsConstrainedToRegularExpression());
+        }
+        return result;
+    }
 }

--- a/tools/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
+++ b/tools/src/main/java/com/nedap/archie/rules/evaluation/FixableAssertionsChecker.java
@@ -2,6 +2,7 @@ package com.nedap.archie.rules.evaluation;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.nedap.archie.aom.CPrimitiveObject;
+import com.nedap.archie.aom.primitives.CString;
 import com.nedap.archie.aom.utils.AOMUtils;
 import com.nedap.archie.query.RMObjectWithPath;
 import com.nedap.archie.rules.*;
@@ -153,11 +154,16 @@ class FixableAssertionsChecker {
                     break;
                 }
                 case "CString": {
-                        String constraint = (String) constraints.get(0);
+                    String constraint = (String) constraints.get(0);
+                    String path = resolveModelReference(pathToSet);
+                    if (CString.isRegexConstraint(constraint)) {
+                        assertionResult.constrainPathToRegularExpression(path, CString.stripRegexDelimiters(constraint));
+                    } else {
                         valueList.addValue(constraint, Collections.emptyList());
-                        setPathsToValues(assertionResult, resolveModelReference(pathToSet), valueList);
+                        setPathsToValues(assertionResult, path, valueList);
                     }
-                    break;
+                }
+                break;
                 //TODO: more type of constraints
 
             }

--- a/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
+++ b/tools/src/test/java/com/nedap/archie/rules/evaluation/FixableAssertionsCheckerTest.java
@@ -21,6 +21,7 @@ import org.openehr.referencemodels.BuiltinReferenceModels;
 import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -202,11 +203,34 @@ public class FixableAssertionsCheckerTest {
         // Evaluate the rmObject and its rules.
         EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
 
-        // Assert the evaluation result, it should contain the element that has to be set to a specific value.
-        assertEquals(1, evaluate.getSetPathValues().size());
+        // The rule constrains the archetype id to a regular expression. It must be routed to the regex-paths map,
+        // with its delimiters stripped, and must NOT land in setPathValues.
+        assertEquals(0, evaluate.getSetPathValues().size());
+        assertEquals(1, evaluate.getPathsConstrainedToRegularExpression().size());
         assertEquals(
-                "/openEHR-EHR-CLUSTER\\.some_archetype_option_a.v(\\d+\\.\\d+\\.\\d+)/",
-                evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id14]/items[id19]/archetype_details/archetype_id/value").getValue());
+                "openEHR-EHR-CLUSTER\\.some_archetype_option_a.v(\\d+\\.\\d+\\.\\d+)",
+                evaluate.getPathsConstrainedToRegularExpression().get("/data[id2]/events[id3]/data[id4]/items[id14]/items[id19]/archetype_details/archetype_id/value"));
+    }
+
+    @Test
+    public void constrainStringToRegularExpression() throws Exception {
+        archetype = parser.parse(ParsedRulesEvaluationTest.class.getResourceAsStream("constrain_string_to_regex.adls"));
+        RuleEvaluation<Locatable> ruleEvaluation = getRuleEvaluation();
+
+        Locatable root = (Locatable) testUtil.constructEmptyRMObject(archetype.getDefinition());
+        EvaluationResult evaluate = ruleEvaluation.evaluate(root, archetype.getRules().getRules());
+
+        // The regex-constrained string path must be routed to the regex map (delimiters stripped) and NOT to setPathValues.
+        assertEquals(1, evaluate.getPathsConstrainedToRegularExpression().size());
+        assertEquals("[0-9]{4}",
+                evaluate.getPathsConstrainedToRegularExpression().get("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"));
+        assertFalse(evaluate.getSetPathValues().containsKey("/data[id2]/events[id3]/data[id4]/items[id5]/value/value"),
+                "a regex constraint must not land in setPathValues");
+
+        // The plain (non-regex) string path must still land in setPathValues (no regression).
+        assertEquals(1, evaluate.getSetPathValues().size());
+        assertEquals("test string",
+                evaluate.getSetPathValues().get("/data[id2]/events[id3]/data[id4]/items[id7]/value/value").getValue());
     }
 
     private RuleEvaluation<Locatable> getRuleEvaluation() {

--- a/tools/src/test/resources/com/nedap/archie/rules/evaluation/constrain_string_to_regex.adls
+++ b/tools/src/test/resources/com/nedap/archie/rules/evaluation/constrain_string_to_regex.adls
@@ -1,0 +1,72 @@
+archetype (adl_version=2.0.5; rm_release=1.1.0; generated)
+    openEHR-EHR-OBSERVATION.constrain_string_to_regex.v1.0.0
+
+language
+    original_language = <[ISO_639-1::en]>
+
+description
+    original_author = <
+        ["name"] = <"Archie">
+    >
+    lifecycle_state = <"published">
+    details = <
+        ["en"] = <
+            language = <[ISO_639-1::en]>
+            purpose = <"Test for rules constraining a string path to a regular expression">
+        >
+    >
+
+definition
+    OBSERVATION[id1] matches {    -- Title
+        data matches {
+            HISTORY[id2] matches {
+                events cardinality matches {1..*; unordered} matches {
+                    EVENT[id3] occurrences matches {1..*} matches {    -- Event
+                        data matches {
+                            ITEM_TREE[id4] matches {
+                                items cardinality matches {1..*; unordered} matches {
+                                    ELEMENT[id5] matches {    -- Regex constrained DvText
+                                        value matches {
+                                            DV_TEXT[id6]
+                                        }
+                                    }
+                                    ELEMENT[id7] matches {    -- Plain DvText
+                                        value matches {
+                                            DV_TEXT[id8]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+rules
+    /data[id2]/events[id3]/data[id4]/items[id5]/value/value matches {/[0-9]{4}/}
+    /data[id2]/events[id3]/data[id4]/items[id7]/value/value matches {"test string"}
+
+
+terminology
+    term_definitions = <
+        ["en"] = <
+            ["id1"] = <
+                text = <"Title">
+                description = <"Title">
+            >
+            ["id3"] = <
+                text = <"Event">
+                description = <"">
+            >
+            ["id5"] = <
+                text = <"Regex constrained DvText">
+                description = <"">
+            >
+            ["id7"] = <
+                text = <"Plain DvText">
+                description = <"">
+            >
+        >
+    >


### PR DESCRIPTION
This adds a new field `AssertionResult.pathsConstrainedToRegularExpression` and a new method `EvaluationResult.getPathsConstrainedToRegularExpression()`, for paths of attributes that are constrained by a regular expression. These are not be added to setPathValues anymore.

Fixes #709 