### PR TITLE
Change default of allowSpecializationAfterExclusion to false

### DIFF
--- a/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
+++ b/tools/src/main/java/com/nedap/archie/flattener/FlattenerConfiguration.java
@@ -63,12 +63,15 @@ public class FlattenerConfiguration {
     /**
      * Officially, objects can only be excluded (occurrences matches {0}) after any
      * specializations. If any object is specialized after the exclusion of the parent object, the specialization is ignored.
-     * This was not ignored before, so this config can be used to reproduce previous behaviour.
+     * This was not ignored before, so this config can be set to true to reproduce that previous (incorrect) behaviour.
+     *
+     * Defaults to false, which is the officially correct behaviour. Before Archie 4 this defaulted to true, because
+     * setting it to false is in theory backwards incompatible.
      *
      * Deprecated because this should be fixed in archetypes, rather than allowing it in a configuration.
      */
     @Deprecated
-    private boolean allowSpecializationAfterExclusion = true;
+    private boolean allowSpecializationAfterExclusion = false;
 
     private FlattenerConfiguration() {
 


### PR DESCRIPTION
Fixes #731 

FlattenerConfiguration.allowSpecializationAfterExclusion default is reverted back to false.

Since Archie 4 is a major version, flip the default to the officially correct behaviour where a specialization applied after a parent node exclusion is ignored. Callers can still opt back in via the deprecated setter.

### Note for release notes:

Breaking change: FlattenerConfiguration.allowSpecializationAfterExclusion now defaults to false (#731)

The flattener now applies the officially correct behaviour by default: when a node is excluded in a specialization (occurrences matches {0}), any further specialization of that node is ignored. Previously (Archie 3.2.0 onwards) this defaulted to true to preserve pre-3.1.0 behaviour, which was in theory backwards-incompatible and so deferred to this major version.

If you rely on the old behaviour, you can restore it by calling config.setAllowSpecializationAfterExclusion(true) — though this is deprecated, and the underlying issue should be fixed in the affected archetypes instead.