### PR TITLE
Fix TerminologyCode JSON type serialization (#723)

### DIFF
--- a/archie-utils/src/main/java/com/nedap/archie/json/OpenEHRTypeNaming.java
+++ b/archie-utils/src/main/java/com/nedap/archie/json/OpenEHRTypeNaming.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsontype.impl.ClassNameIdResolver;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.nedap.archie.base.OpenEHRBase;
+import com.nedap.archie.base.terminology.TerminologyCode;
 import com.nedap.archie.rminfo.ArchieAOMInfoLookup;
 import com.nedap.archie.rminfo.ArchieRMInfoLookup;
 import com.nedap.archie.rminfo.ModelInfoLookup;
@@ -64,6 +65,11 @@ public class OpenEHRTypeNaming extends ClassNameIdResolver {
         if(result == null) {
             //AOM class?
             result = aomInfoLookup.getClass(typeName);
+        }
+        if(result == null && "TerminologyCode".equals(typeName)) {
+            //backwards compatibility: older Archie versions serialized the TERMINOLOGY_CODE type as the simple java
+            //class name "TerminologyCode" instead of the openEHR type name, so still accept that when deserializing.
+            result = TerminologyCode.class;
         }
         if(result != null) {
             TypeFactory typeFactory = (ctxt == null) ? _typeFactory : ctxt.getTypeFactory();

--- a/base/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
+++ b/base/src/main/java/com/nedap/archie/base/terminology/TerminologyCode.java
@@ -2,7 +2,6 @@ package com.nedap.archie.base.terminology;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.nedap.archie.base.OpenEHRBase;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -19,7 +18,6 @@ import java.util.regex.Pattern;
  */
 @XmlType(name="TERMINOLOGY_CODE")
 @XmlAccessorType(XmlAccessType.FIELD)
-@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, defaultImpl=TerminologyCode.class)
 public class TerminologyCode extends OpenEHRBase {
 
     @XmlElement(name="terminology_id")

--- a/tools/src/test/java/com/nedap/archie/json/AOMJacksonTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/AOMJacksonTest.java
@@ -315,7 +315,6 @@ public class AOMJacksonTest {
                 "      \"/subject\" : {\n" +
                 "        \"visibility\" : \"hide\",\n" +
                 "        \"alias\" : {\n" +
-                "          \"@type\" : \"TerminologyCode\",\n" +
                 "          \"terminology_id\" : \"local\",\n" +
                 "          \"code_string\" : \"at12\",\n" +
                 "          \"terminology_id_string\" : \"local\"\n" +

--- a/tools/src/test/java/com/nedap/archie/json/TerminologyCodeJacksonTest.java
+++ b/tools/src/test/java/com/nedap/archie/json/TerminologyCodeJacksonTest.java
@@ -1,0 +1,70 @@
+package com.nedap.archie.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nedap.archie.base.terminology.TerminologyCode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Regression tests for openEHR/archie#723: the type property of TerminologyCode used to be serialized
+ * with a hardcoded "@type" property name and the java simple class name "TerminologyCode", instead of
+ * respecting the configured type property name and the openEHR type name "TERMINOLOGY_CODE".
+ */
+public class TerminologyCodeJacksonTest {
+
+    private TerminologyCode terminologyCode() {
+        TerminologyCode result = new TerminologyCode();
+        result.setTerminologyId("ISO_639-1");
+        result.setCodeString("en");
+        return result;
+    }
+
+    @Test
+    public void standardsCompliantHasNoTypeProperty() throws Exception {
+        // TERMINOLOGY_CODE is a leaf type, so a standards compliant serialization does not need a type property at all.
+        ObjectMapper mapper = JacksonUtil.getObjectMapper(ArchieJacksonConfiguration.createStandardsCompliant());
+        JsonNode node = mapper.readTree(mapper.writeValueAsString(terminologyCode()));
+        assertNull(node.get("_type"));
+        assertFalse(node.has("@type"));
+        assertEquals("ISO_639-1", node.get("terminology_id").textValue());
+        assertEquals("en", node.get("code_string").textValue());
+    }
+
+    @Test
+    public void javascriptConfigUsesStandardsCompliantTypeProperty() throws Exception {
+        ObjectMapper mapper = JacksonUtil.getObjectMapper(ArchieJacksonConfiguration.createConfigForJavascriptUsage());
+        JsonNode node = mapper.readTree(mapper.writeValueAsString(terminologyCode()));
+        assertEquals("TERMINOLOGY_CODE", node.get("_type").textValue());
+        assertFalse(node.has("@type"));
+    }
+
+    @Test
+    public void legacyConfigUsesLegacyTypePropertyWithOpenEHRName() throws Exception {
+        ObjectMapper mapper = JacksonUtil.getObjectMapper(ArchieJacksonConfiguration.createLegacyConfiguration());
+        JsonNode node = mapper.readTree(mapper.writeValueAsString(terminologyCode()));
+        assertEquals("TERMINOLOGY_CODE", node.get("@type").textValue());
+        assertFalse(node.has("_type"));
+    }
+
+    @Test
+    public void roundTrip() throws Exception {
+        ObjectMapper mapper = JacksonUtil.getObjectMapper(ArchieJacksonConfiguration.createStandardsCompliant());
+        TerminologyCode parsed = mapper.readValue(mapper.writeValueAsString(terminologyCode()), TerminologyCode.class);
+        assertEquals("ISO_639-1", parsed.getTerminologyId());
+        assertEquals("en", parsed.getCodeString());
+    }
+
+    @Test
+    public void parsesLegacyTerminologyCodeTypeName() throws Exception {
+        // backwards compatibility: older Archie versions serialized the type as the simple java class name.
+        ObjectMapper mapper = JacksonUtil.getObjectMapper(ArchieJacksonConfiguration.createStandardsCompliant());
+        String legacyJson = "{\"_type\": \"TerminologyCode\", \"terminology_id\": \"ISO_639-1\", \"code_string\": \"en\"}";
+        TerminologyCode parsed = mapper.readValue(legacyJson, TerminologyCode.class);
+        assertEquals("ISO_639-1", parsed.getTerminologyId());
+        assertEquals("en", parsed.getCodeString());
+    }
+}


### PR DESCRIPTION
Fixes #723

### Problem

`TerminologyCode` serialized its type discriminator incorrectly under **every** Jackson config. A class-level annotation:

```java
@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, defaultImpl=TerminologyCode.class)
```

overrode the ObjectMapper's global default typing and always emitted:

```json
"@type" : "TerminologyCode"
```

This was wrong on two counts:
- **Property name**: hardcoded `@type` instead of the configured `_type` (standards-compliant config).
- **Type value**: java simple name `TerminologyCode` instead of the openEHR name `TERMINOLOGY_CODE`.

### Fix

- Removed the `@JsonTypeInfo` annotation from `TerminologyCode` so it uses the mapper's global default typing. The `defaultImpl` behaviour is preserved by the existing `USE_BASE_TYPE_AS_DEFAULT_IMPL` setting.
- Added a backwards-compatibility alias in `OpenEHRTypeNaming` so JSON produced by older Archie versions (type id `"TerminologyCode"`) still deserializes.

### Resulting behaviour

| Config | Before | After |
|---|---|---|
| Standards-compliant | `"@type": "TerminologyCode"` | *(no type property — it's a leaf type)* |
| JavaScript (always include type) | `"@type": "TerminologyCode"` | `"_type": "TERMINOLOGY_CODE"` |
| Legacy | `"@type": "TerminologyCode"` | `"@type": "TERMINOLOGY_CODE"` |

### Tests

- Added `TerminologyCodeJacksonTest` covering all three configs, round-trip, and legacy type-id parsing.
- Updated `AOMJacksonTest.rmOverlay()`, which had been asserting the buggy output.
